### PR TITLE
Add jira changelog collector and enrich issues with lead time

### DIFF
--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -17,5 +17,8 @@ module.exports = {
   jira: {
     host: 'https://your-domain.atlassian.net',
     basicAuth: '***'
+  },
+  enrichment: {
+    connectionString: 'http://localhost:3000/'
   }
 }

--- a/src/collection/collectors/jira/changelogs.js
+++ b/src/collection/collectors/jira/changelogs.js
@@ -1,0 +1,33 @@
+const issueUtil = require('./issues')
+
+const dbConnector = require('@mongo/connection')
+const fetcher = require('./fetcher')
+
+const collectionName = 'jira_issue_changelogs'
+
+module.exports = {
+  async collectChangelogs (projectId) {
+    const { client, db } = await dbConnector.connect()
+
+    try {
+      const issues = await issueUtil.findIssues({ 'fields.project.name': projectId }, 3)
+
+      const changelogCollection = await dbConnector.findOrCreateCollection(db, collectionName)
+
+      for (const issue of issues) {
+        const changelog = await module.exports.fetchChangelogForIssue(issue.id)
+        await changelogCollection.insertOne(changelog)
+      }
+    } catch (error) {
+      console.error(error)
+    } finally {
+      dbConnector.disconnect(client)
+    }
+  },
+
+  async fetchChangelogForIssue (issueId) {
+    const requestUri = `issue/${issueId}/changelog`
+
+    return fetcher.fetch(requestUri)
+  }
+}

--- a/src/collection/collectors/jira/fetcher.js
+++ b/src/collection/collectors/jira/fetcher.js
@@ -1,0 +1,20 @@
+const axios = require('axios')
+
+const config = require('@config/resolveConfig').jira
+
+module.exports = {
+  async fetch (resourceUri) {
+    try {
+      const response = await axios.get(`${config.host}/rest/api/3/${resourceUri}`, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Basic ${config.basicAuth}`
+        }
+      })
+
+      return response.data
+    } catch (error) {
+      console.error(error)
+    }
+  }
+}

--- a/src/collection/collectors/jira/index.js
+++ b/src/collection/collectors/jira/index.js
@@ -1,10 +1,12 @@
 const issues = require('./issues')
+const changelogs = require('./changelogs')
 
 module.exports = {
   async collect ({ projectId }) {
     console.log('Jira Collection, projectId:', projectId)
 
     await issues.collectIssues(projectId)
+    await changelogs.collectChangelogs(projectId)
   },
 
   issues

--- a/src/collection/collectors/jira/issues.js
+++ b/src/collection/collectors/jira/issues.js
@@ -29,7 +29,7 @@ module.exports = {
     return fetcher.fetch(requestUri)
   },
 
-  async findIssues (where, limit = null) {
+  async findIssues (where, limit = 99999999) {
     const { client, db } = await dbConnector.connect()
 
     let issues = []

--- a/src/enrichment/enrichers/jira.js
+++ b/src/enrichment/enrichers/jira.js
@@ -5,7 +5,7 @@ module.exports = {
   async enrich (config) {
     console.log('Jira Enrichment', config)
     const limit = 99999
-    const issues = await issueCollector.findIssues(limit)
+    const issues = await issueCollector.findIssues({}, limit)
 
     issues.forEach(async issue => {
       await JiraIssue.create({

--- a/src/enrichment/enrichers/jira.js
+++ b/src/enrichment/enrichers/jira.js
@@ -1,22 +1,60 @@
+require('module-alias/register')
+
 const issueCollector = require('../../collection/collectors/jira/issues')
+const changelogCollector = require('../../collection/collectors/jira/changelogs')
+
 const { JiraIssue } = require('@db/postgres')
 
+const closedStatuses = ['Done', 'Closed']
+
 module.exports = {
-  async enrich (config) {
-    console.log('Jira Enrichment', config)
-    const limit = 99999
-    const issues = await issueCollector.findIssues({}, limit)
+  async enrich ({ projectId }) {
+    console.log('Jira Enrichment', projectId)
+
+    const issues = await issueCollector.findIssues({ 'fields.project.name': `${projectId}` })
 
     issues.forEach(async issue => {
+      const leadTime = await module.exports.calculateLeadTime(issue)
+
       await JiraIssue.create({
         id: issue.id,
         url: issue.self,
         title: issue.fields.summary,
         projectId: issue.fields.project.id,
-        description: issue.fields.description
+        description: issue.fields.description,
+        leadTime
       })
     })
 
     console.log('Done enriching issues')
+  },
+
+  async calculateLeadTime (issue) {
+    const changelogs = await changelogCollector.findChangelogs({ issueId: `${issue.id}` })
+
+    let leadTime = 0
+    let lastTime = new Date(issue.fields.created).getTime()
+    let isDone = false
+
+    for (const change of changelogs) {
+      for (const item of change.items) {
+        if (item.field === 'status') {
+          const changeTime = new Date(change.created).getTime()
+
+          if (!closedStatuses.includes(item.fromString)) {
+            const elapsedTime = changeTime - lastTime
+
+            leadTime += elapsedTime
+          }
+
+          lastTime = changeTime
+          isDone = closedStatuses.includes(item.toString)
+        }
+      }
+    }
+
+    return isDone
+      ? Math.round(leadTime / 1000)
+      : 0
   }
 }


### PR DESCRIPTION
`Lead Time` is the one metric we really wanted to get done as a POC, so I've added it here. This is not the most fail-proof solution, and I've only given it one pass, but I think it's close.

I made a couple decisions here:

- When we collect changelogs, instead of storing the exact response from jira, which includes request meta data, I'm only inserting the actual changes into the changelog collection.
- Because there is no issue id attached to changelogs, I added it in the collection phase.

The calculation for lead time is as follows:

```
last_timestamp = issue created timestamp 
lead_time = 0

for every status change:
    if the old status was not closed:
        lead_time += the diff in seconds between the change_timestmap and the last_timestamp
  
    last_timestamp = change_date
```

Finally, if the ticket is not currently in a closed state, then the lead time will be 0.