### PR TITLE
Use project id instead of project name to fetch issues from mongo

### DIFF
--- a/src/collection/collectors/jira/changelogs.js
+++ b/src/collection/collectors/jira/changelogs.js
@@ -10,7 +10,7 @@ module.exports = {
     const { client, db } = await dbConnector.connect()
 
     try {
-      const issues = await issueUtil.findIssues({ 'fields.project.name': projectId })
+      const issues = await issueUtil.findIssues({ 'fields.project.id': projectId })
 
       const changelogCollection = await dbConnector.findOrCreateCollection(db, collectionName)
 

--- a/src/enrichment/enrichers/jira.js
+++ b/src/enrichment/enrichers/jira.js
@@ -11,7 +11,7 @@ module.exports = {
   async enrich ({ projectId }) {
     console.log('Jira Enrichment', projectId)
 
-    const issues = await issueCollector.findIssues({ 'fields.project.name': `${projectId}` })
+    const issues = await issueCollector.findIssues({ 'fields.project.id': `${projectId}` })
 
     issues.forEach(async issue => {
       const leadTime = await module.exports.calculateLeadTime(issue)


### PR DESCRIPTION
@paulgoertzen-merico I followed the workflow for computing lead time in the README but found pg didn't have any issues. With some `console.log`, I found the return value of `issueCollector.findIssues` is empty. I was able to fix the issue by using project id as the query parameter instead of the project name.

After this change, both changelog collector started to fetch changelogs and JIRA enricher started writing to `jira_issues` table. 