### PR TITLE
clean up mongodb before collection

### DIFF
--- a/src/collection/collectors/jira/issues.js
+++ b/src/collection/collectors/jira/issues.js
@@ -12,6 +12,8 @@ module.exports = {
     try {
       const { issues } = await module.exports.fetchIssues(projectId)
 
+      await db.collection(collectionName).remove()
+
       const issueCollection = await dbConnector.findOrCreateCollection(db, collectionName)
 
       // Insert issues into mongodb


### PR DESCRIPTION
Previously we had no mechanism to clean out the mongo db before pulling in Jira issues from the API. This will allow us to work from a clean slate, before pulling the data

- clean the mongodb before writing/enhancing 