### PR TITLE
Integrates the new plugin registry pattern

### DIFF
--- a/config/plugins.json
+++ b/config/plugins.json
@@ -1,0 +1,12 @@
+[
+  {
+    "package": "jira-pond",
+    "name": "collector",
+    "type": "collector"
+  },
+  {
+    "package": "jira-pond",
+    "name": "enricher",
+    "type": "enricher"
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1815,6 +1815,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "jira-pond": {
+      "version": "git+https://github.com/merico-dev/jira-pond.git#5f6d4e7740e196f9631cdec7441636146f77baa4",
+      "from": "git+https://github.com/merico-dev/jira-pond.git"
+    },
     "js-beautify": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "body-parser": "^1.19.0",
     "concurrently": "^6.2.0",
     "express": "^4.17.1",
+    "jira-pond": "git+https://github.com/merico-dev/jira-pond.git",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.2",
     "mongodb": "*",

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,33 @@
+const registryConfig = require('../../config/plugins.json')
+
+module.exports = {
+  collection: buildPluginRegistry('collector'),
+  enrichment: buildPluginRegistry('enricher')
+}
+
+function buildPluginRegistry (type) {
+  const pluginRegistry = pluginRegistryFactory()
+
+  for (const pluginModule of registryConfig) {
+    if (pluginModule.type !== type) {
+      continue
+    }
+
+    const plugin = require(pluginModule.package)
+
+    pluginRegistry.register(plugin[pluginModule.name])
+  }
+
+  return pluginRegistry
+}
+
+function pluginRegistryFactory () {
+  return {
+    plugins: {},
+
+    register (plugin) {
+      const { name, exec } = plugin
+      this.plugins[name] = exec
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the plugin registry pattern as described by Hezheng in the Dev Lake MVP doc (https://docs.google.com/document/d/19JqqF_-qVBBzbgbWB5ncaNjtETDMfBrLL7zsaLTtfr0)

The plugin registry doesn't do anything yet, it's not being used. But you can see how we configure it, and how it loads the plugins.

I created https://github.com/merico-dev/jira-pond as the other half to this PR. It implements the plugin interface. Please review it. It also does nothing really, it's just the interface.

You may find the plugin config file weird. I took a few different approaches, but this is the one that seemed best to me. It allows for importing multiple collectors or enrichers from the same package (using the `name` property).

