### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@
 
 ## Requirements
 
+- Node.js
 - Docker
 
 ## Installation
 
 1. Clone this repository
 2. From the newly cloned repo directory, run `docker-compose up --build`
-3. Test that it's working by opening another terminal and running the test script, `node test/test-docker-compose.js`. You should see `Connected to MongoDB`, `Connected to postgres`,  `Connected to RabbitMQ`.
+3. Run `docker-compose ps` to see containers runnning.
+4. Install dependencies with `npm i`
+5. Run migration with `npx sequelize-cli db:migrate`
+
+## Configuration
+
+1. Make a copy of `config/local.sample.js` under the name of `config/local.js`
+2. We can use default values for most fields except the Jira section. For how to set up basic authorization with Jira, please see this [section](#jira) below
 
 ## Usage
 
@@ -22,9 +30,8 @@
 POST http://localhost:3001/
 
 {
-    "projectId": 555555,
     "jira": {
-        "projectId": "test-api",
+        "projectId": "10003",
         "accountUri": "merico.atlassian.net"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,4 @@
 version: "3"
-networks:
-  merico:
-    external: true
-    name: merico_default
 services:
   postgresdb:
     environment:
@@ -10,11 +6,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
     image: postgres:13
-    networks:
-      merico: null
     ports:
-      - published: 5432
-        target: 5432
+      - 5432:5432
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
   rabbitmq:
@@ -23,13 +16,9 @@ services:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_VHOST: rabbitmq
     image: rabbitmq:3-management
-    networks:
-      merico: null
     ports:
-      - published: 15672
-        target: 15672
-      - published: 5672
-        target: 5672
+      - 15672:15672
+      - 5672:5672
     volumes:
       - /tmp/rabbitmq/etc/:/tmp/etc/rabbitmq/
       - /tmp/rabbitmq/data/:/var/lib/rabbitmq/


### PR DESCRIPTION
Two changes in this PR:

1. Simplified the `docker-compose.yml` a little bit, we can just use the default network for all three containers (right now, two containers are using the external network and mongo is using the default)
2. Updated the readme to add all the missing steps