### PR TITLE
Jira fetch issues pagination combinator

### DIFF
--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -48,7 +48,8 @@ module.exports = {
     let retry = 0
     const startAt = issues.length > 0 ? issues.length : 0
     const searchUri = `search?jql=project=${project}`
-    const total = await fetcher.fetch(`${searchUri}&fields=key`).total
+    const totalResponse = await fetcher.fetch(`${searchUri}&fields=key`)
+    const total = totalResponse.total
 
     while (issues.length < total) {
       try {
@@ -64,7 +65,7 @@ module.exports = {
       }
     }
 
-    return issues.map(issue => issue.key)
+    return issues
   },
 
   async findIssues (where, db, limit = 99999999) {


### PR DESCRIPTION
Currently we will stop out at 50 Jira issues on request, this change will allow us to pull in as many exist

- increase the maxResults to 100 (from 50), the limit Jira API will allow
- Add paginating/concat setup to gather Jira issues before saving all to mongo