### PR TITLE
#42 Add Support for Basic Authentication w/ API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,17 @@ To run only the enrichment job on existing collections: `POST http://localhost:3
 
 __Jira auth setup__
 
+#### Basic Auth
 1. Create an API key on Jira
 3. Create a __basic auth header__ from your API key - [Jira Docs](https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/#supply-basic-auth-headers)
 3. Copy your __basic auth header__ into the `jira.basicAuth` field in `/config/local.js` file
 4. Add your jira hostname to the `jira.host` field in the `/config/local.js` file
+
+
+#### Basic Auth w/ API Token
+1. Create an API Token from your Atlassian Account [Manage API tokens](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/)
+2. Add the new **token** to the `jira.restAuth.apiToken` configuration field in `/config/local.js` file
+3. Add your JIRA **username** to the `jira.restAuth.username` field in in `/config/local.js` file
+4. **ENABLE** API REST Authentication by setting `jira.restAuth.enabled` to `true`
+
+NOTE: If Using 2-Factor on your account, you will need enable this method of authentication.

--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -16,7 +16,12 @@ module.exports = {
   },
   jira: {
     host: 'https://your-domain.atlassian.net',
-    basicAuth: '***'
+    basicAuth: '***',
+    restAuth: {
+      enabled: true,
+      username: 'me@example.com',
+      apiToken: 'my-api-token'
+    },    
   },
   gitlab: {
     host: 'https://gitlab.com',

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -5,10 +5,15 @@ const config = require('@config/resolveConfig').jira
 module.exports = {
   async fetch (resourceUri) {
     try {
+      const Authorization = config.restAuth?.enabled
+        ? `Basic ${new Buffer(`${config.restAuth.username}:${config.restAuth.apiToken}`).toString('base64')}`
+        : `Basic ${config.basicAuth}`
+
       const response = await axios.get(`${config.host}/rest/api/3/${resourceUri}`, {
         headers: {
           Accept: 'application/json',
-          Authorization: `Basic ${config.basicAuth}`
+          'Content-Type': 'application/json',
+          Authorization
         }
       })
 

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -17,6 +17,21 @@ module.exports = {
         }
       })
 
+      const hasAuthFailures = (
+        header,
+        value,
+        loginReasonXHeader = 'x-seraph-loginreason',
+        deniedReason = 'AUTHENTICATION_DENIED'
+      ) => {
+        return header === loginReasonXHeader && value === deniedReason
+      }
+
+      if (response &&
+          response.headers.find((value, header) => hasAuthFailures(header.toLowerCase(), value))
+      ) {
+        throw new Error('CAPTCHA Triggered! Too many failed authentication attempts w/ REST API.')
+      }
+
       return response.data
     } catch (error) {
       console.error(error)

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -6,7 +6,7 @@ module.exports = {
   async fetch (resourceUri) {
     try {
       const Authorization = config.restAuth.enabled
-        ? `Basic ${new Buffer(`${config.restAuth.username}:${config.restAuth.apiToken}`).toString('base64')}`
+        ? `Basic ${Buffer.from(`${config.restAuth.username}:${config.restAuth.apiToken}`).toString('base64')}`
         : `Basic ${config.basicAuth}`
 
       const response = await axios.get(`${config.host}/rest/api/3/${resourceUri}`, {

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -5,7 +5,7 @@ const config = require('@config/resolveConfig').jira
 module.exports = {
   async fetch (resourceUri) {
     try {
-      const Authorization = config.restAuth?.enabled
+      const Authorization = config.restAuth.enabled
         ? `Basic ${new Buffer(`${config.restAuth.username}:${config.restAuth.apiToken}`).toString('base64')}`
         : `Basic ${config.basicAuth}`
 


### PR DESCRIPTION
This MR Adds support for JIRA API Basic REST Authentication plus **API Token** by using a **Basic Authorization** Header with JIRA **Username** and **API Token** Base64-encoded as outlined by JIRA Docs for [REST Authentication](https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/)

@joncodo Is this what you had in mind?