### PR TITLE
feat: add proxy support for jira fetcher

### DIFF
--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -16,7 +16,9 @@ module.exports = {
   },
   jira: {
     host: 'https://your-domain.atlassian.net',
-    basicAuth: '***'
+    basicAuth: '***',
+    proxy: 'http://localhost:4780',
+    timeout: 15000
   },
   gitlab: {
     host: 'https://gitlab.com',

--- a/package.json
+++ b/package.json
@@ -38,14 +38,15 @@
     "amqplib": "^0.8.0",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
+    "commondb": "src/plugins/commondb",
     "concurrently": "^6.2.0",
     "express": "^4.17.1",
     "jira-pond": "src/plugins/jira-pond",
-    "commondb": "src/plugins/commondb",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.2",
     "mongodb": "*",
     "pg": "^8.6.0",
+    "proxy-agent": "^5.0.0",
     "sequelize": "^6.3.4"
   },
   "devDependencies": {

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -1,15 +1,19 @@
 const axios = require('axios')
+const ProxyAgent = require('proxy-agent')
 
 const config = require('@config/resolveConfig').jira
 
 module.exports = {
   async fetch (resourceUri) {
+    console.log('[jira] Fetching data from ', resourceUri)
     try {
       const response = await axios.get(`${config.host}/rest/api/3/${resourceUri}`, {
         headers: {
           Accept: 'application/json',
           Authorization: `Basic ${config.basicAuth}`
-        }
+        },
+        agent: config.proxy && new ProxyAgent(config.proxy),
+        timeout: config.timeout
       })
 
       return response.data


### PR DESCRIPTION
Hi, guys, I'm having trouble accessing atlassian.net directly, so, I thought maybe an optional proxy setting would be helpful for both development and production scenario.

Note: proxy option of axios won't work properly