### PR TITLE
Fix lead time

### DIFF
--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -41,17 +41,19 @@ module.exports = {
   },
 
   async fetchIssues (project) {
-    let issues = []
-    let retry = 0
-    const startAt = issues.length > 0 ? issues.length : 0
+    const pageSize = 100
     const searchUri = `search?jql=project=${project}`
-    const totalResponse = await fetcher.fetch(`${searchUri}&fields=key`)
-    const total = totalResponse.total
+    let issues = []
+    let startAt = 0
+    let retry = 0
+    const total = await fetcher.fetch(`${searchUri}&fields=key`).total
 
     while (issues.length < total) {
+      console.log('INFO >> fetching issues ', issues.length)
       try {
-        const pagination = await fetcher.fetch(`${searchUri}&maxResults=100&startAt=${startAt}`)
+        const pagination = await fetcher.fetch(`${searchUri}&maxResults=${pageSize}&startAt=${startAt}`)
         issues = issues.concat(pagination.issues)
+        startAt += pageSize
       } catch (e) {
         console.error(`Jira Get Issue Keys Error start:[${issues.length}] retry:[${retry}]`, { error: e })
         if (retry > 3) {

--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -9,23 +9,20 @@ const collectionName = 'jira_issues'
 module.exports = {
   async collect (options) {
     try {
-      const issuesResponse = await module.exports.fetchIssues(options.projectId)
+      const issues = await module.exports.fetchIssues(options.projectId)
 
-      await module.exports.save({ issuesResponse, db: options.db })
+      await module.exports.save({ issues, db: options.db })
     } catch (error) {
       console.log(error)
     }
   },
 
-  async save ({
-    issuesResponse,
-    db
-  }) {
+  async save ({ issues, db }) {
     try {
       const promises = []
       const issuesCollection = await findOrCreateCollection(db, collectionName)
 
-      issuesResponse.issues.forEach(issue => {
+      issues.forEach(issue => {
         issue.primaryKey = Number(issue.id)
 
         promises.push(issuesCollection.findOneAndUpdate({

--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -48,7 +48,8 @@ module.exports = {
     let retry = 0
     const startAt = issues.length > 0 ? issues.length : 0
     const searchUri = `search?jql=project=${project}`
-    const total = await fetcher.fetch(`${searchUri}&fields=key`).total
+    const totalResponse = await fetcher.fetch(`${searchUri}&fields=key`)
+    const total = totalResponse.total
 
     while (issues.length < total) {
       try {
@@ -64,7 +65,7 @@ module.exports = {
       }
     }
 
-    return issues.map(issue => issue.key)
+    return issues
   },
 
   async findIssues (where, db, limit = 99999999) {

--- a/src/plugins/jira-pond/src/enricher/index.js
+++ b/src/plugins/jira-pond/src/enricher/index.js
@@ -3,7 +3,7 @@ require('module-alias/register')
 const issueCollector = require('../collector/issues')
 const changelogCollector = require('../collector/changelogs')
 
-const closedStatuses = ['Done', 'Closed']
+const closedStatuses = ['Done', 'Closed', '已关闭']
 
 module.exports = {
   async enrich (rawDb, enrichedDb, projectId) {

--- a/src/plugins/jira-pond/src/enricher/index.js
+++ b/src/plugins/jira-pond/src/enricher/index.js
@@ -40,13 +40,18 @@ module.exports = {
     const leadTimes = await Promise.all(leadTimePromises)
 
     leadTimes.forEach((leadTime, index) => {
-      console.log('JON >>> leadTime', leadTime)
       let issue = issuesToCreate[index]
+      console.log('INFO >>> issueId & leadTime', issue.id, leadTime)
       issue = {
         leadTime,
         ...issue
       }
-      creationPromises.push(JiraIssue.create(issue))
+      creationPromises.push(JiraIssue.findOrCreate({
+        where: {
+          id: issue.id
+        },
+        defaults: issue
+      }))
     })
 
     await Promise.all(creationPromises)


### PR DESCRIPTION
The latest main branch is broken due to previous unverified PRs. This PR fixes the major issues so that we get non-zero lead time in the pg again.

Besides the necessary fixes, this PR also incorporates @oddscenes and @joncodo's work described below

1. handling pagination when fetching Jira issues
2. fetching Jira changelogs in parallel with `Promise.all`
3. fixing duplicating issues in mongodb and postgres