### PR TITLE
Gitlab - adding in commit level metrics to grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```
 3. Run `docker-compose ps` to see containers runnning.
 4. Install dependencies with `npm i`
-5. Run migration with `npx sequelize-cli db:migrate`
+5. (optional: Revert all current migrations - `npx sequelize-cli db:migrate:undo:all`) Run migration with `npx sequelize-cli db:migrate`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ POST http://localhost:3001/
     "jira": {
         "projectId": "10003",
         "accountUri": "merico.atlassian.net"
+    },
+    "gitlab": {
+        "projectIds": [19688130, 8967944, 20103385]
     }
 }
 

--- a/db/migrations/20210719164314-add-jira-users.js
+++ b/db/migrations/20210719164314-add-jira-users.js
@@ -2,11 +2,6 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable('jira_users', {
-      uuid: {
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4
-      },
       self: {
         type: Sequelize.STRING
       },
@@ -22,6 +17,7 @@ module.exports = {
       },
       emailAddress: {
         type: Sequelize.STRING,
+        primaryKey: true,
         field: 'email_address'
       },
       displayName: {

--- a/db/migrations/20210719171721-add-jira-issues.js
+++ b/db/migrations/20210719171721-add-jira-issues.js
@@ -2,16 +2,12 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable('jira_issues', {
-      uuid: {
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4
-      },
       projectId: {
         type: Sequelize.INTEGER,
         field: 'project_id'
       },
       id: {
+        primaryKey: true,
         type: Sequelize.INTEGER
       },
       url: {

--- a/db/migrations/20210729124354-add-gitlab-projects.js
+++ b/db/migrations/20210729124354-add-gitlab-projects.js
@@ -2,16 +2,12 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable('gitlab_projects', {
-      uuid: {
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4
-      },
       name: {
         type: Sequelize.STRING
       },
       id: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        primaryKey: true,
       },
       pathWithNamespace: {
         type: Sequelize.STRING,

--- a/db/migrations/20210729134703-add-gitlab-commits.js
+++ b/db/migrations/20210729134703-add-gitlab-commits.js
@@ -2,12 +2,8 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable('gitlab_commits', {
-      uuid: {
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4
-      },
       id: {
+        primaryKey: true,
         type: Sequelize.STRING
       },
       shortId: {

--- a/db/migrations/20210729165758-add-projectId-to-gitlab-commit.js
+++ b/db/migrations/20210729165758-add-projectId-to-gitlab-commit.js
@@ -1,0 +1,27 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.addColumn('gitlab_commits', 'project_id', {
+        type: Sequelize.DataTypes.INTEGER
+      }, { transaction })
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  },
+
+  down: async (queryInterface) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.removeColumn('gitlab_commits', 'project_id', { transaction })
+      await transaction.commit()
+    } catch (err) {
+      await transaction.rollback()
+      throw err
+    }
+  }
+}

--- a/db/postgres/gitlabCommit.js
+++ b/db/postgres/gitlabCommit.js
@@ -10,15 +10,11 @@ module.exports = (sequelize, DataTypes) => {
   }
 
   GitlabCommit.init({
-    uuid: {
-      primaryKey: true,
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4
-    },
     projectId: {
       type: DataTypes.INTEGER
     },
     id: {
+      primaryKey: true,
       type: DataTypes.STRING
     },
     shortId: {

--- a/db/postgres/gitlabCommit.js
+++ b/db/postgres/gitlabCommit.js
@@ -15,6 +15,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.UUID,
       defaultValue: DataTypes.UUIDV4
     },
+    projectId: {
+      type: DataTypes.INTEGER
+    },
     id: {
       type: DataTypes.STRING
     },

--- a/db/postgres/gitlabProject.js
+++ b/db/postgres/gitlabProject.js
@@ -10,15 +10,11 @@ module.exports = (sequelize, DataTypes) => {
   }
 
   GitlabProject.init({
-    uuid: {
-      primaryKey: true,
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4
-    },
     name: {
       type: DataTypes.STRING
     },
     id: {
+      primaryKey: true,
       type: DataTypes.INTEGER
     },
     pathWithNamespace: {

--- a/db/postgres/jiraIssue.js
+++ b/db/postgres/jiraIssue.js
@@ -10,15 +10,11 @@ module.exports = (sequelize, DataTypes) => {
   }
 
   JiraIssue.init({
-    uuid: {
-      primaryKey: true,
-      type: DataTypes.UUID,
-      defaultValue: DataTypes.UUIDV4
-    },
     projectId: {
       type: DataTypes.INTEGER
     },
     id: {
+      primaryKey: true,
       type: DataTypes.INTEGER
     },
     url: {

--- a/db/postgres/jiraUser.js
+++ b/db/postgres/jiraUser.js
@@ -11,7 +11,6 @@ module.exports = (sequelize, DataTypes) => {
 
   JiraUser.init({
     uuid: {
-      primaryKey: true,
       type: DataTypes.UUID,
       defaultValue: DataTypes.UUIDV4
     },
@@ -19,7 +18,10 @@ module.exports = (sequelize, DataTypes) => {
     accountId: DataTypes.STRING,
     name: DataTypes.STRING,
     key: DataTypes.STRING,
-    emailAddress: DataTypes.STRING,
+    emailAddress: {
+      type: DataTypes.STRING,
+      primaryKey: true
+    },
     displayName: DataTypes.STRING,
     active: DataTypes.BOOLEAN,
     timezone: DataTypes.STRING,

--- a/grafana/dashboards/Home.json
+++ b/grafana/dashboards/Home.json
@@ -16,8 +16,179 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
+  "iteration": 1627580781029,
   "links": [],
   "panels": [
+    {
+      "datasource": "Postgres",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 19,
+        "w": 11,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  count(id) as \"Commits\",\n  sum(additions) as \"Additions\",\n  sum(deletions) as \"Deletions\",\n  sum(additions - deletions) as \"LOC\"\nFROM gitlab_commits\nWHERE\n  $__timeFilter(gitlab_commits.committed_date) AND gitlab_commits.project_id = $ProjectId\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_double"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "test_data",
+          "timeColumn": "time_date_time",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Lines Of Code",
+      "type": "stat"
+    },
+    {
+      "datasource": "Postgres",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT count(email) from (\n\n  SELECT\n    committer_email\n  FROM gitlab_commits\n  WHERE\n    $__timeFilter(gitlab_commits.committed_date) AND gitlab_commits.project_id = $ProjectId\n  Group By committer_email\n) as email\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value_double"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "test_data",
+          "timeColumn": "time_date_time",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Contributors",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 10,
+      "title": "Row title",
+      "type": "row"
+    },
     {
       "datasource": "Postgres",
       "fieldConfig": {
@@ -60,7 +231,7 @@
         "h": 16,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 20
       },
       "id": 2,
       "options": {
@@ -87,7 +258,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \r\n  now() as time,\r\n  -- title as metric,\r\n  -- lead_time as value\r\n  -- created_at as time,\r\n  title as title,\r\n  lead_time\r\nfrom jira_issues_enriched\r\n--where issue_type = 'Bug' and fields_status_name = '已完成' and fields_resolutiondate is not null and fields_created is not null and fields_created BETWEEN '2021-06-23T18:50:24.222Z' AND '2021-07-28T18:50:24.222Z'\r\nwhere lead_time > 0\r\norder by created_at;\r\n\r\n",
+          "rawSql": "select \r\n  now() as time,\r\n  title as title,\r\n  lead_time\r\nfrom jira_issues\r\nwhere lead_time > 0\r\norder by created_at;\r\n\r\n",
           "refId": "A",
           "select": [
             [
@@ -137,7 +308,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 36
       },
       "id": 4,
       "options": {
@@ -170,7 +341,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select now() as time, count(*) as value, format('%s-%s', (bucket-1)*30, bucket*30) as metric\nfrom (\nselect lead_time, width_bucket(lead_time, 1, 360, 12) as bucket\nfrom jira_issues_enriched\n) as t\ngroup by bucket\norder by bucket",
+          "rawSql": "select now() as time, count(*) as value, format('%s-%s', (bucket-1)*30, bucket*30) as metric\nfrom (\nselect lead_time, width_bucket(lead_time, 1, 360, 12) as bucket\nfrom jira_issues\n) as t\ngroup by bucket\norder by bucket",
           "refId": "A",
           "select": [
             [
@@ -209,7 +380,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 6,
@@ -244,7 +415,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \n  now() as time,\n  -- Need resolution_time to replace created_at\n  to_char(created_at, 'YYYY-MM') as metric,\n  median(lead_time) as value\nfrom jira_issues_enriched\ngroup by to_char(created_at, 'YYYY-MM')\norder by metric;",
+          "rawSql": "select \n  now() as time,\n  -- Need resolution_time to replace created_at\n  to_char(created_at, 'YYYY-MM') as metric,\n  median(lead_time) as value\nfrom jira_issues\ngroup by to_char(created_at, 'YYYY-MM')\norder by metric;",
           "refId": "A",
           "select": [
             [
@@ -315,7 +486,32 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "19688130",
+          "value": "19688130"
+        },
+        "datasource": "Postgres",
+        "definition": "Select id from gitlab_projects",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "ProjectId",
+        "multi": false,
+        "name": "ProjectId",
+        "options": [],
+        "query": "Select id from gitlab_projects",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-2y",
@@ -325,5 +521,5 @@
   "timezone": "",
   "title": "Lead Times",
   "uid": "0BwAzlZ7k",
-  "version": 18
+  "version": 7
 }

--- a/src/plugins/gitlab-pond/src/collector/collection-manager.js
+++ b/src/plugins/gitlab-pond/src/collector/collection-manager.js
@@ -12,7 +12,7 @@ module.exports = {
       const projectId = options.projectIds[index]
 
       // TODO: this only get 20 commits... we need to page through all of them
-      let response = await module.exports.fetchCollectionData('projects', projectId, 'repository/commits?with_stats=true')
+      let response = await module.exports.fetchCollectionData('projects', projectId, 'repository/commits?with_stats=true&per_page=100')
       response = response.map(res => {
         return {
           projectId,

--- a/src/plugins/gitlab-pond/src/enricher/index.js
+++ b/src/plugins/gitlab-pond/src/enricher/index.js
@@ -38,6 +38,7 @@ module.exports = {
 
     commits.forEach(commit => {
       commit = {
+        projectId: commit.projectId,
         id: commit.id,
         shortId: commit.short_id,
         title: commit.title,

--- a/src/plugins/gitlab-pond/src/enricher/index.js
+++ b/src/plugins/gitlab-pond/src/enricher/index.js
@@ -33,8 +33,7 @@ module.exports = {
       , rawDb)
 
     // mongo always returns an array
-    const creationPromises = []
-    const updatePromises = []
+    const upsertPromises = []
 
     commits.forEach(commit => {
       commit = {
@@ -55,22 +54,10 @@ module.exports = {
         total: commit.stats.total
       }
 
-      creationPromises.push(GitlabCommit.findOrCreate({
-        where: {
-          id: commit.id
-        },
-        defaults: commit
-      }))
-
-      updatePromises.push(GitlabCommit.update(commit, {
-        where: {
-          id: commit.id
-        }
-      }))
+      upsertPromises.push(GitlabCommit.upsert(commit))
     })
 
-    await Promise.all(creationPromises)
-    await Promise.all(updatePromises)
+    await Promise.all(upsertPromises)
   },
 
   async saveProjectsToPsql (rawDb, enrichedDb, projectIds) {
@@ -83,8 +70,7 @@ module.exports = {
       { id: { $in: projectIds } }
       , rawDb)
 
-    const creationPromises = []
-    const updatePromises = []
+    const upsertPromises = []
 
     // mongo always returns an array
     projects.forEach(project => {
@@ -98,21 +84,9 @@ module.exports = {
         starCount: project.star_count
       }
 
-      creationPromises.push(GitlabProject.findOrCreate({
-        where: {
-          id: project.id
-        },
-        defaults: project
-      }))
-
-      updatePromises.push(GitlabProject.update(project, {
-        where: {
-          id: project.id
-        }
-      }))
+      upsertPromises.push(GitlabProject.upsert(project))
     })
 
-    await Promise.all(creationPromises)
-    await Promise.all(updatePromises)
+    await Promise.all(upsertPromises)
   }
 }

--- a/src/plugins/jira-pond/src/enricher/index.js
+++ b/src/plugins/jira-pond/src/enricher/index.js
@@ -23,8 +23,7 @@ module.exports = {
       'fields.project.id': `${projectId}`
     }, rawDb)
 
-    const creationPromises = []
-    const updatePromises = []
+    const upsertPromises = []
     const leadTimePromises = []
     const issuesToCreate = []
     issues.forEach(async issue => {
@@ -49,22 +48,10 @@ module.exports = {
         ...issue
       }
       // Create all new records
-      creationPromises.push(JiraIssue.findOrCreate({
-        where: {
-          id: issue.id
-        },
-        defaults: issue
-      }))
-      // Update all existing records
-      updatePromises.push(JiraIssue.update(issue, {
-        where: {
-          id: issue.id
-        }
-      }))
+      upsertPromises.push(JiraIssue.upsert(issue))
     })
 
-    await Promise.all(creationPromises)
-    await Promise.all(updatePromises)
+    await Promise.all(upsertPromises)
   },
 
   async calculateLeadTime (issue, db) {


### PR DESCRIPTION
## Why

We want to show metrics based on user commits to a repo that have been enhanced with data

## What

Here are the metrics this collects

1. Number of contributors
2. Number of commits
3. Removed lines of code
4. Added lines of code
5. Accumulated lines (defined as the sum of added lines of code and removed lines of code during a time window)

## How

- To change this, I had to load up grafana on port 3002 and then I had to make queries for the dashboard and run them.
- I also had to add gitlab_commits.project_id
- set page size of gitlab commits to 100 and not the default 20

<img width="1716" alt="Screen Shot 2021-07-29 at 2 48 10 PM" src="https://user-images.githubusercontent.com/3011407/127540447-9f14c39e-8cd6-4e94-9630-c80d446c6752.png">
