### PR TITLE
Make Grafana wait for Postgres by setting restart to always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     depends_on:
       - postgresdb
     command: sh -c './scripts/wait-for postgresdb:5432 -- grafana'
+    restart: always
     environment:
       GF_DATABASE_TYPE: postgres
       GF_DATABASE_HOST: postgresdb:5432

--- a/src/plugins/gitlab-pond/index.js
+++ b/src/plugins/gitlab-pond/index.js
@@ -33,10 +33,10 @@ module.exports = {
 
 if (require.main === module) {
   require('module-alias/register')
-  const dbConnector = require('@mongo/connection')
-  const enrichedDb = require('@db/postgres');
+  const dbConnector = require('@mongo/connection');
+  // const enrichedDb = require('@db/postgres');
 
-  (async function() {
+  (async function () {
     const { db, client } = await dbConnector.connect()
     try {
       await module.exports.collector.exec(db, { projectId: process.argv[2] })


### PR DESCRIPTION
## Why

When we run `npm run docker`, if Postgres is not all the way initialized, Grafana will shutdown. Since Postgres on initial startup takes a moment to set everything up, we need a mechanism to make Grafana wait for Postgres.

Simply setting `depends_on` doesn't work since docker-compose does not wait until a container is “ready” - only until it’s running. Here's the [doc](https://docs.docker.com/compose/startup-order/).

## What

This PR is not a perfect fix, but it should work. By setting `restart: always` in `docker-compose.yml`, Grafana will retry many times until Postgres is fully up. This has been tested on my laptop.