### PR TITLE
fix: removed grafana internal db things from working db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,12 +48,5 @@ services:
       - postgresdb
     command: sh -c './scripts/wait-for postgresdb:5432 -- grafana'
     restart: always
-    environment:
-      GF_DATABASE_TYPE: postgres
-      GF_DATABASE_HOST: postgresdb:5432
-      GF_DATABASE_NAME: lake
-      GF_DATABASE_USER: postgres
-      GF_DATABASE_PASSWORD: postgres
-      GF_DATABASE_SSL_MODE: disable
 volumes:
   grafana-storage: {}


### PR DESCRIPTION
We actually don't need to specify the database + datasource for Grafana. This is what's causing all the internal Grafana DB stuff to populate the `lake` postgres db.

**Updated:**
- Removed Grafana database env variables

**Fixes:** 
- Stops cluttering the working db with Grafana internal db things that we don't really need

**Note**
- It's possible in the future if we want this Grafana internal db stuff back, we can just make another db in `docker-compose.yml`. Then populate it. As of now though, I don't see any use for it.