### PR TITLE
chore(npm): we need a way to run without DEBUG when desired

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "enrich": "nodemon src/enrichment/main.js",
     "enrichment-worker": "./src/enrichment/worker.js",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives --fix && echo '✔  Your .js files look good.'",
-    "all": "node src/plugins/index.js && concurrently \"DEBUG=true nodemon src/collection/main.js\" \"DEBUG=true nodemon src/collection/worker.js\" \"DEBUG=true nodemon src/enrichment/main.js\" \"DEBUG=true nodemon src/enrichment/worker.js\"",
+    "all": "node src/plugins/index.js && concurrently \"nodemon src/collection/main.js\" \"nodemon src/collection/worker.js\" \"nodemon src/enrichment/main.js\" \"nodemon src/enrichment/worker.js\"",
+    "all-debug": "node src/plugins/index.js && concurrently \"DEBUG=true nodemon src/collection/main.js\" \"DEBUG=true nodemon src/collection/worker.js\" \"DEBUG=true nodemon src/enrichment/main.js\" \"DEBUG=true nodemon src/enrichment/worker.js\"",
     "prepare": "husky install",
     "commit": "cz",
     "docker": "docker-compose up --build --force-recreate"


### PR DESCRIPTION
Concurrently seems to not allow you to run something like `DEBUG=true npm run all` so we need `npm
run all` and `npm run all-debug`. The reason to have DEBUG is so we can comment out console logs
with `process.env.DEBUG && console.log()` so we don't remove console logs needed by others.