### PR TITLE
fix(gitlab collection): fix pagination, table types, mongo names

### DIFF
--- a/db/migrations/20210730182134-change-string-to-text-gitlab.js
+++ b/db/migrations/20210730182134-change-string-to-text-gitlab.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('gitlab_commits', 'message', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('gitlab_commits', 'title', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('gitlab_merge_requests', 'description', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('gitlab_merge_requests', 'title', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    
+  }
+};

--- a/db/postgres/gitlabCommit.js
+++ b/db/postgres/gitlabCommit.js
@@ -21,10 +21,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING
     },
     title: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     message: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     authorName: {
       type: DataTypes.STRING

--- a/db/postgres/gitlabMergeRequest.js
+++ b/db/postgres/gitlabMergeRequest.js
@@ -15,7 +15,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER
     },
     title: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     projectId: {
       type: DataTypes.INTEGER
@@ -51,7 +51,7 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING
     },
     description: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     authorUsername: {
       type: DataTypes.STRING

--- a/src/plugins/gitlab-pond/src/collector/commits.js
+++ b/src/plugins/gitlab-pond/src/collector/commits.js
@@ -2,7 +2,7 @@ require('module-alias/register')
 const { findOrCreateCollection } = require('../../../commondb')
 const fetcher = require('./fetcher')
 
-const collectionName = 'gitlab_project_repo_commits'
+const collectionName = 'gitlab_commits'
 
 module.exports = {
   async collect ({ db, projectId, forceAll }) {
@@ -15,7 +15,7 @@ module.exports = {
 
   async collectByProjectId (db, projectId, forceAll) {
     const commitsCollection = await findOrCreateCollection(db, collectionName)
-    for await (const commit of fetcher.fetchPaged(`projects/${projectId}/repository/commits?all=true&with_stats=true`)) {
+    for await (const commit of fetcher.fetchPaged(`projects/${projectId}/repository/commits?with_stats=true`)) {
       commit.projectId = projectId
       await commitsCollection.findOneAndUpdate(
         { id: commit.id },

--- a/src/plugins/gitlab-pond/src/collector/fetcher.js
+++ b/src/plugins/gitlab-pond/src/collector/fetcher.js
@@ -31,13 +31,13 @@ module.exports = {
     resourceUri = `${resourceUri}${resourceUri.includes('?') ? '&' : '?'}`
 
     let page = 1
-    
+
     while (true) {
       const res = await module.exports.fetch(`${resourceUri}per_page=${pageSize}&page=${page}`, maxRetry)
       // we always simply want the next page of data
       page += 1
       // If no data is returned, we must be on the last page of refults
-      if(res.data.length === 0){
+      if (res.data.length === 0) {
         console.log('INFO: fetchPaged: No data for this page, done fetching paged')
         break
       }

--- a/src/plugins/gitlab-pond/src/collector/fetcher.js
+++ b/src/plugins/gitlab-pond/src/collector/fetcher.js
@@ -31,10 +31,16 @@ module.exports = {
     resourceUri = `${resourceUri}${resourceUri.includes('?') ? '&' : '?'}`
 
     let page = 1
-
-    while (page) {
+    
+    while (true) {
       const res = await module.exports.fetch(`${resourceUri}per_page=${pageSize}&page=${page}`, maxRetry)
-      page = res.headers['x-next-page']
+      // we always simply want the next page of data
+      page += 1
+      // If no data is returned, we must be on the last page of refults
+      if(res.data.length === 0){
+        console.log('INFO: fetchPaged: No data for this page, done fetching paged')
+        break
+      }
       for (const item of res.data) {
         yield item
       }

--- a/src/plugins/gitlab-pond/src/collector/merge-requests.js
+++ b/src/plugins/gitlab-pond/src/collector/merge-requests.js
@@ -2,7 +2,7 @@ require('module-alias/register')
 const { findOrCreateCollection } = require('../../../commondb')
 const fetcher = require('./fetcher')
 
-const collectionName = 'gitlab_project_merge_requests'
+const collectionName = 'gitlab_merge_requests'
 
 module.exports = {
   async collect ({ db, projectId, forceAll }) {

--- a/src/plugins/gitlab-pond/src/enricher/index.js
+++ b/src/plugins/gitlab-pond/src/enricher/index.js
@@ -5,35 +5,35 @@ const mongo = require('../util/mongo')
 module.exports = {
   async enrich (rawDb, enrichedDb, options) {
     try {
-      console.log('INFO: Gitlab Enrichment for projectIds: ', options.projectIds)
+      console.log('INFO: Gitlab Enrichment for projectId: ', options.projectId)
       await module.exports.saveProjectsToPsql(
         rawDb,
         enrichedDb,
-        options.projectIds
+        options.projectId
       )
-      await module.exports.saveCommitsToPsqlBasedOnProjectIds(
+      await module.exports.saveCommitsToPsqlBasedOnProjectId(
         rawDb,
         enrichedDb,
-        options.projectIds
+        options.projectId
       )
-      await module.exports.saveMergeRequestsToPsqlBasedOnProjectIds(
+      await module.exports.saveMergeRequestsToPsqlBasedOnProjectId(
         rawDb,
         enrichedDb,
-        options.projectIds
+        options.projectId
       )
       console.log('Done enriching issues')
     } catch (error) {
       console.error(error)
     }
   },
-  async saveMergeRequestsToPsqlBasedOnProjectIds (rawDb, enrichedDb, projectIds) {
+  async saveMergeRequestsToPsqlBasedOnProjectId (rawDb, enrichedDb, projectId) {
     const {
       GitlabMergeRequest
     } = enrichedDb
 
     // find the project in mongo
     const mergeRequests = await mongo.findCollection('gitlab_merge_requests',
-      { projectId: { $in: projectIds } }
+      { projectId: projectId }
       , rawDb)
 
     // mongo always returns an array
@@ -63,14 +63,14 @@ module.exports = {
 
     await Promise.all(upsertPromises)
   },
-  async saveCommitsToPsqlBasedOnProjectIds (rawDb, enrichedDb, projectIds) {
+  async saveCommitsToPsqlBasedOnProjectId (rawDb, enrichedDb, projectId) {
     const {
       GitlabCommit
     } = enrichedDb
 
     // find the project in mongo
     const commits = await mongo.findCollection('gitlab_commits',
-      { projectId: { $in: projectIds } }
+      { projectId: projectId }
       , rawDb)
 
     // mongo always returns an array
@@ -101,14 +101,14 @@ module.exports = {
     await Promise.all(upsertPromises)
   },
 
-  async saveProjectsToPsql (rawDb, enrichedDb, projectIds) {
+  async saveProjectsToPsql (rawDb, enrichedDb, projectId) {
     const {
       GitlabProject
     } = enrichedDb
 
     // find the project in mongo
     const projects = await mongo.findCollection('gitlab_projects',
-      { id: { $in: projectIds } }
+      { id: projectId }
       , rawDb)
 
     const upsertPromises = []

--- a/src/plugins/jira-pond/index.js
+++ b/src/plugins/jira-pond/index.js
@@ -29,10 +29,10 @@ module.exports = {
 
 if (require.main === module) {
   require('module-alias/register')
-  const dbConnector = require('@mongo/connection')
-  const enrichedDb = require('@db/postgres');
+  const dbConnector = require('@mongo/connection');
+  // const enrichedDb = require('@db/postgres');
 
-  (async function() {
+  (async function () {
     const { db, client } = await dbConnector.connect()
     try {
       await module.exports.collector.exec(db, { boardId: process.argv[2], forceAll: process.argv[3] })

--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -14,7 +14,7 @@ module.exports = {
     await module.exports.collectByBoardId(db, boardId, forceAll)
   },
 
-  async collectByBoardId(db, boardId, forceAll) {
+  async collectByBoardId (db, boardId, forceAll) {
     const issuesCollection = await findOrCreateCollection(db, collectionName)
     const latestUpdated = await issuesCollection.find().sort({ 'fields.updated': -1 }).limit(1).next()
     let jql = ''


### PR DESCRIPTION
1. There was an issue with the fetchPaginated where we were using `?all=true`. I removed that since
it was not giving the correct number of issues in the default branch in gitlab. If you use all=true,
it seems to get about double the commits. I have a theory that this is caused by teams that use
rebase in gitlab. Gitlab seems to save the commits that were rebased with a diffdrent parent so the
ids of the commmits are different. see #95 

2. I also changed the type of the gitlab postgres models to TEXT instead of STRING since some descriptions and title of our data were too long. There is a migration for this and you have to run `npx secquelize db:migrate`

3. I also changed the names of the mongo collections back to `gitlab_commits` and `gitlab_merge_requests` as approved by @UltimateBeaver . This was needed since the collection name in the collectors and enrichers were different. The new names match the Postgres table names defined in `/db`

4. I also changed all the gitlab code for project ids and converted them to projectId.