### PR TITLE
fix: rabbitmq can't log to /tmp on macOS permission denied

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - 5672:5672
     volumes:
       - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
-      - /tmp/rabbitmq/etc/:/tmp/etc/rabbitmq/
-      - /tmp/rabbitmq/data/:/var/lib/rabbitmq/
-      - /tmp/rabbitmq/logs/:/var/log/rabbitmq/
+      - ./rabbitmq/etc/:/etc/rabbitmq/
+      - ./rabbitmq/data/:/var/lib/rabbitmq/
+      - ./rabbitmq/logs/:/var/log/rabbitmq/
   mongodb:
     image: mongo:5.0.0
     container_name: mongodb


### PR DESCRIPTION
## Why

When I run `npm run docker`, rabbitmq doesn't start up due to a permission denied error: 

```
rabbitmq_1    | 2021-07-31 17:47:47.113606+00:00 [noti] <0.44.0> Application rabbit exited with reason: {{cannot_log_to_file,"/var/log/rabbitmq/rabbit@fcdd6141911a_upgrade.log",eacces},{rabbit,start,[normal,[]]}}
```

## What

This PR fixes the issue by changing the location of rabbitmq volume to the current folder.

