### PR TITLE
feat: plugins initialization before all workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,20 @@ POST http://localhost:3001/
         "boardId": 8
     },
     "gitlab": {
-        "projectId": 19688130
+        "projectId": 8967944
     }
 }
 
 ```
     Or, by using `curl`
 ```sh
+# ee
 curl -X POST "http://localhost:3001/" -H 'content-type: application/json' \
-    -d '{"jira":{"boardId": 8}}'
+    -d '{"jira":{"boardId": 8}, "gitlab": {"projectId": 8967944}}'
+
+# small data set for test
+curl -X POST "http://localhost:3001/" -H 'content-type: application/json' \
+    -d '{"jira":{"boardId": 29}, "gitlab": {"projectId": 24547305}}'
 ```
 
 3. See that the collection job was published, jira collection ran, the enrichment job was published, and jira enrichment ran

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,22 +1,17 @@
 module.exports = [
   {
     package: 'jira-pond',
-    name: 'collector',
-    type: 'collector'
-  },
-  {
-    package: 'jira-pond',
-    name: 'enricher',
-    type: 'enricher'
+    name: 'jira',
+    configuration: {}
   },
   {
     package: 'gitlab-pond',
-    name: 'collector',
-    type: 'collector'
+    name: 'gitlab',
+    configuration: {}
   },
   {
-    package: 'gitlab-pond',
-    name: 'enricher',
-    type: 'enricher'
+    package: 'compound-figures',
+    name: 'compound-figures',
+    configuration: {}
   }
 ]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "enrich": "nodemon src/enrichment/main.js",
     "enrichment-worker": "./src/enrichment/worker.js",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives --fix && echo '✔  Your .js files look good.'",
-    "all": "concurrently \"DEBUG=true nodemon src/collection/main.js\" \"DEBUG=true nodemon src/collection/worker.js\" \"DEBUG=true nodemon src/enrichment/main.js\" \"DEBUG=true nodemon src/enrichment/worker.js\"",
+    "all": "node src/plugins/index.js && concurrently \"DEBUG=true nodemon src/collection/main.js\" \"DEBUG=true nodemon src/collection/worker.js\" \"DEBUG=true nodemon src/enrichment/main.js\" \"DEBUG=true nodemon src/enrichment/worker.js\"",
     "prepare": "husky install",
     "commit": "cz",
     "docker": "docker-compose up --build --force-recreate"
@@ -45,6 +45,7 @@
     "express": "^4.17.1",
     "jira-pond": "src/plugins/jira-pond",
     "gitlab-pond": "src/plugins/gitlab-pond",
+    "compound-figures": "src/plugins/compound-figures",
     "lodash": "^4.17.21",
     "module-alias": "^2.2.2",
     "mongodb": "*",

--- a/src/collection/worker.js
+++ b/src/collection/worker.js
@@ -5,34 +5,30 @@ const axios = require('axios')
 const _has = require('lodash/has')
 
 const dbConnector = require('@mongo/connection')
-const { buildPluginRegistry } = require('../plugins')
+const { collection } = require('../plugins')
 const consumer = require('../queue/consumer')
 const enrichmentApiUrl = require('@config/resolveConfig').enrichment.connectionString
 
 const queue = 'collection'
 
 const jobHandler = async (job) => {
-  const collection = await buildPluginRegistry('collector')
   const {
     db, client
   } = await dbConnector.connect()
 
-  const enrichmentJob = {}
-
   try {
-    if (_has(job, 'jira')) {
-      enrichmentJob.jira = await collection.plugins.jiraCollector(db, job.jira)
-    }
-    if (_has(job, 'gitlab')) {
-      enrichmentJob.gitlab = await collection.plugins.gitlabCollector(db, job.gitlab)
-    }
+    await Promise.all(
+      Object.keys(job)
+        .filter(key => _has(collection, key))
+        .map(pluginName => collection[pluginName](db, job[pluginName]))
+    )
   } catch (error) {
     console.log('Failed to collect', error)
   } finally {
     dbConnector.disconnect(client)
   }
 
-  await axios.post(enrichmentApiUrl, enrichmentJob)
+  await axios.post(enrichmentApiUrl, job)
 }
 
 consumer(queue, jobHandler)

--- a/src/plugins/compound-figures/index.js
+++ b/src/plugins/compound-figures/index.js
@@ -2,6 +2,10 @@ require('module-alias/register')
 const config = require('@config/resolveConfig').jiraBoardGitlabProject
 
 module.exports = {
+  configuration: {
+    // default configuration which could be overrided by `config/plugins.js`
+  },
+
   async initialize (rawDb, enrichedDb, plugins) {
     if (!config) {
       return

--- a/src/plugins/gitlab-pond/index.js
+++ b/src/plugins/gitlab-pond/index.js
@@ -2,6 +2,10 @@ const collection = require('./src/collector')
 const enrichment = require('./src/enricher')
 
 module.exports = {
+  configuration: {
+    // default configuration which could be overrided by `config/plugins.js`
+  },
+
   collector: {
     name: 'gitlabCollector',
     exec: async function (rawDb, options) {

--- a/src/plugins/gitlab-pond/src/collector/index.js
+++ b/src/plugins/gitlab-pond/src/collector/index.js
@@ -3,7 +3,7 @@ const mergeRequests = require('./merge-requests')
 const projects = require('./projects')
 
 async function collect (db, { projectId, forceAll }) {
-  const args = { db, projectId, forceAll }
+  const args = { db, projectId: Number(projectId), forceAll }
   await projects.collect(args)
   await commits.collect(args)
   await mergeRequests.collect(args)

--- a/src/plugins/gitlab-pond/src/enricher/index.js
+++ b/src/plugins/gitlab-pond/src/enricher/index.js
@@ -3,7 +3,7 @@ const commits = require('./commits')
 const mergeRequests = require('./merge-requests')
 
 async function enrich (rawDb, enrichedDb, { projectId }) {
-  const args = { rawDb, enrichedDb, projectId }
+  const args = { rawDb, enrichedDb, projectId: Number(projectId) }
   await projects.enrich(args)
   await commits.enrich(args)
   await mergeRequests.enrich(args)

--- a/src/plugins/gitlab-pond/src/enricher/projects.js
+++ b/src/plugins/gitlab-pond/src/enricher/projects.js
@@ -11,7 +11,7 @@ async function enrich ({ rawDb, enrichedDb, projectId }) {
 async function enrichProjectById (rawDb, enrichedDb, projectId) {
   console.info('INFO >>> gitlab enriching project', projectId)
   const projectsCollection = await projectsCollector.getCollection(rawDb)
-  const project = await projectsCollection.findOne({ id: Number(projectId) })
+  const project = await projectsCollection.findOne({ id: projectId })
   const enriched = {
     name: project.name,
     id: project.id,

--- a/src/plugins/jira-pond/index.js
+++ b/src/plugins/jira-pond/index.js
@@ -2,6 +2,10 @@ const collection = require('./src/collector')
 const enrichment = require('./src/enricher')
 
 module.exports = {
+  configuration: {
+    // default configuration which could be overrided by `config/plugins.js`
+  },
+
   collector: {
     name: 'jiraCollector',
     exec: async function (rawDb, options) {

--- a/src/plugins/jira-pond/src/collector/fetcher.js
+++ b/src/plugins/jira-pond/src/collector/fetcher.js
@@ -8,6 +8,11 @@ async function fetch (resourceUri) {
   let res
   while (retry < maxRetry) {
     console.log(`INFO >>> jira fetching data from ${resourceUri} #${retry}`)
+    const abort = axios.CancelToken.source()
+    const id = setTimeout(
+      () => abort.cancel(`Timeout of ${config.timeout}ms.`),
+      config.timeout
+    )
     try {
       res = await axios.get(`${config.host}/rest/${resourceUri}`, {
         headers: {
@@ -15,8 +20,9 @@ async function fetch (resourceUri) {
           Authorization: `Basic ${config.basicAuth}`
         },
         agent: config.proxy && new ProxyAgent(config.proxy),
-        timeout: config.timeout
+        cancelToken: abort.token
       })
+      clearTimeout(id)
       break
     } catch (error) {
       retry++

--- a/src/plugins/jira-pond/src/collector/index.js
+++ b/src/plugins/jira-pond/src/collector/index.js
@@ -1,7 +1,7 @@
 const issues = require('./issues')
 
 async function collect (db, { boardId, forceAll }) {
-  const args = { db, boardId, forceAll }
+  const args = { db, boardId: Number(boardId), forceAll }
   await issues.collect(args)
 }
 

--- a/src/plugins/jira-pond/src/collector/issues.js
+++ b/src/plugins/jira-pond/src/collector/issues.js
@@ -14,11 +14,11 @@ async function collect ({ db, boardId, forceAll }) {
 async function collectByBoardId (db, boardId, forceAll) {
   const issuesCollection = await getCollection(db)
   const latestUpdated = await issuesCollection.find().sort({ 'fields.updated': -1 }).limit(1).next()
-  const $addToSet = { boardIds: Number(boardId) }
+  const $addToSet = { boardIds: boardId }
   let jql = ''
   if (!forceAll && latestUpdated) {
     const jiraDate = dayjs(latestUpdated.fields.updated).format('YYYY/MM/DD HH:mm')
-    jql = encodeURIComponent(`updated >= '${jiraDate}'`)
+    jql = encodeURIComponent(`updated >= '${jiraDate}' ORDER BY updated ASC`)
   }
   for await (const issue of fetcher.fetchPaged(`agile/1.0/board/${boardId}/issue?jql=${jql}`, 'issues')) {
     await issuesCollection.findOneAndUpdate(

--- a/src/plugins/jira-pond/src/enricher/index.js
+++ b/src/plugins/jira-pond/src/enricher/index.js
@@ -1,7 +1,7 @@
 const issues = require('./issues')
 
 async function enrich (rawDb, enrichedDb, { boardId, forceAll }) {
-  const args = { rawDb, enrichedDb, boardId, forceAll }
+  const args = { rawDb, enrichedDb, boardId: Number(boardId), forceAll }
   await issues.enrich(args)
 }
 

--- a/src/plugins/jira-pond/src/enricher/index.js
+++ b/src/plugins/jira-pond/src/enricher/index.js
@@ -1,7 +1,7 @@
 const issues = require('./issues')
 
-async function enrich (rawDb, enrichedDb, { forceAll }) {
-  const args = { rawDb, enrichedDb, forceAll }
+async function enrich (rawDb, enrichedDb, { boardId, forceAll }) {
+  const args = { rawDb, enrichedDb, boardId, forceAll }
   await issues.enrich(args)
 }
 

--- a/src/plugins/jira-pond/src/enricher/issues.js
+++ b/src/plugins/jira-pond/src/enricher/issues.js
@@ -13,7 +13,7 @@ async function enrich ({ rawDb, enrichedDb, boardId, forceAll }) {
 }
 
 async function enrichIssues (rawDb, enrichedDb, boardId, forceAll) {
-  console.info('INFO >>> jira enriching issues, forceAll', forceAll)
+  console.info(`INFO >>> jira enriching issues for board #${boardId}, forceAll ${forceAll}`)
   const issueCollection = await issuesCollecotr.getCollection(rawDb)
   const { JiraIssue, JiraBoardIssue } = enrichedDb
   // filtering out portion of records that need to be enriched


### PR DESCRIPTION
1. Support plugin configuration injection
   Plugin can declare a default configuration on its main module, which could be overridden by 
   `config/plugins.js`. We should move their configurations from `local.js` to `plugins.js` file
2. Collectors now execute in parallel, so do enrichers
   Our collectors have no dependency to each other at this point, all plugins we specified in 
   request body will be executed in parallel
3. Ensure correct data types of parameters(boardId/projectId) on root functions `collect/enrich`
   Once and for all
4. `axios` timeout mitigation for `jira-pond`
5. Mitigation for scenario that jira data collecting procedure got interrupted(Ctrl-C) with sorting
   jira issues from API by `updated` field