### PR TITLE
fix: fix lead time charts in grafana dashboard

### DIFF
--- a/grafana/dashboards/Home.json
+++ b/grafana/dashboards/Home.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1,
-  "iteration": 1627670210682,
+  "iteration": 1627944564089,
   "links": [],
   "panels": [
     {
@@ -268,6 +268,7 @@
             "mode": "thresholds"
           },
           "mappings": [],
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -418,7 +419,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \r\n  now() as time,\r\n  title as title,\r\n  lead_time\r\nfrom jira_issues\r\nwhere lead_time > 0\r\norder by created_at;\r\n\r\n",
+          "rawSql": "select \r\n  now() as time,\r\n  title as title,\r\n  lead_time\r\nfrom jira_issues\r\nwhere \r\n  lead_time > 0\r\n  and $__timeFilter(issue_created_at)\r\norder by created_at;\r\n\r\n",
           "refId": "A",
           "select": [
             [
@@ -501,7 +502,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select now() as time, count(*) as value, format('%s-%s', (bucket-1)*30, bucket*30) as metric\nfrom (\nselect lead_time, width_bucket(lead_time, 1, 360, 12) as bucket\nfrom jira_issues\n) as t\ngroup by bucket\norder by bucket",
+          "rawSql": "select now() as time, count(*) as value, format('>%s', bucket*5) as metric\nfrom (\n  select lead_time, width_bucket(lead_time, ARRAY[5, 10, 15, 20]) as bucket\n  from jira_issues\n  where lead_time > 0\n    and $__timeFilter(issue_created_at)\n) as t\ngroup by bucket\norder by bucket",
           "refId": "A",
           "select": [
             [
@@ -529,45 +530,76 @@
       "type": "piechart"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "Postgres",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 10,
         "w": 12,
         "x": 12,
         "y": 52
       },
-      "hiddenSeries": false,
       "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
       },
-      "percentage": false,
       "pluginVersion": "8.0.6",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
           "format": "table",
@@ -575,7 +607,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \n  now() as time,\n  -- Need resolution_time to replace created_at\n  to_char(created_at, 'YYYY-MM') as metric,\n  median(lead_time) as value\nfrom jira_issues\ngroup by to_char(created_at, 'YYYY-MM')\norder by metric;",
+          "rawSql": "select \n  to_date(to_char(issue_created_at, 'YYYY-MM'), 'YYYY-MM') as time_month,\n  percentile_cont(0.5) within group (order by lead_time) as value\nfrom jira_issues\nwhere lead_time > 0\n  and $__timeFilter(issue_created_at)\ngroup by to_char(issue_created_at, 'YYYY-MM')\norder by 1",
           "refId": "A",
           "select": [
             [
@@ -599,46 +631,10 @@
           ]
         }
       ],
-      "thresholds": [],
       "timeFrom": null,
-      "timeRegions": [],
       "timeShift": null,
       "title": "Lead Time Median Trend",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -651,8 +647,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "20103385",
-          "value": "20103385"
+          "text": "8967944",
+          "value": "8967944"
         },
         "datasource": "Postgres",
         "definition": "Select id from gitlab_projects",
@@ -674,12 +670,12 @@
     ]
   },
   "time": {
-    "from": "now-2y",
+    "from": "now-1y",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Lead Times",
+  "title": "Jira lead times & Gitlab basics",
   "uid": "0BwAzlZ7k",
-  "version": 2
+  "version": 4
 }


### PR DESCRIPTION
## What

1. All three lead time charts support time filter
2. Fix lead time median trend no data issue
3. Adjust bucket configuration for lead time distribution and improve pie chart labels

## Before

![screencapture-localhost-3002-d-0BwAzlZ7k-lead-times-2021-08-02-19_50_48](https://user-images.githubusercontent.com/2908155/127950034-57dbbc3a-e633-4927-a58f-a5c792d0f3e8.png)

## After

![screencapture-localhost-3002-d-0BwAzlZ7k-jira-lead-times-and-gitlab-basics-2021-08-02-19_46_48](https://user-images.githubusercontent.com/2908155/127950050-4c8e10fc-ecde-4d94-a60f-7a853bf18989.png)
