### PR TITLE
refactor(gitlab collection): removing the 'skip' flags from collection

### DIFF
--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -30,13 +30,7 @@ module.exports = {
     token: '***',
     proxy: 'http://localhost:4780',
     timeout: 10000,
-    maxRetry: 10,
-    skip: {
-      commits: false,
-      projects: false,
-      mergeRequests: false,
-      notes: false
-    }
+    maxRetry: 10
   },
   jiraBoardGitlabProject: {
     8: 8967944

--- a/src/plugins/gitlab-pond/src/collector/index.js
+++ b/src/plugins/gitlab-pond/src/collector/index.js
@@ -2,22 +2,13 @@ const projects = require('./projects')
 const mergeRequests = require('./merge-requests')
 const commits = require('./commits')
 const notes = require('./notes')
-const { gitlab } = require('@config/resolveConfig')
 
 async function collect (db, { projectId, forceAll }) {
   const args = { db, projectId: Number(projectId), forceAll }
-  const skipFlags = gitlab.skip
-  if (skipFlags) {
-    !skipFlags.projects && await projects.collect(args)
-    !skipFlags.commits && await commits.collect(args)
-    !skipFlags.mergeRequests && await mergeRequests.collect(args)
-    !skipFlags.notes && await notes.collect(args)
-  } else {
-    await projects.collect(args)
-    await commits.collect(args)
-    await mergeRequests.collect(args)
-    await notes.collect(args)
-  }
+  await projects.collect(args)
+  await commits.collect(args)
+  await mergeRequests.collect(args)
+  await notes.collect(args)
 }
 
 module.exports = { collect }


### PR DESCRIPTION
Skipping collection causes more problems than it solves. Better to collect all at once, and maybe
later implement a configuration by API request.