### PR TITLE
feat: allow users to configure which branch to fetch for gitlab repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ POST http://localhost:3001/
         "boardId": 8
     },
     "gitlab": {
-        "projectId": 8967944
+        "projectId": 8967944,
+        "branch": "<your-branch-name>", // branch is optional, we fetch Gitlab default branch if this arg is absent
     }
 }
 

--- a/src/plugins/gitlab-pond/src/collector/commits.js
+++ b/src/plugins/gitlab-pond/src/collector/commits.js
@@ -2,18 +2,25 @@ require('module-alias/register')
 const { findOrCreateCollection } = require('../../../commondb')
 const fetcher = require('./fetcher')
 
-async function collect ({ db, projectId, forceAll }) {
+async function collect ({ db, projectId, branch, forceAll }) {
   if (!projectId) {
     throw new Error('Failed to collect gitlab data, projectId is required')
   }
 
-  await collectByProjectId(db, projectId, forceAll)
+  await collectByProjectId(db, projectId, branch, forceAll)
 }
 
-async function collectByProjectId (db, projectId, forceAll) {
+async function collectByProjectId (db, projectId, branch, forceAll) {
   console.info('INFO >>> gitlab collecting commits for project', projectId)
   const commitsCollection = await getCollection(db)
-  for await (const commit of fetcher.fetchPaged(`projects/${projectId}/repository/commits?with_stats=true`)) {
+
+  let queryParams = 'withStats=true'
+  // in some cases, the user does not want to pull commits from the default branch.
+  if (branch) {
+    queryParams += `&ref_name=${branch}`
+  }
+
+  for await (const commit of fetcher.fetchPaged(`projects/${projectId}/repository/commits?${queryParams}`)) {
     commit.projectId = projectId
     await commitsCollection.findOneAndUpdate(
       { id: commit.id },

--- a/src/plugins/gitlab-pond/src/collector/index.js
+++ b/src/plugins/gitlab-pond/src/collector/index.js
@@ -4,8 +4,8 @@ const commits = require('./commits')
 const notes = require('./notes')
 const { gitlab } = require('@config/resolveConfig')
 
-async function collect (db, { projectId, forceAll }) {
-  const args = { db, projectId: Number(projectId), forceAll }
+async function collect (db, { projectId, branch, forceAll }) {
+  const args = { db, projectId: Number(projectId), branch, forceAll }
   const skipFlags = gitlab.skip
   if (skipFlags) {
     !skipFlags.projects && await projects.collect(args)

--- a/src/plugins/gitlab-pond/src/enricher/commits.js
+++ b/src/plugins/gitlab-pond/src/enricher/commits.js
@@ -29,9 +29,10 @@ async function enrichCommitsByProjectId (rawDb, enrichedDb, projectId) {
         committerEmail: commit.committer_email,
         committedDate: commit.committed_date,
         webUrl: commit.web_url,
-        additions: commit.stats.additions,
-        deletions: commit.stats.deletions,
-        total: commit.stats.total
+        // some commits can happen with no additions or deletions so stats is not populated
+        additions: commit.stats && commit.stats.additions,
+        deletions: commit.stats && commit.stats.deletions,
+        total: commit.stats && commit.stats.total
       }
       await enrichedDb.GitlabCommit.upsert(enriched)
       counter++

--- a/src/plugins/jira-pond/src/enricher/boards.js
+++ b/src/plugins/jira-pond/src/enricher/boards.js
@@ -17,7 +17,7 @@ async function enrichBoardById (rawDb, enrichedDb, boardId) {
     projectId: board.location.projectId,
     name: board.name,
     type: board.type,
-    webUrl: board.self,
+    webUrl: board.self
   }
   await enrichedDb.JiraBoard.upsert(enriched)
   console.info('INFO >>> jira enriching board done!', boardId)


### PR DESCRIPTION
## WHY

Users sometimes do not work off of the main branch on gitlab. The main branch could be 'main' but all the current work is on the 'development' branch. 

## WHAT

You can now send a post request to localhost:3001 with this body:

```
{
    "gitlab": {
        "projectId": 19688130,
        "branch": "jon-test"
    }
}
```

Where "branch" is optional. It defaults to the default branch of gitlab.

Here is the terminal output calling this api

<img width="840" alt="Screen Shot 2021-08-04 at 9 23 19 AM" src="https://user-images.githubusercontent.com/3011407/128181723-f8b05b35-1c36-4d07-8e65-f2a6d8d2d993.png">

Here is the record in mongo locally

<img width="889" alt="Screen Shot 2021-08-04 at 9 30 57 AM" src="https://user-images.githubusercontent.com/3011407/128181751-a9b88bba-0c0b-48c9-8e5a-e3fd4a405d92.png">

Here is the branch I tested in gitlab

<img width="1139" alt="Screen Shot 2021-08-04 at 9 31 11 AM" src="https://user-images.githubusercontent.com/3011407/128181778-d822e431-46eb-4ebe-a68b-223cf742a07d.png">

Here is the record in psql

<img width="1248" alt="Screen Shot 2021-08-04 at 9 32 53 AM" src="https://user-images.githubusercontent.com/3011407/128181822-86002774-3f3e-450e-94b9-ad045340a857.png">

