### PR TITLE
Move grafana config readme

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -5,6 +5,15 @@
 1. Make a copy of `config/local.sample.js` under the name of `config/local.js`
 2. We can use default values for most fields except the Jira section. For how to set up basic authorization with Jira, please see this [section](#jira) below
 
+## Core Configuration
+
+### Grafana Connection For Data Visualization (https://localhost:3002)
+
+To ensure we have properly connected our database to the data source in Grafana, check database settings in `./grafana/datasources/datasource.yml`, specifically:
+- `database`
+- `user`
+- `secureJsonData/password`
+
 ## Plugin Level Configuration
 
 ### Jira Specific String Configuration
@@ -18,7 +27,7 @@ This can be set up in `/config/constants.js`.
       "Closed": ["Done", "Closed", "已关闭"],
       "Bug": "Bug",
       "Incident": "Incident"
-    } 
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,20 +32,6 @@
 
 For how to set up basic authorization with Jira, and many more things, please see [CONFIGURATION.md](CONFIGURATION.md)
 
-### Grafana Connection For Data Visualization (https://localhost:3002)
-
-Connect to the Grafana database:
-Inside `docker-compose.yml` edit the environment variables as needed to connect to your local postgres instance, specifically:
-- `GF_DATABASE_NAME`
-- `GF_DATABASE_USER`
-- `GF_DATABASE_PASSWORD`
-
-Connect the Grafana data source:
-Additionally to use the postgres database as data source inside grafana, ensure postgres config options are correct in `./grafana/datasources/datasource.yml`, specifically:
-- `database`
-- `user`
-- `secureJsonData/password`
-
 ## Usage
 
 ### Create a Collection Job


### PR DESCRIPTION
- Grafana data source connection info should go in configuration readme with other config
- Duplicate info is also removed from main `readme.md` 

As I'm working on some other readme stuff, I'm considering Grafana and other collection/enrichment tasks as "core" functionality (hence the title). Jira/gitlab etc are "plugin" functionality. I think this split will be useful for scaling the docs