### PR TITLE
feat: allow the migrations to be run while running the app in prod mode

### DIFF
--- a/config/database.json
+++ b/config/database.json
@@ -6,5 +6,13 @@
     "database": "lake",
     "port": 5432,
     "dialect": "postgres"
+  },
+  "docker": {
+    "username": "postgres",
+    "password": "postgresWhat",
+    "host": "postgresdb",
+    "database": "lake",
+    "port": 5432,
+    "dialect": "postgres"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compose-logs": "docker-compose logs -f",
     "lake": "node src/plugins/index.js && concurrently \"nodemon src/collection/main.js\" \"nodemon src/collection/worker.js\" \"nodemon src/enrichment/main.js\" \"nodemon src/enrichment/worker.js\"",
     "lake-debug": "node src/plugins/index.js && concurrently \"DEBUG=true nodemon src/collection/main.js\" \"DEBUG=true nodemon src/collection/worker.js\" \"DEBUG=true nodemon src/enrichment/main.js\" \"DEBUG=true nodemon src/enrichment/worker.js\"",
-    "lake-prod": "node src/plugins/index.js && node concurrently.js",
+    "lake-prod": "npx sequelize-cli db:migrate && node src/plugins/index.js && node concurrently.js",
     "test": "mocha \"test/**\" src/**/*.test.js",
     "unit-test": "ENCRYPTION_KEY=123 NODE_ENV=test ./node_modules/mocha/bin/mocha \"test/unit/**/*.test.js\"",
     "lint": "./node_modules/eslint/bin/eslint.js . --max-warnings=0 --report-unused-disable-directives --fix && echo '✔  Your .js files look good.'",


### PR DESCRIPTION
## WHY

We are trying to reduce the number of steps that a new user needs to do when they attempt to run the application for the first time.  Fixes: https://github.com/merico-dev/lake/issues/145

## WHAT

All we need to do here is to run the migrations when the `npm run compose-prod` command is run.

## HOW

In order to do this, the Dockerfile has `ENV NODE_ENV=docker`. This means that sequelize will look for a file called database.json and then look for a key called `docker`. This is why I had to add it with the `"host": "postgresdb",` so sequelize could connect to the correct port within docker compose.

You can see the docker logs that show this working here:

<img width="562" alt="Screen Shot 2021-08-06 at 9 40 12 AM" src="https://user-images.githubusercontent.com/3011407/128512141-e46c9f52-f48d-499b-97f4-a9c6ba2fbc4a.png">

And this is a result of modifying the `npm run lake-prod` command.

<img width="804" alt="Screen Shot 2021-08-06 at 9 28 50 AM" src="https://user-images.githubusercontent.com/3011407/128512238-c028353c-9a88-4b7e-a4be-a26c32fc2958.png">

Which is run from the Dockerfile as `CMD ["npm", "run", "lake-prod"]`
