### PR TITLE
fix: update postgres passwd for grafana

### DIFF
--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -8,7 +8,7 @@ datasources:
     database: lake
     user: postgres
     secureJsonData:
-      password: "postgres"
+      password: "postgresWhat"
     jsonData:
       sslmode: "disable"
       maxOpenConns: 0


### PR DESCRIPTION
We changed Postgres password but didn't update it for Grafana. Without this fix, Grafana can't connect to pg.