### PR TITLE
chore: add ci config for unit test

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+comment:
+  require_changes: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+# This action will upload coverage info to codecov.io
+name: coverage
+on:
+  pull_request:
+  push:
+    branches:
+      - ts-main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - run: 'npm install'
+      - run: 'npm run test:cov'
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/clover.xml
+          verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+# This action run unit test and e2e test for pull requests
+name: CI
+on: [pull_request]
+jobs:
+  Unit-Test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: 'npm install'
+      - run: 'npm run test'
+      - run: 'npm run test:e2e'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dev Lake
 
 ![badge](https://github.com/merico-dev/lake/actions/workflows/test.yml/badge.svg?branch=ts-main)
-[![codecov](https://codecov.io/gh/narrowizard/lake/branch/ts-main/graph/badge.svg?token=MRL1RZ7CXD)](https://codecov.io/gh/narrowizard/lake)
+[![codecov](https://codecov.io/gh/merico-dev/lake/branch/ts-main/graph/badge.svg?token=UN126GAU9D)](https://codecov.io/gh/merico-dev/lake)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dev Lake
 
-![badge](https://github.com/merico-dev/lake/actions/workflows/main.yml/badge.svg)
+![badge](https://github.com/merico-dev/lake/actions/workflows/test.yml/badge.svg?branch=ts-main)
+[![codecov](https://codecov.io/gh/narrowizard/lake/branch/ts-main/graph/badge.svg?token=MRL1RZ7CXD)](https://codecov.io/gh/narrowizard/lake)
 
 ## Requirements
 

--- a/apps/queue/test/app.e2e-spec.ts
+++ b/apps/queue/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { QueueModule } from './../src/Queue.module';
+import { QueueModule } from './../src/queue.module';
 
 describe('QueueController (e2e)', () => {
   let app: INestApplication;

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     }
   },
   "lint-staged": {
-    "**/*.+(js|jsx|css|less|scss|ts|tsx|md)": [
+    "**/*.+(js|jsx|css|less|scss|ts|tsx)": [
       "eslint --fix",
       "git add"
     ]


### PR DESCRIPTION
This PR aimed to adding unit test CI check and report coverage for PR.  
## todo list
- [x] add unit test
- [x] add e2e test
- [x] report coverage for PR @narrowizard 
- [x] report coverage for branch @narrowizard 
- [x] add coverage to README.md @narrowizard 
- [x] create codecov account for uploading coverage info @UltimateBeaver 

## Report coverage for PR & Report coverage for branch & add to readme
We planed to use [codecov](https://app.codecov.io/) to display coverage info in README.md and PR comments. For that purpose, we need install [codecov app](https://github.com/marketplace/codecov) for lake repository, and add the upload token as a secret key called `CODECOV_TOKEN`. @UltimateBeaver  
