### PR TITLE
fix(gitlab collection for commits): fixed query parameter

### DIFF
--- a/src/plugins/gitlab-pond/src/collector/commits.js
+++ b/src/plugins/gitlab-pond/src/collector/commits.js
@@ -14,7 +14,7 @@ async function collectByProjectId (db, projectId, branch, forceAll) {
   console.info('INFO >>> gitlab collecting commits for project', projectId)
   const commitsCollection = await getCollection(db)
 
-  let queryParams = 'withStats=true'
+  let queryParams = 'with_stats=true'
   // in some cases, the user does not want to pull commits from the default branch.
   if (branch) {
     queryParams += `&ref_name=${branch}`


### PR DESCRIPTION
Change from withStats to with_stats is necessary to get additions / deletions / total from gitlab commits API.