### PR TITLE
docs: add missing docs, links table and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ Requirements | Underlying software used | [View Section](#requirements)
 User Setup | Quick and easy setup | [View Section](#user-setup)
 Developer Setup | Steps to get up and running | [View Section](#developer-setup)
 Plugins | Links to specific plugin usage & details | [View Section](#plugins)
+Build a Plugin | Details on how to make your own | [Link](src/plugins/README.md)
+Add Plugin Metrics | Guide to adding plugin metrics | [Link](src/plugins/HOW-TO-ADD-METRICS.md)
 Configuration | Local file config settings info | [Link](docs/CONFIGURATION.md)
+Grafana | How to visualize the data | [Link](docs/GRAFANA.md)
 Contributing | How to contribute to this repo | [Link](CONTRIBUTING.md)
 
-## Requirements<a id="requirements" />
+## Requirements<a id="requirements"></a>
 
 - [Node.js](https://nodejs.org/en/download)
 - [Docker](https://docs.docker.com/get-docker)
 
-## User Setup<a id="user-setup" />
+## User Setup<a id="user-setup"></a>
 
 **NOTE: If you only plan to run the product, this is the only section you should need**
 
@@ -53,7 +56,7 @@ curl -X POST "http://localhost:3001/" -H 'content-type: application/json' \
 5. Check the console logs for docker-compose to see when the logs stop collecting your data. This can take up to 30 minutes for large projects. (gitlab 10k+ commits or jira 10k+ issues)
 6. Navigate to Grafana Dashboard `https://localhost:3002` (Username: `admin`, password: `admin`)
 
-## Developer Setup<a id="developer-setup" />
+## Developer Setup<a id="developer-setup"></a>
 
 1. Clone this repository<br>
 
@@ -140,7 +143,7 @@ We use Grafana as a visualization tool to build charts for the data stored in ou
 
 All the details on provisioning, and customizing a dashboard can be found in the [Grafana Doc](docs/GRAFANA.md)
 
-## Plugins<a id="plugins" />
+## Plugins<a id="plugins"></a>
 
 Section | Section Info | Docs
 ------------ | ------------- | -------------

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,3 +77,20 @@ __Jira auth setup__
 - Port: 5672
 - Username: guest
 - Password: guest
+
+<br>
+
+---
+
+## Other Docs
+
+Section | Description | Link
+:------------ | :------------- | :-------------
+Requirements | Underlying software used | [Link](../README.md#requirements)
+User Setup | Quick and easy setup | [Link](../README.md#user-setup)
+Developer Setup | Steps to get up and running | [Link](../README.md#developer-setup)
+Plugins | Links to specific plugin usage & details | [Link](../README.md#plugins)
+Build a Plugin | Details on how to make your own | [Link](../src/plugins/README.md)
+Add Plugin Metrics | Guide to adding plugin metrics | [Link](../src/plugins/HOW-TO-ADD-METRICS.md)
+Grafana | How to visualize the data | [Link](GRAFANA.md)
+Contributing | How to contribute to this repo | [Link](../CONTRIBUTING.md)

--- a/docs/GRAFANA.md
+++ b/docs/GRAFANA.md
@@ -14,7 +14,7 @@ Customizing a Dashboard | [View Section](#customizing-a-dashboard)
 Dashboard Settings | [View Section](#dashboard-settings)
 Provisioning a Dashboard | [View Section](#provisioning-a-dashboard)
 
-## Logging In<a id="logging-in" />
+## Logging In<a id="logging-in"></a>
 
 Once the app is up and running, visit `http://localhost:3002` to view the Grafana dashboard.
 
@@ -23,7 +23,7 @@ Default login credentials are:
 - Username: `admin`
 - Password: `admin`
 
-## Viewing All Dashboards<a id="viewing-all-dashboards" />
+## Viewing All Dashboards<a id="viewing-all-dashboards"></a>
 
 To see all dashboards created in Grafana visit `/dashboards`
 
@@ -32,7 +32,7 @@ Or, use the sidebar and click on **Manage**:
 ![Screen Shot 2021-08-06 at 11 27 08 AM](https://user-images.githubusercontent.com/3789273/128534617-1992c080-9385-49d5-b30f-be5c96d5142a.png)
 
 
-## Customizing a Dashboard<a id="customizing-a-dashboard" />
+## Customizing a Dashboard<a id="customizing-a-dashboard"></a>
 
 When viewing a dashboard, click the top bar of a panel, and go to **edit**
 
@@ -77,7 +77,7 @@ In the top right of the window are buttons for:
 - Modify chart styling
 - Other Grafana specific settings
 
-## Dashboard Settings<a id="dashboard-settings" />
+## Dashboard Settings<a id="dashboard-settings"></a>
 
 When viewing a dashboard click on the settings icon to view dashboard settings. In here there is 2 pages important sections to use:
 
@@ -93,7 +93,7 @@ When viewing a dashboard click on the settings icon to view dashboard settings. 
 
   ![Screen Shot 2021-08-06 at 2 02 52 PM](https://user-images.githubusercontent.com/3789273/128553176-65a5ae43-742f-4abf-9c60-04722033339e.png)
 
-## Provisioning a Dashboard<a id="provisioning-a-dashboard" />
+## Provisioning a Dashboard<a id="provisioning-a-dashboard"></a>
 
 To save a dashboard in the `lake` repo and load it:
 
@@ -102,3 +102,20 @@ To save a dashboard in the `lake` repo and load it:
 3. Go to dashboard settings (in top right of screen)
 4. Click on _JSON Model_ in sidebar
 5. Copy code into a new `.json` file in `/grafana/dashboards`
+
+<br>
+
+---
+
+## Other Docs
+
+Section | Description | Link
+:------------ | :------------- | :-------------
+Requirements | Underlying software used | [Link](../README.md#requirements)
+User Setup | Quick and easy setup | [Link](../README.md#user-setup)
+Developer Setup | Steps to get up and running | [Link](../README.md#developer-setup)
+Plugins | Links to specific plugin usage & details | [Link](../README.md#plugins)
+Build a Plugin | Details on how to make your own | [Link](../src/plugins/README.md)
+Add Plugin Metrics | Guide to adding plugin metrics | [Link](../src/plugins/HOW-TO-ADD-METRICS.md)
+Configuration | Local file config settings info | [Link](CONFIGURATION.md)
+Contributing | How to contribute to this repo | [Link](../CONTRIBUTING.md)

--- a/src/plugins/HOW-TO-ADD-METRICS.md
+++ b/src/plugins/HOW-TO-ADD-METRICS.md
@@ -2,7 +2,7 @@
 
 ...you've never had a better idea than that!
 
-You love getting data from a source like GitLab, but perhaps you're not getting the 
+You love getting data from a source like GitLab, but perhaps you're not getting the
 the metric you want. Good news! You can get any metric you like by contributing a little
 bit of code.
 
@@ -10,7 +10,7 @@ Each plugin has an Enricher. Just navigate into the plugin folder to find the en
 
 An the index file of an enricher contains something like this:
 
-```
+```js
 async function enrich (rawDb, enrichedDb, { thingId }) {
   const args = { rawDb, enrichedDb, thingId: Number(projectId) }
   await thingNumberOne.enrich(args)
@@ -22,7 +22,7 @@ async function enrich (rawDb, enrichedDb, { thingId }) {
 
 It gathers all the enrich functions into one, so you can keep your implementations separate. For example:
 
-```
+```js
 async function enrichSomeThing (rawDb, enrichedDb, id) {
   const collectionOfRawThings = await collector.getCollection(rawDb)
   const rawThing = await collectionOfRawThings.findOne({ id: id })
@@ -39,4 +39,19 @@ async function enrichSomeThing (rawDb, enrichedDb, id) {
 
 In order for the enriched DB to have a ThingModel for you to upsert into, you will need to write a Model file in the [model directory](../../db/postgres) and a migration script for Sequelize in the [migrations directory](../../db/migrations)
 
+<br>
 
+---
+
+## Other Docs
+
+Section | Description | Link
+:------------ | :------------- | :-------------
+Requirements | Underlying software used | [Link](../../README.md#requirements)
+User Setup | Quick and easy setup | [Link](../../README.md#user-setup)
+Developer Setup | Steps to get up and running | [Link](../../README.md#developer-setup)
+Plugins | Links to specific plugin usage & details | [Link](../../README.md#plugins)
+Build a Plugin | Details on how to make your own | [Link](README.md)
+Configuration | Local file config settings info | [Link](../../docs/CONFIGURATION.md)
+Grafana | How to visualize the data | [Link](../../docs/GRAFANA.md)
+Contributing | How to contribute to this repo | [Link](../../CONTRIBUTING.md)

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -4,7 +4,7 @@
 
 ### Basic Interface
 
-```
+```js
 const collection = require('./src/collector')
 const enrichment = require('./src/enricher')
 
@@ -41,13 +41,13 @@ To build a new plugin you will need a few things. You should choose an API that 
 
 #### What to Collect
 
-Then you will want to build a collector to gather data. You will need to do some reading of the API documentation to figure out what metrics you will want to see at the end in your Grafana dashboard (configuring Grafana is the final step).  
+Then you will want to build a collector to gather data. You will need to do some reading of the API documentation to figure out what metrics you will want to see at the end in your Grafana dashboard (configuring Grafana is the final step).
 
 #### Build a Fetcher to make Requests
 
 We're working with Node, so you will want your collector to use some sort of HTTP requests to gather data from the api. A package like axios can be used here, or there may be a Node package you can download and use. You will probably want to create a 'fetcher' file that handles your requests as well as pagination. Your api calls may look something like this:
 
-```
+```js
 res = await axios.get(`${host}/${apiPath}/${resourceUri}`, {
         headers: { 'PRIVATE-TOKEN': token },
         agent: config.proxy && new ProxyAgent(config.proxy),
@@ -59,7 +59,7 @@ res = await axios.get(`${host}/${apiPath}/${resourceUri}`, {
 
 Once you have fetched raw data, you will want to store that data in a DB. If you are storing it in a document DB like Mongo, you can store it as is. If you are using a relational DB like Postgres, you will need a schema to be defined according to the fields you get from your API requests. Storing data will look something like this:
 
-```
+```js
  await yourCollection.findOneAndUpdate(
     { id: yourData.id },
     { $set: yourData },
@@ -80,7 +80,7 @@ c) Eliminate fields you don't need
 
 #### Adding to the DB
 
-To build the enricher, you will want to query your DB to find the raw data you've stored. Then you may perform actions to enrich data. You will need to define a new model for your data, and migrations for your enrichment DB. These folders can be found at [migrations](../db/migrations) and [models](../db/postgres). Once you have that set up, you can store your raw data in its new format in your enriched data DB. This is recommended to be a relational DB. 
+To build the enricher, you will want to query your DB to find the raw data you've stored. Then you may perform actions to enrich data. You will need to define a new model for your data, and migrations for your enrichment DB. These folders can be found at [migrations](../db/migrations) and [models](../db/postgres). Once you have that set up, you can store your raw data in its new format in your enriched data DB. This is recommended to be a relational DB.
 
 It is good to build a collector and an enricher together, because knowledge of the API will help with both.
 
@@ -90,14 +90,14 @@ Let's walk through a short example.
 
 1. Choose an API you're interested in.
 
-Let's say you want to see data from the Movie Database. 
+Let's say you want to see data from the Movie Database.
 
 2. Choose some metrics you would like to see about movies.
 
 You would like to know how movie production has increased over the last 50 years.
 Let's start with how many movies have been produced each year as a metric.
 
-3. Look for the data to support this from the Movie DB API 
+3. Look for the data to support this from the Movie DB API
 
 Lets assume this data is available through an endpoint like (this may not be the case):
 
@@ -105,7 +105,7 @@ GET /movies
 
 4. Get an API key for authentication.
 
-You will need an API key to access the data. 
+You will need an API key to access the data.
 
 5. Understand Rate Limits and Pagination
 
@@ -123,5 +123,19 @@ There are limits to accessing API data. You will need to work around these limit
 
 9. Congrats on building your first plugin!
 
+<br>
 
+---
 
+## Other Docs
+
+Section | Description | Link
+:------------ | :------------- | :-------------
+Requirements | Underlying software used | [Link](../../README.md#requirements)
+User Setup | Quick and easy setup | [Link](../../README.md#user-setup)
+Developer Setup | Steps to get up and running | [Link](../../README.md#developer-setup)
+Plugins | Links to specific plugin usage & details | [Link](../../README.md#plugins)
+Add Plugin Metrics | Guide to adding plugin metrics | [Link](HOW-TO-ADD-METRICS.md)
+Configuration | Local file config settings info | [Link](../../docs/CONFIGURATION.md)
+Grafana | How to visualize the data | [Link](../../docs/GRAFANA.md)
+Contributing | How to contribute to this repo | [Link](../../CONTRIBUTING.md)


### PR DESCRIPTION
## WHY
An update to the readme docs regarding formatting, linking and adding a new table of contents footer. All changes are made for better navigation and inclusion of all the doc files

## WHAT
1. modified self-closing anchor tags in readmes
    - This was breaking some markdown preview functionalities

2. Added a table of contents to other doc files in the repo
    - Included at the footer of all markdown files (except plugin specific ones - ex. jira, gitlab)

  ![Screen Shot 2021-08-09 at 11 36 59 AM](https://user-images.githubusercontent.com/3789273/128739265-41711c5c-69b4-4bb1-8ea4-3f209651f392.png)

3. Added syntax highlighting to plugin docs

  ![Screen Shot 2021-08-09 at 11 42 42 AM](https://user-images.githubusercontent.com/3789273/128739429-00ee3697-e3d8-406d-a848-50324921ad52.png)

4. Added `GRAFANA.md` readme file to the table of contents (on main readme and footers) - it was missing previously