### PR TITLE
fix: fixed type in migration file for gitlab commits

### DIFF
--- a/db/migrations/20210729134703-add-gitlab-commits.js
+++ b/db/migrations/20210729134703-add-gitlab-commits.js
@@ -25,7 +25,7 @@ module.exports = {
         field: 'author_email'
       },
       authoredDate: {
-        type: Sequelize.STRING,
+        type: Sequelize.DATE,
         field: 'authored_date'
       },
       committerName: {


### PR DESCRIPTION
### WHY
A few charts in Grafana were not showing up due to `authored_date` column being a string in `gitlab_commits` table. We needed this to be a date type.

### WHAT
- Updated a migration file so now when **running a migration** the postgres db will update the correct type for the column. On initial setup, it should be the correct (date) type

**Delivery Quality (dashboard) - panels 6 and 7 now working:**
![Screen Shot 2021-08-09 at 5 22 19 PM](https://user-images.githubusercontent.com/3789273/128776533-182915ff-1256-4336-9a37-63d0ae0cdc40.png)
