### PR TITLE
chore: change database connection log message to include any db

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -75,7 +75,7 @@ async function initialize () {
         .map(plugin => plugin.initialize(connection.rawDb, enrichedDb, plugins))
     )
   } catch (error) {
-    console.log('ERROR: connecting to mongodb', error)
+    console.log('ERROR: connecting to database', error)
     process.exit()
   } finally {
     dbConnector.disconnect(client)


### PR DESCRIPTION
We have a log that was outputting `ERROR: connecting to mongodb` even when there was postgres connection issues

- Change log message to include any database connection issues

---

**Previous log example**
```sh
ERROR: connecting to mongodb DatabaseError [SequelizeDatabaseError]: relation "..." does not exist
```

**New log example**
```sh
ERROR: connecting to database DatabaseError [SequelizeDatabaseError]: relation "..." does not exist
```

