### PR TITLE
Feat: add request param validator

### DIFF
--- a/apps/rest/src/app.module.ts
+++ b/apps/rest/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { SourceController } from './core/source.controller';
 
 @Module({
   imports: [],
-  controllers: [AppController],
+  controllers: [AppController, SourceController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/apps/rest/src/core/source.controller.spec.ts
+++ b/apps/rest/src/core/source.controller.spec.ts
@@ -1,0 +1,29 @@
+import { Test } from '@nestjs/testing';
+import { SourceController } from './source.controller';
+
+describe('SourceController', () => {
+  let sourceController: SourceController;
+
+  beforeEach(async () => {
+    const app = await Test.createTestingModule({
+      controllers: [SourceController],
+      providers: [],
+    }).compile();
+
+    sourceController = app.get(SourceController);
+  });
+
+  describe('post', () => {
+    it('should return source info without options', async () => {
+      const response = await sourceController.create({
+        type: 'jira',
+        options: {
+          host: 'https://www.atlassian.com/',
+          email: 'xx@example.com',
+          auth: 'base64EncodedAuthToken',
+        },
+      });
+      expect(response).toBeUndefined();
+    });
+  });
+});

--- a/apps/rest/src/core/source.controller.ts
+++ b/apps/rest/src/core/source.controller.ts
@@ -1,0 +1,11 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import Source from './source.model';
+import { CreateSource } from './source.type';
+
+@Controller('source')
+export class SourceController {
+  @Post()
+  async create(@Body() source: CreateSource): Promise<Source> {
+    return;
+  }
+}

--- a/apps/rest/src/core/source.model.ts
+++ b/apps/rest/src/core/source.model.ts
@@ -1,0 +1,10 @@
+export const SupportedSourceType = ['jira', 'gitlab'] as const;
+
+export type SourceType = typeof SupportedSourceType[number];
+
+export default class Source {
+  id: number;
+  type: SourceType;
+
+  options: Record<string, unknown>;
+}

--- a/apps/rest/src/core/source.type.ts
+++ b/apps/rest/src/core/source.type.ts
@@ -1,0 +1,10 @@
+import { IsIn, IsNotEmpty } from 'class-validator';
+import { SourceType, SupportedSourceType } from './source.model';
+
+export class CreateSource {
+  @IsIn(SupportedSourceType)
+  type: SourceType;
+
+  @IsNotEmpty()
+  options: Record<string, unknown>;
+}

--- a/apps/rest/src/main.ts
+++ b/apps/rest/src/main.ts
@@ -1,8 +1,10 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
 }
 bootstrap();

--- a/apps/rest/test/__snapshots__/source.e2e-spec.ts.snap
+++ b/apps/rest/test/__snapshots__/source.e2e-spec.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SourceController (e2e) /source (POST) should return validate error 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": Array [
+    "type must be one of the following values: jira, gitlab",
+  ],
+  "statusCode": 400,
+}
+`;
+
+exports[`SourceController (e2e) /source (POST) should return validate error 2 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": Array [
+    "type must be one of the following values: jira, gitlab",
+  ],
+  "statusCode": 400,
+}
+`;
+
+exports[`SourceController (e2e) /source (POST) should return validate error 3 1`] = `
+Object {
+  "error": "Bad Request",
+  "message": Array [
+    "options should not be empty",
+  ],
+  "statusCode": 400,
+}
+`;

--- a/apps/rest/test/source.e2e-spec.ts
+++ b/apps/rest/test/source.e2e-spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('SourceController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+  });
+
+  describe('/source (POST)', () => {
+    it('should return validate error', () => {
+      const sourceWithoutType = {
+        options: {},
+      };
+      return request(app.getHttpServer())
+        .post('/source')
+        .send(sourceWithoutType)
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toMatchSnapshot();
+        });
+    });
+
+    it('should return validate error 2', () => {
+      const sourceWithoutType = {
+        type: 'github',
+        options: {},
+      };
+      return request(app.getHttpServer())
+        .post('/source')
+        .send(sourceWithoutType)
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toMatchSnapshot();
+        });
+    });
+
+    it('should return validate error 3', () => {
+      const sourceWithoutType = {
+        type: 'gitlab',
+      };
+      return request(app.getHttpServer())
+        .post('/source')
+        .send(sourceWithoutType)
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toMatchSnapshot();
+        });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1972,6 +1972,11 @@
         "@types/superagent": "*"
       }
     },
+    "@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
+    },
     "@types/yargs": {
       "version": "15.0.14",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
@@ -2896,6 +2901,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+    },
+    "class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "requires": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -6961,6 +6981,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.23",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.23.tgz",
+      "integrity": "sha512-+qWSwPyJWSV9ukb7Iu21WpWEP7irFWR1ojoYykL2itAfXKj9FjsTjS6PPZoPUOZk+1kxliHjwsilqA1TNeOhuQ=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -9399,6 +9424,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@nestjs/microservices": "^8.0.5",
     "@nestjs/platform-express": "^8.0.0",
     "bull": "^3.27.0",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",


### PR DESCRIPTION
## This PR is ready to merge

## why
We should validate incomming requests before handling it. The validator will reject bad requests and protect our service.

## what
- This PR added request parameter validator for restful api.  
- `SourceController` was added as an example for request validator.
- Also, some end-to-end test suit is added.

/review @likyh @jaxzhou
/cc @UltimateBeaver 