### PR TITLE
feat: calculate lead-time for resolved issue only

### DIFF
--- a/config/docker.sample.js
+++ b/config/docker.sample.js
@@ -2,10 +2,7 @@ module.exports = {
   // Configuration of lake's own services
   lake: {
     // Enable basic authentication to the lake API
-    // token: 'mytoken',
-
-    // Set how often lake will fetch new data from data sources (default every hour)
-    loopIntervalInMinutes: 60
+    // token: 'mytoken'
   },
   // Configuration of MongoDB
   mongo: {
@@ -23,5 +20,20 @@ module.exports = {
     database: 'lake',
     port: 5432,
     dialect: 'postgres'
+  },
+  cron: {
+    // uncomment and update following configuration to enable the cron job
+    /*
+    job: {
+      jira: {
+        boardId: 123
+      },
+      gitlab: {
+        projectId: 123
+      }
+    },
+    */
+    // Set how often does lake fetch new data from data sources, defaults to every hour
+    loopIntervalInMinutes: 60
   }
 }

--- a/config/local.sample.js
+++ b/config/local.sample.js
@@ -3,8 +3,6 @@ module.exports = {
   lake: {
     // Enable basic authentication to the lake API
     // token: 'mytoken'
-
-    // Set how often lake will fetch new data from data sources (default every hour)
   },
   // Configuration of MongoDB
   mongo: {
@@ -24,7 +22,7 @@ module.exports = {
     dialect: 'postgres'
   },
   cron: {
-    // uncomment and update the following configuration to enable the cron job
+    // uncomment and update following configuration to enable the cron job
     /*
     job: {
       jira: {
@@ -35,6 +33,7 @@ module.exports = {
       }
     },
     */
+    // Set how often does lake fetch new data from data sources, defaults to every hour
     loopIntervalInMinutes: 60
   }
 }

--- a/config/plugins.sample.js
+++ b/config/plugins.sample.js
@@ -20,20 +20,46 @@ module.exports = [
       },
       enrichment: {
         issue: {
-          mapping: {
+          //  This maps issue types in your Jira system to the standard issue type in dev lake
+          typeMappings: [
             // This maps issue types in your Jira system to the standard issue type in dev lake
             // In lake, we define bugs as issues found in the development process whereas
             // incidents are issues found in production environment
-            // Format: <Standard Type>: [<Jira Type>]
-            type: {
-              // This mapping powers the metrics like Bug Count, Bug Age, and etc
-              // Replace 'Bug' with your own issue types for bugs.
-              Bug: ['Bug'],
-              // This mapping powers the metrics like Incident Count, Incident Age, and etc
-              // Replace 'Incident' with your own issue types for incidents
-              Incident: ['Incident']
+
+            // This mapping powers the metrics like Bug Count, Bug Age, and etc
+            // Replace 'Bug' with your own issue types for bugs.
+            {
+              originTypes: ['Bug'],
+              standardType: 'Bug',
+              statusMappings: [
+                // This mapping powers the metrics like Bug Age
+                { originStatuses: ['Rejected', 'Abandoned', 'Cancelled', 'ByDesign', 'Irreproducible'], standardStatus: 'Rejected' },
+                { originStatuses: ['Resolved', 'Approved', 'Verified', 'Done', 'Closed'], standardStatus: 'Resolved' }
+              ]
+            },
+            // This mapping powers the metrics like Incident Count, Incident Age, and etc
+            // Replace 'Incident' with your own issue types for incidents
+            {
+              originTypes: ['Incident'],
+              standardType: 'Incident',
+              statusMappings: [
+                // This mapping powers the metrics like Incident Age
+                { originStatuses: ['Rejected', 'Abandoned', 'Cancelled', 'Irreproducible'], standardStatus: 'Rejected' },
+                { originStatuses: ['Resolved', 'Approved', 'Verified', 'Done', 'Closed'], standardStatus: 'Resolved' }
+              ]
+            },
+            // This mapping powers the metrics like Requirement Count, Requirement Age, and etc
+            // Replace 'Story' with your own issue types for requirements
+            {
+              originTypes: ['Story'],
+              standardType: 'Requirement',
+              statusMappings: [
+                // This mapping powers the metrics like Requirement Lead Time, Requirement Count
+                { originStatuses: ['Rejected', 'Abandoned', 'Cancelled'], standardStatus: 'Rejected' },
+                { originStatuses: ['Resolved', 'Done', 'Closed'], standardStatus: 'Resolved' }
+              ]
             }
-          },
+          ],
           // Enables lake to track which epic an issue belongs to
           // ➤➤➤ Replace 'customfiled_10014' with your own field ID for the epic key
           epicKeyField: 'customfield_10014'

--- a/simulate-new-setup.sh
+++ b/simulate-new-setup.sh
@@ -2,8 +2,8 @@
 
 
 cleanup() {
-    CON_PATH=$(npx which concurrently)
-    PID=$(pgrep -f "node $CON_PATH")
+    # CON_PATH=$(npx which node)
+    PID=$(pgrep -f "concurrently.js")
     if [ -n "$PID" ]; then
         kill -s TERM $PID
         wait $PID || true
@@ -26,7 +26,8 @@ sudo rm -rf data postgres-data
 docker-compose up -d
 npm i
 npx sequelize-cli db:migrate
-npm run dev | tee /tmp/lake.log &
+node src/plugins/index.js
+nodemon concurrently.js | tee /tmp/lake.log &
 
 # wait untill services ready
 echo waiting services to be ready


### PR DESCRIPTION
 1. New configuration schema to describe type and status conversion between raw and standard.
    Each type of issue may have different set of statuses representing `Resolved` or `Rejected`, so
    in new schema, status-mapping are nested within type-mapping. User can choose to map one or
    more JIRA types to a single standard type, same logic for status conversion.
 2. Calculates Lead-Time for those `Resolved` issues only.