### PR TITLE
chore(ci): update github actions

### DIFF
--- a/.github/workflows/commit-msg.yml
+++ b/.github/workflows/commit-msg.yml
@@ -1,8 +1,8 @@
-name: Lint Commit Messages
+name: lint
 on: [pull_request]
 
 jobs:
-  commitlint:
+  commit-msg:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 # This action will upload coverage info to codecov.io
-name: coverage
+name: test
 on:
   pull_request:
   push:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,4 +1,4 @@
-name: reviewdog
+name: lint
 on: [pull_request]
 jobs:
   eslint:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,55 @@
+# This action run e2e test for pull requests
+name: test
+on: [pull_request]
+jobs:
+  e2e-mysql:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+    env:
+      DB_DATABASE: lake_db
+      DB_USER: root
+      DB_PASSWORD: root
+      DB_TYPE: mysql
+      DB_URL: mysql://root:root@localhost:3306/lake_db
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: 'npm install'
+      - name: set up mysql
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
+      - run: 'npm run test:e2e'
+  # e2e-postgres:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [12.x, 14.x, 15.x]
+  #   services:
+  #     postgres:
+  #       image: postgres
+  #       env: 
+  #         POSTGRES_PASSWORD: postgres
+  #       ports:
+  #         - 5432:5432
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #   env:
+  #     DB_TYPE: postgres
+  #     DB_URL: postgresql://postgres:postgres@localhost:5432/postgres
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - run: 'npm install'
+  #     - run: 'npm run test:e2e'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
-# This action run unit test and e2e test for pull requests
-name: CI
+# This action run unit test for pull requests
+name: test
 on: [pull_request]
 jobs:
-  Unit-Test:
+  unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,4 +15,3 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: 'npm install'
       - run: 'npm run test'
-      - run: 'npm run test:e2e'


### PR DESCRIPTION
## why
Previous CI configuration combined unit test and e2e test.
- it's not a great practice since these two kind tests are not related. 
- Another reason is that we need setup third-party services for e2e test but not for unit test.

## what
- separate unit test and e2e test into different github actions
- setup mysql for e2e test
- update github actions scope/name