### PR TITLE
feat: add plugins auto for plugin manager

### DIFF
--- a/apps/queue/src/consumer/plugins.ts
+++ b/apps/queue/src/consumer/plugins.ts
@@ -1,12 +1,13 @@
 import { ClassProvider, DynamicModule } from '@nestjs/common';
-import Jira from 'plugins/jira/src';
+import { plugins } from 'plugins';
 
-const JiraProvider: ClassProvider<Jira> = {
-  provide: 'Jira',
-  useClass: Jira,
-};
-
-export const providers = [JiraProvider];
+export const providers = plugins.map(
+  (plugin) =>
+    <ClassProvider<Plugin>>{
+      provide: plugin.name,
+      useClass: plugin,
+    },
+);
 
 export class PluginModule {
   static async forRootAsync(): Promise<DynamicModule> {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,5 +1,24 @@
 # How plugin work?
 
+## 推荐的文件目录是什么样的
+## recommended file directory
+可以以如下的格式来创建一个插件，以下结构core会自动注册一个名为「example」，入口代码定义在`index.ts`的一个插件。
+
+You can create a plug-in in the following format. <br>
+The core of the following structure will automatically register a plugin named "example" whose entry code is defined in `index.ts`.
+```text
+plugins/
+    example/
+        src/
+            index.ts
+            migrations/
+            entities/
+            ……
+        test/
+            ……
+```
+    
+
 ## plugin state and callback flow
 ```mermaid
 graph TD;

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,0 +1,24 @@
+import Plugin from './core/src/plugin';
+
+/**
+ * 导入plugins目录下的所有plugin
+ * import and export all plugins
+ */
+export const pluginRecords: Record<string, typeof Plugin> = {};
+export const plugins: typeof Plugin[] = [];
+
+{
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const r = require.context('./', true, /src\/index\.ts$/);
+  r.keys().forEach((key: string) => {
+    // 获取plugin文件夹的名字
+    // get plugin's path name
+    const attr = key.substring(
+      key.indexOf('/') + 1,
+      key.indexOf('/', key.indexOf('/') + 1),
+    );
+    plugins.push(r(key).default);
+    pluginRecords[attr] = r(key).default;
+  });
+}


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Update plugin import code.

### Does this close any open issues?
No.

### Current Behavior
We should import plugin direct in core code. It's not extendable for more new plugin.

### New Behavior
Now export all code which is in `./plugins` and we can import it genareteble in core code.
