### PR TITLE
Ts migrations

### DIFF
--- a/apps/queue/src/consumer/index.ts
+++ b/apps/queue/src/consumer/index.ts
@@ -2,7 +2,8 @@ import { DynamicModule } from '@nestjs/common';
 import { BullQueueModule } from '../bull/queue.module';
 import PluginModule from 'plugins/core/src/plugins.module';
 import { ConsumerService } from './service';
-import { plugins } from '../../../../plugins';
+import { entities, migrations, plugins } from 'plugins';
+import CustomTypeOrmModule from '../../../rest/src/providers/typeorm.module';
 
 export class ConsumerModule {
   static forRoot(queue = 'default'): DynamicModule {
@@ -11,9 +12,13 @@ export class ConsumerModule {
       imports: [
         BullQueueModule.forRoot(queue),
         PluginModule.forRootAsync(plugins),
-        ConsumerService,
+        CustomTypeOrmModule.forRootAsync({
+          entities,
+          migrations,
+          migrationsRun: true,
+        }),
       ],
-      providers: [],
+      providers: [ConsumerService],
       exports: [ConsumerService],
     };
   }

--- a/apps/queue/src/consumer/index.ts
+++ b/apps/queue/src/consumer/index.ts
@@ -2,7 +2,7 @@ import { DynamicModule } from '@nestjs/common';
 import { BullQueueModule } from '../bull/queue.module';
 import PluginModule from 'plugins/core/src/plugins.module';
 import { ConsumerService } from './service';
-import Jira from 'plugins/jira/src';
+import { plugins } from '../../../../plugins';
 
 export class ConsumerModule {
   static forRoot(queue = 'default'): DynamicModule {
@@ -10,7 +10,7 @@ export class ConsumerModule {
       module: ConsumerModule,
       imports: [
         BullQueueModule.forRoot(queue),
-        PluginModule.forRootAsync([Jira]),
+        PluginModule.forRootAsync(plugins),
         ConsumerService,
       ],
       providers: [],

--- a/apps/rest/src/app.module.ts
+++ b/apps/rest/src/app.module.ts
@@ -10,16 +10,18 @@ import { SourceController } from './controllers/source';
 import { SourceTaskController } from './controllers/sourceTask';
 import { SourceService } from './services/source';
 import { SourceTaskService } from './services/sourceTask';
+import { migrations } from './migrations';
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
     }),
-    CustomTypeOrmModule.forRootAsync(null, {
+    CustomTypeOrmModule.forRootAsync({
       entities,
-      // FIXME: using db migration instead of synchronize
-      synchronize: true,
+      migrations,
+      migrationsRun: true,
     }),
   ],
   controllers: [AppController, SourceController, SourceTaskController],

--- a/apps/rest/src/migrations/index.ts
+++ b/apps/rest/src/migrations/index.ts
@@ -1,0 +1,12 @@
+export const migrations = [];
+
+if (process.env.NODE_ENV !== 'test') {
+  {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const r = require.context('./', true, /src\/migrations\/*\.ts$/);
+    r.keys().forEach((key: string) => {
+      migrations.push(r(key).default);
+    });
+  }
+}

--- a/apps/rest/src/providers/typeorm.module.ts
+++ b/apps/rest/src/providers/typeorm.module.ts
@@ -1,18 +1,17 @@
 import { DynamicModule } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 /**
  * 自定义typeorm模块
+ * 引入了config模块自动获取url，同时封装了以目录获取entities、migrations
  * CustomTypeOrmModule
+ * import configModule to get db url
+ * also add hack to entities/migrations path auto
  */
 export default class CustomTypeOrmModule {
-  static forRootAsync(
-    name?: string,
-    options?: TypeOrmModuleOptions,
-  ): DynamicModule {
+  static forRootAsync(options?: TypeOrmModuleOptions): DynamicModule {
     return TypeOrmModule.forRootAsync({
-      name,
       imports: [ConfigModule],
       useFactory: async (config: ConfigService) => {
         return <TypeOrmModuleOptions>{

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -10,10 +10,10 @@ services:
       - 3306:3306
     platform: linux/x86_64
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: 6533fb8811825d34b
       MYSQL_DATABASE: lake_db
-      MYSQL_USER: root
-      MYSQL_PASSWORD: root
+      MYSQL_USER: merico
+      MYSQL_PASSWORD: merico
   redis:
     image: redis:6
     ports:

--- a/jest-e2e.json
+++ b/jest-e2e.json
@@ -1,7 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "moduleNameMapper": {
-    "^plugins/(.*)$": "<rootDir>/plugins/$1"
+    "^plugins($|(/.*$))": "<rootDir>/plugins$1"
   },
   "rootDir": ".",
   "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       "ts"
     ],
     "moduleNameMapper": {
-      "^plugins/(.*)$": "<rootDir>/plugins/$1"
+      "^plugins($|(/.*$))": "<rootDir>/plugins$1"
     },
     "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -47,12 +47,23 @@ class SampleEnricher implements Task {
 
 - Dependency Resolver would get the Task DAG for task exexution managment.
 
-# How to manage the Entities in Plugin
+## 推荐的文件目录是什么样的
+## recommended file directory
+可以以如下的格式来创建一个插件，以下结构core会自动注册一个名为「example」，入口代码定义在`index.ts`的一个插件。
 
-- One Task With The Exports Entities
-   - task.ts
-   - task.entity.ts
-   - task.spec.ts
+You can create a plug-in in the following format. <br>
+The core of the following structure will automatically register a plugin named "example" whose entry code is defined in `index.ts`.
+```text
+plugins/
+    example/
+        src/
+            index.ts
+            migrations/
+            entities/
+            ……
+        test/
+            ……
+```
 
-- All migrates should put at /plugins/YourPlugin/src/migrates, generator your migrate file with typeorm
-```typeorm migrate:create -d /plugins/YourPlugin/src/migrates -n mymigrate````
+- All migrates should put at /plugins/YourPlugin/src/migrations, generator your migrate file with typeorm
+```typeorm migrate:create -d /plugins/YourPlugin/src/migrations -n mymigrate````

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -49,10 +49,14 @@ class SampleEnricher implements Task {
 
 ## 推荐的文件目录是什么样的
 ## recommended file directory
-可以以如下的格式来创建一个插件，以下结构core会自动注册一个名为「example」，入口代码定义在`index.ts`的一个插件。
+可以以如下的格式来创建一个插件，以下结构core会自动注册一个名为「example」，入口代码定义在`index.ts`的一个插件。 <br>
+并且会自动读取`migrations/*.ts`或`**/*.migration.ts`作为插件的migrations的代码，
+自动读取`entities/*.ts`或`**/*.entity.ts`作为插件的entity。
 
 You can create a plug-in in the following format. <br>
 The core of the following structure will automatically register a plugin named "example" whose entry code is defined in `index.ts`.
+It will automatically read the code of `migrations/*.ts` and `**/*.migration.ts` as the migrations of the plugin,
+and automatically read `entities/*.ts` and `**/*.entity.ts` as the entity of the plugin.
 ```text
 plugins/
     example/

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -2,24 +2,52 @@ import PluginInterface from './core/src/plugin.interface';
 import { Type } from '@nestjs/common';
 
 /**
- * 导入plugins目录下的所有plugin
- * import and export all plugins
+ * 导入plugins目录下的所有plugin/migration脚本/entity
+ * import and export all plugins/migrations/entities
  */
 export const pluginRecords: Record<string, Type<PluginInterface>> = {};
 export const plugins: Type<PluginInterface>[] = [];
+export const migrations = [];
+export const entities = [];
 
-{
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const r = require.context('./', true, /src\/index\.ts$/);
-  r.keys().forEach((key: string) => {
-    // 获取plugin文件夹的名字
-    // get plugin's path name
-    const attr = key.substring(
-      key.indexOf('/') + 1,
-      key.indexOf('/', key.indexOf('/') + 1),
+if (process.env.NODE_ENV !== 'test') {
+  {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const r = require.context('./', true, /src\/index\.ts$/);
+    r.keys().forEach((key: string) => {
+      // 获取plugin文件夹的名字
+      // get plugin's path name
+      const attr = key.substring(
+        key.indexOf('/') + 1,
+        key.indexOf('/', key.indexOf('/') + 1),
+      );
+      plugins.push(r(key).default);
+      pluginRecords[attr] = r(key).default;
+    });
+  }
+  {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const r = require.context(
+      './',
+      true,
+      /(src\/.*\/migrations\/.*\.ts$)|(src\/.*\/.*\.migration\.ts$)/,
     );
-    plugins.push(r(key).default);
-    pluginRecords[attr] = r(key).default;
-  });
+    r.keys().forEach((key: string) => {
+      migrations.push(r(key).default);
+    });
+  }
+  {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const r = require.context(
+      './',
+      true,
+      /(src\/entities\/*\.ts$)|(src\/*\.entity\.ts$)/,
+    );
+    r.keys().forEach((key: string) => {
+      entities.push(r(key).default);
+    });
+  }
 }

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,0 +1,25 @@
+import PluginInterface from './core/src/plugin.interface';
+import { Type } from '@nestjs/common';
+
+/**
+ * 导入plugins目录下的所有plugin
+ * import and export all plugins
+ */
+export const pluginRecords: Record<string, Type<PluginInterface>> = {};
+export const plugins: Type<PluginInterface>[] = [];
+
+{
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const r = require.context('./', true, /src\/index\.ts$/);
+  r.keys().forEach((key: string) => {
+    // 获取plugin文件夹的名字
+    // get plugin's path name
+    const attr = key.substring(
+      key.indexOf('/') + 1,
+      key.indexOf('/', key.indexOf('/') + 1),
+    );
+    plugins.push(r(key).default);
+    pluginRecords[attr] = r(key).default;
+  });
+}

--- a/plugins/jira/src/migrates/1629304465163-initialize.ts
+++ b/plugins/jira/src/migrates/1629304465163-initialize.ts
@@ -1,7 +1,0 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
-
-export class initialize1629304465163 implements MigrationInterface {
-  public async up(queryRunner: QueryRunner): Promise<void> {}
-
-  public async down(queryRunner: QueryRunner): Promise<void> {}
-}

--- a/plugins/jira/src/migrations/1628765474000-Example.migration.ts
+++ b/plugins/jira/src/migrations/1628765474000-Example.migration.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export default class Example1628765474000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'plugin_example_user',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+          },
+          {
+            name: 'firstName',
+            type: 'varchar',
+          },
+          {
+            name: 'lastName',
+            type: 'varchar',
+          },
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('plugin_example_user');
+  }
+}


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [*] New or existing documentation is updated

### Description
We need migrations and entity load for plugin to finish db init.

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/247

### New Behavior
Now Core will read `plugins/pluginName/src/migrations/*.ts` or `plugins/pluginName/src/**/*.migration.ts` ro run migration when queue start.
Rest will read `rest/migrations/*.ts` ro run migration when rest start.
