### PR TITLE
feat: task service with plugin execution

### DIFF
--- a/apps/core/events/events.module.spec.ts
+++ b/apps/core/events/events.module.spec.ts
@@ -13,7 +13,7 @@ describe('EventModule', () => {
 
   beforeAll(async () => {
     app = await Test.createTestingModule({
-      imports: [EventsModule],
+      imports: [EventsModule.forRoot()],
     }).compile();
   });
 

--- a/apps/core/events/events.module.ts
+++ b/apps/core/events/events.module.ts
@@ -1,50 +1,55 @@
-import { Inject, Module, OnModuleDestroy } from '@nestjs/common';
+import { DynamicModule, Inject, OnModuleDestroy } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { EventsService } from './events.service';
 import { URL } from 'url';
 
-@Module({
-  imports: [ConfigModule.forRoot()],
-  providers: [
-    {
-      provide: 'REDIS_PUB_CLIENT',
-      useFactory: (config: ConfigService): Redis.Redis => {
-        const redisUrl = config.get<string>('REDIS_URL');
-        const url = new URL(redisUrl);
-        return new Redis({
-          host: url.hostname,
-          port: parseInt(url.port),
-          db: parseInt(url.pathname.slice(1)),
-          username: url.username,
-          password: url.password,
-        });
-      },
-      inject: [ConfigService],
-    },
-    {
-      provide: 'REDIS_SUB_CLIENT',
-      useFactory: (config: ConfigService): Redis.Redis => {
-        const redisUrl = config.get<string>('REDIS_URL');
-        const url = new URL(redisUrl);
-        return new Redis({
-          host: url.hostname,
-          port: parseInt(url.port),
-          db: parseInt(url.pathname.slice(1)),
-          username: url.username,
-          password: url.password,
-        });
-      },
-      inject: [ConfigService],
-    },
-    {
-      provide: EventsService,
-      useClass: EventsService,
-    },
-  ],
-  exports: [EventsService],
-})
 export class EventsModule implements OnModuleDestroy {
+  static forRoot(): DynamicModule {
+    return {
+      module: EventsModule,
+      global: true,
+      imports: [ConfigModule.forRoot()],
+      providers: [
+        {
+          provide: 'REDIS_PUB_CLIENT',
+          useFactory: (config: ConfigService): Redis.Redis => {
+            const redisUrl = config.get<string>('REDIS_URL');
+            const url = new URL(redisUrl);
+            return new Redis({
+              host: url.hostname,
+              port: parseInt(url.port),
+              db: parseInt(url.pathname.slice(1)),
+              username: url.username,
+              password: url.password,
+            });
+          },
+          inject: [ConfigService],
+        },
+        {
+          provide: 'REDIS_SUB_CLIENT',
+          useFactory: (config: ConfigService): Redis.Redis => {
+            const redisUrl = config.get<string>('REDIS_URL');
+            const url = new URL(redisUrl);
+            return new Redis({
+              host: url.hostname,
+              port: parseInt(url.port),
+              db: parseInt(url.pathname.slice(1)),
+              username: url.username,
+              password: url.password,
+            });
+          },
+          inject: [ConfigService],
+        },
+        {
+          provide: EventsService,
+          useClass: EventsService,
+        },
+      ],
+      exports: [EventsService],
+    };
+  }
+
   constructor(
     @Inject('REDIS_PUB_CLIENT') private pub: Redis.Redis,
     @Inject('REDIS_SUB_CLIENT') private sub: Redis.Redis,

--- a/apps/core/events/events.service.ts
+++ b/apps/core/events/events.service.ts
@@ -11,13 +11,15 @@ export class EventsService {
   ) {}
 
   async emit(event: string, payload: any): Promise<number> {
+    await this.pub.lpush(event, JSON.stringify(payload));
     return this.pub.publish(event, JSON.stringify(payload));
   }
 
   async on(event: string, handler: EventHandler): Promise<void> {
     await this.sub.subscribe(event);
-    this.sub.on('message', (channel, message) => {
+    this.sub.on('message', async (channel) => {
       if (channel === event) {
+        const message = await this.pub.rpop(event);
         const args = JSON.parse(message);
         handler(args);
       }

--- a/apps/core/events/events.service.ts
+++ b/apps/core/events/events.service.ts
@@ -20,8 +20,10 @@ export class EventsService {
     this.sub.on('message', async (channel) => {
       if (channel === event) {
         const message = await this.pub.rpop(event);
-        const args = JSON.parse(message);
-        handler(args);
+        if (message) {
+          const args = JSON.parse(message);
+          handler(args);
+        }
       }
     });
   }

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -1,0 +1,17 @@
+import { DAG } from "plugins/core/src/dependency.resolver";
+
+export type Job = {
+  id: string;
+  name: string;
+  data?: any;
+}
+
+class Task {
+  constructor(private dag: DAG) {}
+
+  async next(jobId?: string): Promise<Job[]> {
+    if (jobId) {
+
+    }
+  }
+}

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'crypto';
 import { Redis } from 'ioredis';
 import { DAG } from 'plugins/core/src/dependency.resolver';
+import { v4 } from 'uuid';
 
 export type Job = {
   id: string;
@@ -28,7 +28,7 @@ export default class Task {
       return null;
     }
     if (!job.id) {
-      const jobId = randomUUID();
+      const jobId = v4();
       job.id = jobId;
     }
     return job;
@@ -47,7 +47,9 @@ export default class Task {
       }
     } else {
       const job = await this._getJobAtIndex(0);
-      return [job];
+      if (job) {
+        return [job];
+      }
     }
     return [];
   }

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -6,7 +6,7 @@ export type Job = {
   id: string;
   name: string;
   data?: any;
-}
+};
 
 export default class Task {
   private dag: DAG;

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { DAG } from "plugins/core/src/dependency.resolver";
 
 export type Job = {
@@ -6,12 +7,34 @@ export type Job = {
   data?: any;
 }
 
-class Task {
+export default class Task {
   constructor(private dag: DAG) {}
+
+  private _getJobAtIndex(index: number): Job {
+    const job = this.dag.get(index);
+    if (!job) {
+      return null;
+    }
+    if (!job.id) {
+      const jobId = randomUUID();
+      job.id = jobId;
+    }
+    return job;
+  }
 
   async next(jobId?: string): Promise<Job[]> {
     if (jobId) {
-
+      const currentIndex = this.dag.findIndex({ id: jobId });
+      if (currentIndex < this.dag.length - 1) {
+        return [this._getJobAtIndex(currentIndex + 1)];
+      }
+    } else {
+      return [this._getJobAtIndex(0)];
     }
+    return [];
+  }
+
+  stringify(): string {
+    return JSON.stringify(this.dag);
   }
 }

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -39,6 +39,9 @@ export default class Task {
   }
 
   async next(jobId?: string): Promise<Job[]> {
+    if (!this.dag) {
+      await this._initiDag();
+    }
     if (jobId) {
       const currentIndex = this.dag.findIndex({ id: jobId });
       if (currentIndex < this.dag.length - 1) {

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -35,7 +35,18 @@ export default class Task {
   }
 
   async init(dag: DAG): Promise<void> {
-    this.dag = dag;
+    this.dag = new DAG(
+      dag.getPipline().map((t) => {
+        t.data = { ...t.data, taskId: this.taskId };
+        return t;
+      }),
+    );
+    console.info(
+      `Initial Task [${this.taskId}] with pipline [${this.dag
+        .getPipline()
+        .map((p) => p.name)
+        .join(' --> ')}]`,
+    );
   }
 
   async next(jobId?: string, datas?: any): Promise<Job[]> {
@@ -46,7 +57,8 @@ export default class Task {
     if (jobId) {
       const id = jobId.split(':')[0];
       jobindx = this.dag.findIndex({ id });
-      if (jobindx >= this.dag.length) {
+      if (jobindx >= this.dag.length - 1) {
+        console.info(`Task Pipline Finished [${this.taskId}]`);
         return [];
       }
       const current = this.dag.get(jobindx);

--- a/apps/core/tasks/task.model.ts
+++ b/apps/core/tasks/task.model.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "crypto";
-import { Redis } from "ioredis";
-import { DAG } from "plugins/core/src/dependency.resolver";
+import { randomUUID } from 'crypto';
+import { Redis } from 'ioredis';
+import { DAG } from 'plugins/core/src/dependency.resolver';
 
 export type Job = {
   id: string;

--- a/apps/core/tasks/tasks.module.ts
+++ b/apps/core/tasks/tasks.module.ts
@@ -3,9 +3,10 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { TasksService } from './tasks.services';
 import { URL } from 'url';
+import { ProducerModule } from 'apps/queue/src/producer';
 
 @Module({
-  imports: [ConfigModule.forRoot()],
+  imports: [ConfigModule.forRoot(), ProducerModule],
   providers: [
     {
       provide: 'REDIS_TASK_CLIENT',

--- a/apps/core/tasks/tasks.module.ts
+++ b/apps/core/tasks/tasks.module.ts
@@ -4,9 +4,10 @@ import Redis from 'ioredis';
 import { TasksService } from './tasks.services';
 import { URL } from 'url';
 import { ProducerModule } from 'apps/queue/src/producer';
+import { EventsModule } from '../events/events.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), ProducerModule],
+  imports: [ConfigModule.forRoot(), ProducerModule.forRoot(), EventsModule],
   providers: [
     {
       provide: 'REDIS_TASK_CLIENT',
@@ -31,12 +32,9 @@ import { ProducerModule } from 'apps/queue/src/producer';
   exports: [TasksService],
 })
 export class TasksModule implements OnModuleDestroy {
-  constructor(
-    @Inject('REDIS_PUB_CLIENT') private pub: Redis.Redis,
-    @Inject('REDIS_SUB_CLIENT') private sub: Redis.Redis,
-  ) {}
+  constructor(@Inject('REDIS_TASK_CLIENT') private redis: Redis.Redis) {}
+
   async onModuleDestroy(): Promise<void> {
-    await this.pub.disconnect();
-    await this.sub.disconnect();
+    await this.redis.disconnect();
   }
 }

--- a/apps/core/tasks/tasks.module.ts
+++ b/apps/core/tasks/tasks.module.ts
@@ -1,0 +1,41 @@
+import { Inject, Module, OnModuleDestroy } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+import { TasksService } from './tasks.services';
+import { URL } from 'url';
+
+@Module({
+  imports: [ConfigModule.forRoot()],
+  providers: [
+    {
+      provide: 'REDIS_TASK_CLIENT',
+      useFactory: (config: ConfigService): Redis.Redis => {
+        const redisUrl = config.get<string>('REDIS_URL');
+        const url = new URL(redisUrl);
+        return new Redis({
+          host: url.hostname,
+          port: parseInt(url.port),
+          db: parseInt(url.pathname.slice(1)),
+          username: url.username,
+          password: url.password,
+        });
+      },
+      inject: [ConfigService],
+    },
+    {
+      provide: TasksService,
+      useClass: TasksService,
+    },
+  ],
+  exports: [TasksService],
+})
+export class TasksModule implements OnModuleDestroy {
+  constructor(
+    @Inject('REDIS_PUB_CLIENT') private pub: Redis.Redis,
+    @Inject('REDIS_SUB_CLIENT') private sub: Redis.Redis,
+  ) {}
+  async onModuleDestroy(): Promise<void> {
+    await this.pub.disconnect();
+    await this.sub.disconnect();
+  }
+}

--- a/apps/core/tasks/tasks.module.ts
+++ b/apps/core/tasks/tasks.module.ts
@@ -7,7 +7,11 @@ import { ProducerModule } from 'apps/queue/src/producer';
 import { EventsModule } from '../events/events.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), ProducerModule.forRoot(), EventsModule],
+  imports: [
+    ConfigModule.forRoot(),
+    ProducerModule.forRoot(),
+    EventsModule.forRoot(),
+  ],
   providers: [
     {
       provide: 'REDIS_TASK_CLIENT',

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -1,0 +1,34 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import redis from 'ioredis';
+import { DAG } from 'plugins/core/src/dependency.resolver';
+import { EventsService } from '../events/events.service';
+
+export type JobEvent = {
+  jobId: string;
+  taskId: string;
+  results?: any;
+  error?: Error;
+};
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @Inject('REDIS_TASK_CLIENT') private redis: redis.Redis,
+    private events: EventsService,
+  ) {
+    this.events.on('job:finished', this.handleJobFinishd.bind(this));
+  }
+
+  async startTask(taskDag: DAG): Promise<string> {
+    const sessionId = randomUUID();
+    await this.redis.set(sessionId, JSON.stringify(taskDag));
+    return sessionId;
+  }
+
+  async handleJobFinishd(job: JobEvent): Promise<void> {
+    const {taskId, jobId} = job;
+    const dag = JSON.parse(await this.redis.get(taskId));
+
+  }
+}

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ProducerService } from 'apps/queue/src/producer/service';
-import { randomUUID } from 'crypto';
 import { Redis } from 'ioredis';
 import { DAG } from 'plugins/core/src/dependency.resolver';
+import { v4 } from 'uuid';
 import { EventsService } from '../events/events.service';
 import Task from './task.model';
 
@@ -24,7 +24,7 @@ export class TasksService {
   }
 
   async startTask(taskDag: DAG): Promise<string> {
-    const sessionId = randomUUID();
+    const sessionId = v4();
     const task = new Task(sessionId, this.redis);
     task.init(taskDag);
     const startJobs = await task.next();

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -9,7 +9,7 @@ import Task from './task.model';
 export type JobEvent = {
   jobId: string;
   taskId: string;
-  results?: any;
+  result?: any;
   error?: Error;
 };
 
@@ -29,7 +29,11 @@ export class TasksService {
     task.init(taskDag);
     const startJobs = await task.next();
     for (const job of startJobs) {
-      await this.producer.addJob(job.name, job.data, { jobId: job.id });
+      await this.producer.addJob(
+        job.name,
+        { ...job.data, taskId: sessionId },
+        { jobId: job.id },
+      );
     }
     await task.save();
     return sessionId;

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -46,7 +46,6 @@ export class TasksService {
     }
     const task = new Task(taskId, this.redis);
     const jobs = await task.next(jobId, result);
-    console.info(jobs)
     for (const job of jobs) {
       await this.producer.addJob(job.name, job.data, { jobId: job.id });
     }

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -46,6 +46,7 @@ export class TasksService {
     }
     const task = new Task(taskId, this.redis);
     const jobs = await task.next(jobId, result);
+    console.info(jobs)
     for (const job of jobs) {
       await this.producer.addJob(job.name, job.data, { jobId: job.id });
     }

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -41,6 +41,9 @@ export class TasksService {
 
   async handleJobFinishd(job: JobEvent): Promise<void> {
     const { taskId, jobId } = job;
+    if (!taskId) {
+      return;
+    }
     const task = new Task(taskId, this.redis);
     const jobs = await task.next(jobId);
     for (const job of jobs) {

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -45,23 +45,9 @@ export class TasksService {
       return;
     }
     const task = new Task(taskId, this.redis);
-    const jobs = await task.next(jobId);
+    const jobs = await task.next(jobId, result);
     for (const job of jobs) {
-      if (Array.isArray(result)) {
-        for (const r of result) {
-          await this.producer.addJob(
-            job.name,
-            { ...job.data, ...r },
-            { jobId: job.id },
-          );
-        }
-      } else {
-        await this.producer.addJob(
-          job.name,
-          { ...job.data, ...result },
-          { jobId: job.id },
-        );
-      }
+      await this.producer.addJob(job.name, job.data, { jobId: job.id });
     }
     await task.save();
   }

--- a/apps/core/tasks/tasks.services.ts
+++ b/apps/core/tasks/tasks.services.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ProducerService } from 'apps/queue/src/producer/service';
 import { randomUUID } from 'crypto';
-import redis from 'ioredis';
+import { Redis } from 'ioredis';
 import { DAG } from 'plugins/core/src/dependency.resolver';
 import { EventsService } from '../events/events.service';
 import Task from './task.model';
@@ -16,7 +16,7 @@ export type JobEvent = {
 @Injectable()
 export class TasksService {
   constructor(
-    @Inject('REDIS_TASK_CLIENT') private redis: redis.Redis,
+    @Inject('REDIS_TASK_CLIENT') private redis: Redis,
     private events: EventsService,
     private producer: ProducerService,
   ) {

--- a/apps/core/tasks/tasks.spec.ts
+++ b/apps/core/tasks/tasks.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TasksModule } from './tasks.module';
+import { TasksService } from './tasks.services';
+
+jest.mock('ioredis', () => {
+  return {
+    default: require('ioredis-mock/jest'),
+  };
+});
+
+describe('TasksModule', () => {
+  let app: TestingModule;
+
+  beforeAll(async () => {
+    app = await Test.createTestingModule({
+      imports: [TasksModule],
+    }).compile();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('TasksService', () => {
+    it('TasksService should initlized', () => {
+      const tasksService = app.get<TasksService>(TasksService);
+      expect(tasksService).toBeDefined();
+    });
+  });
+});

--- a/apps/core/tasks/tasks.spec.ts
+++ b/apps/core/tasks/tasks.spec.ts
@@ -1,4 +1,6 @@
+import { getQueueToken } from '@nestjs/bull';
 import { Test, TestingModule } from '@nestjs/testing';
+import { DAG } from 'plugins/core/src/dependency.resolver';
 import { TasksModule } from './tasks.module';
 import { TasksService } from './tasks.services';
 
@@ -8,23 +10,48 @@ jest.mock('ioredis', () => {
   };
 });
 
+const mockedQueue = {
+  add: jest.fn(() => {
+    return Promise.resolve('ut_test');
+  }),
+};
+
 describe('TasksModule', () => {
   let app: TestingModule;
 
   beforeAll(async () => {
     app = await Test.createTestingModule({
       imports: [TasksModule],
-    }).compile();
+    })
+      .overrideProvider(getQueueToken('default'))
+      .useValue(mockedQueue)
+      .compile();
   });
 
   afterAll(async () => {
     await app.close();
   });
 
+  afterEach(async () => {
+    mockedQueue.add.mockClear();
+  });
+
   describe('TasksService', () => {
     it('TasksService should initlized', () => {
       const tasksService = app.get<TasksService>(TasksService);
       expect(tasksService).toBeDefined();
+    });
+
+    it('add Task', async () => {
+      const tasksService = app.get<TasksService>(TasksService);
+      const taskId = await tasksService.startTask(new DAG([]));
+      expect(taskId).not.toBeNull();
+    });
+
+    it('add Task to Queue', async () => {
+      const tasksService = app.get<TasksService>(TasksService);
+      await tasksService.startTask(new DAG([{ name: 'Test' }]));
+      expect(mockedQueue.add).toBeCalled();
     });
   });
 });

--- a/apps/core/test/events.e2e-spec.ts
+++ b/apps/core/test/events.e2e-spec.ts
@@ -24,15 +24,15 @@ describe('EventsModule (e2e)', () => {
     expect(service).toBeDefined();
   });
 
-  // it('Event', (done) => {
-  //   const service = app.get(EventsService);
-  //   const linstenFuc = (value) => {
-  //     expect(value).toEqual({ ut: 'test' });
-  //     //use done to make sure function be called
-  //     done();
-  //     return;
-  //   };
-  //   service.on('Custom', linstenFuc);
-  //   service.emit('Custom', { ut: 'test' });
-  // }, 10000);
+  it('Event', (done) => {
+    const service = app.get(EventsService);
+    const linstenFuc = (value) => {
+      expect(value).toEqual({ ut: 'test' });
+      //use done to make sure function be called
+      done();
+      return;
+    };
+    service.on('Custom', linstenFuc);
+    service.emit('Custom', { ut: 'test' });
+  }, 10000);
 });

--- a/apps/core/test/events.e2e-spec.ts
+++ b/apps/core/test/events.e2e-spec.ts
@@ -8,7 +8,7 @@ describe('EventsModule (e2e)', () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [EventsModule],
+      imports: [EventsModule.forRoot()],
     }).compile();
 
     app = moduleFixture.createNestMicroservice(moduleFixture);

--- a/apps/core/test/tasks.e2e-spec.ts
+++ b/apps/core/test/tasks.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestMicroservice } from '@nestjs/common';
+import { TasksModule } from '../tasks/tasks.module';
+import { TasksService } from '../tasks/tasks.services';
+import { BullQueueModule } from 'apps/queue/src/bull/queue.module';
+import { DAG } from 'plugins/core/src/dependency.resolver';
+import { getQueueToken } from '@nestjs/bull';
+import { Queue } from 'bull';
+
+describe('EventsModule (e2e)', () => {
+  let app: INestMicroservice;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [BullQueueModule.forRoot(), TasksModule],
+    }).compile();
+
+    app = moduleFixture.createNestMicroservice(moduleFixture);
+    await app.init();
+    const queue = app.get<Queue>(getQueueToken('default'));
+    await queue.empty();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Initialized', () => {
+    const service = app.get(TasksService);
+    expect(service).toBeDefined();
+  });
+
+  it('Start Task', async () => {
+    const service = app.get(TasksService);
+    const queue = app.get<Queue>(getQueueToken('default'));
+    const taskId = await service.startTask(new DAG([{ name: 'UnitTest' }]));
+    expect(taskId).toBeDefined();
+    const jobs = await queue.getJobs(['active', 'waiting']);
+    expect(jobs).toHaveLength(1);
+  }, 10000);
+
+});

--- a/apps/queue/src/consumer/index.ts
+++ b/apps/queue/src/consumer/index.ts
@@ -3,6 +3,8 @@ import { BullQueueModule } from '../bull/queue.module';
 import PluginModule from 'plugins/core/src/plugins.module';
 import { ConsumerService } from './service';
 import Jira from 'plugins/jira/src';
+import { EventsModule } from 'apps/core/events/events.module';
+import { TasksModule } from 'apps/core/tasks/tasks.module';
 
 export class ConsumerModule {
   static forRoot(queue = 'default'): DynamicModule {
@@ -11,9 +13,10 @@ export class ConsumerModule {
       imports: [
         BullQueueModule.forRoot(queue),
         PluginModule.forRootAsync([Jira]),
-        ConsumerService,
+        EventsModule,
+        TasksModule,
       ],
-      providers: [],
+      providers: [{ provide: ConsumerService, useClass: ConsumerService }],
       exports: [ConsumerService],
     };
   }

--- a/apps/queue/src/consumer/index.ts
+++ b/apps/queue/src/consumer/index.ts
@@ -13,7 +13,7 @@ export class ConsumerModule {
       imports: [
         BullQueueModule.forRoot(queue),
         PluginModule.forRootAsync([Jira]),
-        EventsModule,
+        EventsModule.forRoot(),
         TasksModule,
       ],
       providers: [{ provide: ConsumerService, useClass: ConsumerService }],

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -20,6 +20,7 @@ export class ConsumerService {
     this.queue.on('completed', this.jobCompleted.bind(this));
   }
 
+
   async process(job: Bull.Job): Promise<void> {
     const { name, data } = job;
     const executor = this.moduleRef.get<IExecutable<any>>(name, {

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -20,8 +20,7 @@ export class ConsumerService {
     this.queue.on('completed', this.jobCompleted.bind(this));
   }
 
-
-  async process(job: Bull.Job): Promise<void> {
+  async process(job: Bull.Job): Promise<any> {
     const { name, data } = job;
     const executor = await this.moduleRef.resolve<IExecutable<any>>(
       name,
@@ -41,7 +40,9 @@ export class ConsumerService {
           result,
         });
       }
+      return Promise.resolve(result);
     }
+    return Promise.resolve(true);
   }
 
   async jobFailed(job: Bull.Job, error: Error): Promise<void> {

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -35,7 +35,7 @@ export class ConsumerService {
       if (result instanceof DAG) {
         await this.tasksService.startTask(result);
       } else {
-        this.eventsService.emit('job:completed', {
+        this.eventsService.emit('job:finished', {
           jobId: job.id,
           taskId: job.data.taskId,
           result,
@@ -45,10 +45,10 @@ export class ConsumerService {
   }
 
   async jobFailed(job: Bull.Job, error: Error): Promise<void> {
-    console.error(`${job.name}-${job.id}`, error);
+    console.error(`[BULL:failed]-[${job.name}]-[${job.id}]`, error);
   }
 
   async jobCompleted(job: Bull.Job): Promise<void> {
-    console.info(`${job.name}-${job.id}`);
+    console.info(`[BULL:completed]-[${job.name}]-[${job.id}]`);
   }
 }

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -15,7 +15,7 @@ export class ConsumerService {
     private eventsService: EventsService,
     private tasksService: TasksService,
   ) {
-    this.queue.process('*', this.process.bind(this));
+    this.queue.process('*', 2, this.process.bind(this));
     this.queue.on('failed', this.jobFailed.bind(this));
     this.queue.on('completed', this.jobCompleted.bind(this));
   }

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -1,6 +1,6 @@
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
 import Bull, { Queue } from 'bull';
 import IExecutable from 'plugins/core/src/executable.interface';
 import { DAG } from 'plugins/core/src/dependency.resolver';
@@ -23,9 +23,13 @@ export class ConsumerService {
 
   async process(job: Bull.Job): Promise<void> {
     const { name, data } = job;
-    const executor = this.moduleRef.get<IExecutable<any>>(name, {
-      strict: false,
-    });
+    const executor = await this.moduleRef.resolve<IExecutable<any>>(
+      name,
+      ContextIdFactory.create(),
+      {
+        strict: false,
+      },
+    );
     if (executor) {
       const result = await executor.execute(data);
       if (result instanceof DAG) {

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -15,7 +15,7 @@ export class ConsumerService {
     private eventsService: EventsService,
     private tasksService: TasksService,
   ) {
-    this.queue.process('*', 2, this.process.bind(this));
+    this.queue.process('*', 4, this.process.bind(this));
     this.queue.on('failed', this.jobFailed.bind(this));
     this.queue.on('completed', this.jobCompleted.bind(this));
   }

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -4,15 +4,20 @@ import { ModuleRef } from '@nestjs/core';
 import Bull, { Queue } from 'bull';
 import IExecutable from 'plugins/core/src/executable.interface';
 import { DAG } from 'plugins/core/src/dependency.resolver';
+import { EventsService } from 'apps/core/events/events.service';
+import { TasksService } from 'apps/core/tasks/tasks.services';
 
 @Injectable()
 export class ConsumerService {
   constructor(
     @InjectQueue('default') private queue: Queue,
     private moduleRef: ModuleRef,
+    private eventsService: EventsService,
+    private tasksService: TasksService,
   ) {
     this.queue.process('*', this.process.bind(this));
     this.queue.on('failed', this.jobFailed.bind(this));
+    this.queue.on('completed', this.jobCompleted.bind(this));
   }
 
   async process(job: Bull.Job): Promise<void> {
@@ -24,11 +29,22 @@ export class ConsumerService {
       const result = await executor.execute(data);
       if (result instanceof DAG) {
         //TODO: ADD DAG IN TASK SERVICE
+        await this.tasksService.startTask(result);
+      } else {
+        this.eventsService.emit('job:completed', {
+          jobId: job.id,
+          taskId: job.data.taskId,
+          result,
+        });
       }
     }
   }
 
   async jobFailed(job: Bull.Job, error: Error): Promise<void> {
     console.error(`${job.name}-${job.id}`, error);
+  }
+
+  async jobCompleted(job: Bull.Job): Promise<void> {
+    console.info(`${job.name}-${job.id}`);
   }
 }

--- a/apps/queue/src/consumer/service.ts
+++ b/apps/queue/src/consumer/service.ts
@@ -28,7 +28,6 @@ export class ConsumerService {
     if (executor) {
       const result = await executor.execute(data);
       if (result instanceof DAG) {
-        //TODO: ADD DAG IN TASK SERVICE
         await this.tasksService.startTask(result);
       } else {
         this.eventsService.emit('job:completed', {

--- a/apps/queue/src/producer/index.ts
+++ b/apps/queue/src/producer/index.ts
@@ -6,8 +6,8 @@ export class ProducerModule {
   static forRoot(queue = 'default'): DynamicModule {
     return {
       module: ProducerModule,
-      imports: [BullQueueModule.forRoot(queue), ProducerService],
-      providers: [],
+      imports: [BullQueueModule.forRoot(queue)],
+      providers: [{ provide: ProducerService, useClass: ProducerService }],
       exports: [ProducerService],
     };
   }

--- a/apps/queue/src/producer/service.ts
+++ b/apps/queue/src/producer/service.ts
@@ -4,10 +4,7 @@ import { JobOptions, Queue } from 'bull';
 
 @Injectable()
 export class ProducerService {
-  constructor(@InjectQueue('default') private queue: Queue) {
-    this.addJob('Jira', {});
-    console.info('Add Jira Task');
-  }
+  constructor(@InjectQueue('default') private queue: Queue) {}
 
   async addJob<T>(
     name: string,

--- a/apps/queue/src/producer/service.ts
+++ b/apps/queue/src/producer/service.ts
@@ -6,6 +6,7 @@ import { JobOptions, Queue } from 'bull';
 export class ProducerService {
   constructor(@InjectQueue('default') private queue: Queue) {
     this.addJob('Jira', {});
+    console.info('Add Jira Task');
   }
 
   async addJob<T>(

--- a/apps/queue/src/producer/service.ts
+++ b/apps/queue/src/producer/service.ts
@@ -1,13 +1,17 @@
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable } from '@nestjs/common';
-import { Queue } from 'bull';
+import { JobOptions, Queue } from 'bull';
 
 @Injectable()
 export class ProducerService {
   constructor(@InjectQueue('default') private queue: Queue) {}
 
-  async addJob<T>(name: string, options: T): Promise<string> {
-    const job = await this.queue.add(name, options);
+  async addJob<T>(
+    name: string,
+    options: T,
+    jobOption?: JobOptions,
+  ): Promise<string> {
+    const job = await this.queue.add(name, options, jobOption);
     return `${job.id}`;
   }
 }

--- a/apps/queue/src/producer/service.ts
+++ b/apps/queue/src/producer/service.ts
@@ -4,7 +4,9 @@ import { JobOptions, Queue } from 'bull';
 
 @Injectable()
 export class ProducerService {
-  constructor(@InjectQueue('default') private queue: Queue) {}
+  constructor(@InjectQueue('default') private queue: Queue) {
+    this.addJob('Jira', {});
+  }
 
   async addJob<T>(
     name: string,

--- a/apps/queue/src/queue.module.ts
+++ b/apps/queue/src/queue.module.ts
@@ -6,8 +6,8 @@ import { ProducerModule } from './producer';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
-    ConsumerModule.forRoot(),
     ProducerModule.forRoot(),
+    ConsumerModule.forRoot(),
   ],
   providers: [],
 })

--- a/apps/queue/test/app.e2e-spec.ts
+++ b/apps/queue/test/app.e2e-spec.ts
@@ -3,16 +3,19 @@ import { INestMicroservice } from '@nestjs/common';
 import { QueueModule } from './../src/queue.module';
 import { ConsumerService } from '../src/consumer/service';
 import { ProducerService } from '../src/producer/service';
+import { TasksService } from 'apps/core/tasks/tasks.services';
+import { EventsService } from 'apps/core/events/events.service';
 
 describe('QueueController (e2e)', () => {
   let app: INestMicroservice;
+  let module: TestingModule;
 
   beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       imports: [QueueModule],
     }).compile();
 
-    app = moduleFixture.createNestMicroservice({});
+    app = module.createNestMicroservice({});
     await app.init();
   });
 
@@ -28,5 +31,20 @@ describe('QueueController (e2e)', () => {
   it('Producer', () => {
     const producer = app.get(ProducerService);
     expect(producer).toBeDefined();
+  });
+
+  it('TaskService', () => {
+    const tasks = app.get(TasksService);
+    expect(tasks).toBeDefined();
+  });
+
+  it('EventService', () => {
+    const event = app.get(EventsService);
+    expect(event).toBeDefined();
+  });
+
+  it('Send Task', () => {
+    const event = app.get(EventsService);
+    expect(event).toBeDefined();
   });
 });

--- a/apps/queue/tsconfig.app.json
+++ b/apps/queue/tsconfig.app.json
@@ -5,5 +5,5 @@
     "outDir": "../../dist/apps/queue"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"],
 }

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: lake_db
-      MYSQL_USER: root
+      MYSQL_USER: mysql
       MYSQL_PASSWORD: root
   redis:
     image: redis:6

--- a/jest-e2e.json
+++ b/jest-e2e.json
@@ -1,7 +1,8 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "moduleNameMapper": {
-    "^plugins/(.*)$": "<rootDir>/plugins/$1"
+    "^plugins/(.*)$": "<rootDir>/plugins/$1",
+    "^apps/(.*)$": "<rootDir>/apps/$1"
   },
   "rootDir": ".",
   "testEnvironment": "node",

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,6 +1,6 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "apps/rest/src",
+  "sourceRoot": "./",
   "monorepo": true,
   "root": "apps/rest",
   "compilerOptions": {
@@ -24,6 +24,14 @@
       "sourceRoot": "apps/queue/src",
       "compilerOptions": {
         "tsConfigPath": "apps/queue/tsconfig.app.json"
+      }
+    },
+    "producer": {
+      "type": "application",
+      "root": "scripts",
+      "entryFile": "producer",
+      "compilerOptions": {
+        "tsConfigPath": "scripts/tsconfig.script.json"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
       "ts"
     ],
     "moduleNameMapper": {
-      "^plugins/(.*)$": "<rootDir>/plugins/$1"
+      "^plugins/(.*)$": "<rootDir>/plugins/$1",
+      "^apps/(.*)$": "<rootDir>/apps/$1"
     },
     "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "all:dev": "concurrently \"nest start reset --watch\" \"nest start queue --watch\"",
     "queue": "nest start queue",
     "rest": "nest start rest",
+    "producer": "nest start producer",
     "queue:dev": "nest start queue --watch",
     "rest:dev": "nest start rest --watch",
     "lint": "eslint \"{apps,plugins}/**/*.ts\" --fix",

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -2,6 +2,7 @@ import { Injectable, Type } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import BaseEntity from './base.entity';
 import { EXPORTS_META_KEY, PRODUCER_META_KEY } from './exports.decorator';
+import { IMPORTS_META_KEY } from './imports.decorator';
 import Task from './task.interface';
 
 export class DAG {
@@ -60,8 +61,6 @@ export class DAG {
 
 @Injectable()
 export default class DependencyResolver {
-  constructor(private moduleRef: ModuleRef) {}
-
   async resolve(entity: Type<BaseEntity>): Promise<DAG> {
     //TODO: fetch TASK DAG from target Entity
     const dag = new DAG([]);
@@ -72,7 +71,7 @@ export default class DependencyResolver {
   async resolveEntity(entity: Type<BaseEntity>, dag: DAG): Promise<void> {
     const ProducerType = Reflect.getMetadata(PRODUCER_META_KEY, entity);
     dag.appendTask(ProducerType);
-    const importEntities = Reflect.getMetadata(EXPORTS_META_KEY, ProducerType);
+    const importEntities = Reflect.getMetadata(IMPORTS_META_KEY, ProducerType);
     if (importEntities) {
       for (const entityClass of importEntities) {
         this.resolveEntity(entityClass, dag);

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -7,6 +7,10 @@ import Task from './task.interface';
 export class DAG {
   private _tasks = [];
 
+  constructor(task: any[]) {
+    this._tasks = task;
+  }
+
   get length(): number {
     return this._tasks.length;
   }
@@ -47,6 +51,10 @@ export class DAG {
       }
       return true;
     });
+  }
+
+  getPipline() {
+    return this._tasks;
   }
 }
 

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -64,7 +64,7 @@ export default class DependencyResolver {
 
   async resolve(entity: Type<BaseEntity>): Promise<DAG> {
     //TODO: fetch TASK DAG from target Entity
-    const dag = new DAG();
+    const dag = new DAG([]);
     await this.resolveEntity(entity, dag);
     return dag;
   }

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -6,6 +6,11 @@ import Task from './task.interface';
 
 export class DAG {
   private _tasks = [];
+
+  get length(): number {
+    return this._tasks.length;
+  }
+
   async appendTask(task: Type<Task>): Promise<void> {
     this._tasks.splice(0, 0, { name: task.name });
   }
@@ -16,6 +21,32 @@ export class DAG {
 
   toPipline(): any[] {
     return this._tasks;
+  }
+
+  get(index: number): any {
+    return this._tasks[index];
+  }
+
+  find(query: any): any {
+    return this._tasks.find((task) => {
+      for (const key of Object.keys(query)) {
+        if (query[key] !== task[key]) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }
+
+  findIndex(query: any): number {
+    return this._tasks.findIndex((task) => {
+      for (const key of Object.keys(query)) {
+        if (query[key] !== task[key]) {
+          return false;
+        }
+      }
+      return true;
+    });
   }
 }
 

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -61,6 +61,20 @@ export class DAG {
 
 @Injectable()
 export default class DependencyResolver {
+  static resolveEntity(entity: Type<BaseEntity>): Type<Task>[] {
+    let tasks = [];
+    const ProducerType = Reflect.getMetadata(PRODUCER_META_KEY, entity);
+    tasks.push(ProducerType);
+    const importEntities = Reflect.getMetadata(IMPORTS_META_KEY, ProducerType);
+    if (importEntities) {
+      for (const entityClass of importEntities) {
+        const subtasks = DependencyResolver.resolveEntity(entityClass);
+        tasks = tasks.concat(subtasks);
+      }
+    }
+    return tasks;
+  }
+
   async resolve(entity: Type<BaseEntity>): Promise<DAG> {
     //TODO: fetch TASK DAG from target Entity
     const dag = new DAG([]);

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -1,15 +1,43 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Type } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import BaseEntity from './base.entity';
+import { EXPORTS_META_KEY, PRODUCER_META_KEY } from './exports.decorator';
+import Task from './task.interface';
 
-export class DAG {} //TEMP TYPE
+export class DAG {
+  private _tasks = [];
+  async appendTask(task: Type<Task>): Promise<void> {
+    this._tasks.splice(0, 0, { name: task.name });
+  }
+
+  async pushTask(task: Type<Task>): Promise<void> {
+    this._tasks.push({ name: task.name });
+  }
+
+  toPipline(): any[] {
+    return this._tasks;
+  }
+}
 
 @Injectable()
 export default class DependencyResolver {
   constructor(private moduleRef: ModuleRef) {}
 
-  async resolve(entity: typeof BaseEntity): Promise<DAG> {
+  async resolve(entity: Type<BaseEntity>): Promise<DAG> {
     //TODO: fetch TASK DAG from target Entity
-    return {};
+    const dag = new DAG();
+    await this.resolveEntity(entity, dag);
+    return dag;
+  }
+
+  async resolveEntity(entity: Type<BaseEntity>, dag: DAG): Promise<void> {
+    const ProducerType = Reflect.getMetadata(PRODUCER_META_KEY, entity);
+    dag.appendTask(ProducerType);
+    const importEntities = Reflect.getMetadata(EXPORTS_META_KEY, ProducerType);
+    if (importEntities) {
+      for (const entityClass of importEntities) {
+        this.resolveEntity(entityClass, dag);
+      }
+    }
   }
 }

--- a/plugins/core/src/dependency.resolver.ts
+++ b/plugins/core/src/dependency.resolver.ts
@@ -32,6 +32,10 @@ export class DAG {
     return this._tasks[index];
   }
 
+  set(index: number, task: any) {
+    this._tasks[index] = task;
+  }
+
   find(query: any): any {
     return this._tasks.find((task) => {
       for (const key of Object.keys(query)) {
@@ -45,6 +49,19 @@ export class DAG {
 
   findIndex(query: any): number {
     return this._tasks.findIndex((task) => {
+      if (Array.isArray(task)) {
+        const subindex = task.findIndex((t) => {
+          for (const key of Object.keys(query)) {
+            if (query[key] !== t[key]) {
+              return false;
+            }
+          }
+          return true;
+        });
+        if (subindex >= 0) {
+          return true;
+        }
+      }
       for (const key of Object.keys(query)) {
         if (query[key] !== task[key]) {
           return false;

--- a/plugins/core/src/exports.decorator.ts
+++ b/plugins/core/src/exports.decorator.ts
@@ -1,9 +1,11 @@
 import BaseEntity from './base.entity';
 
 export const EXPORTS_META_KEY = 'EXPORTS_ENTITIES';
+export const PRODUCER_META_KEY = 'PRODUCER_TASK';
 
 export default function Exports(entity: typeof BaseEntity) {
   return (target) => {
     Reflect.defineMetadata(EXPORTS_META_KEY, entity, target);
+    Reflect.defineMetadata(PRODUCER_META_KEY, target, entity);
   };
 }

--- a/plugins/core/src/plugin.interface.ts
+++ b/plugins/core/src/plugin.interface.ts
@@ -1,3 +1,5 @@
+import { Type } from '@nestjs/common';
+import BaseEntity from './base.entity';
 import { DAG } from './dependency.resolver';
 import IExecutable from './executable.interface';
 
@@ -11,6 +13,8 @@ interface Plugin extends IExecutable<DAG> {
    * It should include collector init/enricher init/or more by args
    */
   execute(...args: any[]): Promise<DAG>;
+
+  exports(): Type<BaseEntity>[];
 }
 
 export default Plugin;

--- a/plugins/core/src/plugins.module.ts
+++ b/plugins/core/src/plugins.module.ts
@@ -1,10 +1,7 @@
 import { DynamicModule, Provider, Type } from '@nestjs/common';
-import CustomTypeOrmModule from 'apps/rest/src/providers/typeorm.module';
 import DependencyResolver from './dependency.resolver';
-import { PRODUCER_META_KEY } from './exports.decorator';
-import { IMPORTS_META_KEY } from './imports.decorator';
+import { EXPORTS_META_KEY } from './exports.decorator';
 import PluginInterface from './plugin.interface';
-import Task from './task.interface';
 
 export default class PluginModule {
   static async forRootAsync(
@@ -18,26 +15,15 @@ export default class PluginModule {
         useClass: plugin,
       });
       const i = new plugin();
-      const entities = i.exports();
-      const registTask = (task: Type<Task>) => {
-        providers.push({
-          provide: task.name,
-          useClass: task,
-        });
-        const importEntities = Reflect.getMetadata(IMPORTS_META_KEY, task);
-        for (const e of importEntities) {
-          entities.push(e);
-          const DepTask = Reflect.getMetadata(PRODUCER_META_KEY, e);
-          if (DepTask) {
-            registTask(DepTask);
-          }
-        }
-      };
-      for (const entity of entities) {
-        const Task = Reflect.getMetadata(PRODUCER_META_KEY, entity);
-        entities.push(entity);
-        if (Task) {
-          registTask(Task);
+      const plgunExports = i.exports();
+      for (const e of plgunExports) {
+        const tasks = DependencyResolver.resolveEntity(e);
+        for (const t of tasks) {
+          providers.push({
+            provide: t.name,
+            useClass: t,
+          });
+          entities.push(Reflect.getMetadata(EXPORTS_META_KEY, t));
         }
       }
     }

--- a/plugins/core/src/plugins.module.ts
+++ b/plugins/core/src/plugins.module.ts
@@ -1,20 +1,51 @@
-import { ClassProvider, DynamicModule, Type } from '@nestjs/common';
+import { DynamicModule, Provider, Type } from '@nestjs/common';
+import CustomTypeOrmModule from 'apps/rest/src/providers/typeorm.module';
 import DependencyResolver from './dependency.resolver';
+import { PRODUCER_META_KEY } from './exports.decorator';
+import { IMPORTS_META_KEY } from './imports.decorator';
 import PluginInterface from './plugin.interface';
+import Task from './task.interface';
 
 export default class PluginModule {
   static async forRootAsync(
     plugins: Type<PluginInterface>[],
   ): Promise<DynamicModule> {
-    const providers: ClassProvider[] = plugins.map((p) => ({
-      provide: p.name,
-      useClass: p,
-    }));
+    const providers: Provider[] = [DependencyResolver];
+    const entities = [];
+    for (const plugin of plugins) {
+      providers.push({
+        provide: plugin.name,
+        useClass: plugin,
+      });
+      const i = new plugin();
+      const entities = i.exports();
+      const registTask = (task: Type<Task>) => {
+        providers.push({
+          provide: task.name,
+          useClass: task,
+        });
+        const importEntities = Reflect.getMetadata(IMPORTS_META_KEY, task);
+        for (const e of importEntities) {
+          entities.push(e);
+          const DepTask = Reflect.getMetadata(PRODUCER_META_KEY, e);
+          if (DepTask) {
+            registTask(DepTask);
+          }
+        }
+      };
+      for (const entity of entities) {
+        const Task = Reflect.getMetadata(PRODUCER_META_KEY, entity);
+        entities.push(entity);
+        if (Task) {
+          registTask(Task);
+        }
+      }
+    }
     return {
       module: PluginModule,
       imports: [],
-      providers: [...providers, DependencyResolver],
-      exports: [...providers, DependencyResolver],
+      providers: [...providers],
+      exports: [...providers],
     };
   }
 }

--- a/plugins/core/test/plugin.spec.ts
+++ b/plugins/core/test/plugin.spec.ts
@@ -5,7 +5,11 @@ import PluginModule from '../src/plugins.module';
 
 class TestPlugin implements Plugin {
   async execute(...args: any[]): Promise<DAG> {
-    return {};
+    return new DAG([]);
+  }
+
+  exports() {
+    return [];
   }
 }
 

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -1,7 +1,10 @@
-import { Inject, Injectable, Scope } from '@nestjs/common';
+import { Inject, Injectable, Scope, Type } from '@nestjs/common';
+import BaseEntity from 'plugins/core/src/base.entity';
 import DependencyResolver, { DAG } from 'plugins/core/src/dependency.resolver';
 import Plugin from 'plugins/core/src/plugin.interface';
 import IssueLeadTimeEntity from './tasks/leadtime/leadtime.entity';
+
+export * from './tasks';
 
 export type JiraOptions = {
   source: {
@@ -17,9 +20,13 @@ class Jira implements Plugin {
 
   async execute(options: JiraOptions): Promise<DAG> {
     //TODO: Add jira collector and enrichment
-    console.info('Excute Jira', options);
-    const dag = await this.resolver.resolve(IssueLeadTimeEntity);
+    console.info('Execute Jira', options, this.exports()[0]);
+    const dag = await this.resolver.resolve(this.exports()[0]);
     return dag;
+  }
+
+  exports(): Type<BaseEntity>[] {
+    return [IssueLeadTimeEntity];
   }
 }
 

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -20,7 +20,7 @@ class Jira implements Plugin {
 
   async execute(options: JiraOptions): Promise<DAG> {
     //TODO: Add jira collector and enrichment
-    console.info('Execute Jira', options, this.exports()[0]);
+    console.info('Execute Jira', options);
     const dag = await this.resolver.resolve(this.exports()[0]);
     return dag;
   }

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -20,7 +20,7 @@ class Jira implements Plugin {
 
   async execute(options: JiraOptions): Promise<DAG> {
     //TODO: Add jira collector and enrichment
-    console.info('Execute Jira', options);
+    console.info('Jira Plugin Executed', options);
     const dag = await this.resolver.resolve(this.exports()[0]);
     return dag;
   }

--- a/plugins/jira/src/tasks/changelog/changelog.collector.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.collector.ts
@@ -1,0 +1,26 @@
+import { Inject } from '@nestjs/common';
+import Exports from 'plugins/core/src/exports.decorator';
+import Task from 'plugins/core/src/task.interface';
+import { Repository } from 'typeorm';
+import ChangelogEntity from './changelog.entity';
+
+export type JiraSource = {
+  host: string;
+  username: string;
+  token: string;
+};
+
+@Exports(ChangelogEntity)
+export default class ChangelogCollector implements Task {
+  // @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;
+
+  name(): string {
+    return 'IssueChangelog';
+  }
+
+  async execute(source: JiraSource): Promise<void> {
+    //TODO: do collector
+    console.info('Excute Issue Changelog Collector', source);
+    return;
+  }
+}

--- a/plugins/jira/src/tasks/changelog/changelog.collector.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.collector.ts
@@ -1,7 +1,9 @@
 import { Inject } from '@nestjs/common';
 import Exports from 'plugins/core/src/exports.decorator';
+import Imports from 'plugins/core/src/imports.decorator';
 import Task from 'plugins/core/src/task.interface';
 import { Repository } from 'typeorm';
+import IssueEntity from '../issue/issue.entity';
 import ChangelogEntity from './changelog.entity';
 
 export type JiraSource = {
@@ -10,6 +12,7 @@ export type JiraSource = {
   token: string;
 };
 
+@Imports([IssueEntity])
 @Exports(ChangelogEntity)
 export default class ChangelogCollector implements Task {
   // @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;

--- a/plugins/jira/src/tasks/changelog/changelog.collector.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.collector.ts
@@ -24,6 +24,7 @@ export default class ChangelogCollector implements Task {
   async execute(source: JiraSource): Promise<void> {
     //TODO: do collector
     console.info('Excute Issue Changelog Collector', source);
+    await new Promise((resolve) => setTimeout(() => resolve(true), 100));
     return;
   }
 }

--- a/plugins/jira/src/tasks/changelog/changelog.entity.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.entity.ts
@@ -1,0 +1,14 @@
+import BaseEntity from 'plugins/core/src/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity()
+export default class ChangelogEntity extends BaseEntity {
+  @Column()
+  key: string;
+
+  @Column()
+  fromString: string;
+
+  @Column()
+  toString: string;
+}

--- a/plugins/jira/src/tasks/changelog/changelog.entity.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.entity.ts
@@ -7,8 +7,8 @@ export default class ChangelogEntity extends BaseEntity {
   key: string;
 
   @Column()
-  fromString: string;
+  from: string;
 
   @Column()
-  toString: string;
+  to: string;
 }

--- a/plugins/jira/src/tasks/changelog/changelog.spec.ts
+++ b/plugins/jira/src/tasks/changelog/changelog.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import ChangelogCollector from './changelog.collector';
+import ChangelogEntity from './changelog.entity';
+
+describe('Jira/Changelog', () => {
+  let app: TestingModule;
+
+  beforeEach(async () => {
+    app = await Test.createTestingModule({
+      providers: [
+        ChangelogCollector,
+        {
+          provide: ChangelogEntity,
+          useFactory: () => {
+            return jest.fn();
+          },
+        },
+      ],
+    }).compile();
+  });
+
+  describe('Collector', () => {
+    it('constructor', () => {
+      const collector = app.get(ChangelogCollector);
+      expect(collector).toBeDefined();
+    });
+  });
+});

--- a/plugins/jira/src/tasks/index.ts
+++ b/plugins/jira/src/tasks/index.ts
@@ -1,0 +1,7 @@
+import IssueCollector from './issue/issue.collector';
+import LeadTimeEnricher from './leadtime/leadtime.enricher';
+
+export default {
+  IssueCollector,
+  LeadTimeEnricher,
+};

--- a/plugins/jira/src/tasks/index.ts
+++ b/plugins/jira/src/tasks/index.ts
@@ -1,7 +1,9 @@
 import IssueCollector from './issue/issue.collector';
+import ChangelogCollector from './changelog/changelog.collector';
 import LeadTimeEnricher from './leadtime/leadtime.enricher';
 
 export default {
   IssueCollector,
+  ChangelogCollector,
   LeadTimeEnricher,
 };

--- a/plugins/jira/src/tasks/issue/issue.collector.ts
+++ b/plugins/jira/src/tasks/issue/issue.collector.ts
@@ -12,7 +12,7 @@ export type JiraSource = {
 
 @Exports(IssueEntity)
 export default class IssueCollector implements Task {
-  @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;
+  // @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;
 
   name(): string {
     return 'JiraIssue';

--- a/plugins/jira/src/tasks/issue/issue.collector.ts
+++ b/plugins/jira/src/tasks/issue/issue.collector.ts
@@ -18,9 +18,20 @@ export default class IssueCollector implements Task {
     return 'JiraIssue';
   }
 
-  async execute(source: JiraSource): Promise<void> {
+  async execute(source: JiraSource): Promise<any[]> {
     //TODO: do collector
     console.info('Excute Jira Issue Collector', source);
-    return;
+    const samplekeys = [
+      'ISSUE-1',
+      'ISSUE-2',
+      'ISSUE-3',
+      'ISSUE-4',
+      'ISSUE-5',
+      'ISSUE-6',
+    ];
+    return samplekeys.map((issue) => ({
+      ...source,
+      issue,
+    }));
   }
 }

--- a/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
+++ b/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
@@ -22,10 +22,10 @@ export default class LeadTimeEnricher implements Task {
     return 'JiraIssueLeadTime';
   }
 
-  async execute(source: JiraSource): Promise<void> {
+  async execute(source: JiraSource): Promise<any> {
     //TODO: do enrichment
     console.info('Excute Jira Lead Time Enricher', source);
     await new Promise((resolve) => setTimeout(() => resolve(true), 100));
-    return;
+    return {};
   }
 }

--- a/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
+++ b/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
@@ -3,7 +3,7 @@ import Exports from 'plugins/core/src/exports.decorator';
 import Imports from 'plugins/core/src/imports.decorator';
 import Task from 'plugins/core/src/task.interface';
 import { Repository } from 'typeorm';
-import IssueEntity from '../issue/issue.entity';
+import ChangelogEntity from '../changelog/changelog.entity';
 import IssueLeadTimeEntity from './leadtime.entity';
 
 export type JiraSource = {
@@ -12,7 +12,7 @@ export type JiraSource = {
   token: string;
 };
 
-@Imports([IssueEntity])
+@Imports([ChangelogEntity])
 @Exports(IssueLeadTimeEntity)
 export default class LeadTimeEnricher implements Task {
   // @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;

--- a/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
+++ b/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
@@ -25,6 +25,7 @@ export default class LeadTimeEnricher implements Task {
   async execute(source: JiraSource): Promise<void> {
     //TODO: do enrichment
     console.info('Excute Jira Lead Time Enricher', source);
+    await new Promise((resolve) => setTimeout(() => resolve(true), 100));
     return;
   }
 }

--- a/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
+++ b/plugins/jira/src/tasks/leadtime/leadtime.enricher.ts
@@ -15,9 +15,8 @@ export type JiraSource = {
 @Imports([IssueEntity])
 @Exports(IssueLeadTimeEntity)
 export default class LeadTimeEnricher implements Task {
-  @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;
-  @Inject(IssueLeadTimeEntity)
-  private IssueLeadTimeRepository: Repository<IssueLeadTimeEntity>;
+  // @Inject(IssueEntity) private IssueRepository: Repository<IssueEntity>;
+  // @Inject(IssueLeadTimeEntity) private IssueLeadTimeRepository: Repository<IssueLeadTimeEntity>;
 
   name(): string {
     return 'JiraIssueLeadTime';

--- a/scripts/producer.ts
+++ b/scripts/producer.ts
@@ -1,0 +1,18 @@
+import { NestFactory } from '@nestjs/core';
+import { Module } from '@nestjs/common';
+import { ProducerModule } from 'apps/queue/src/producer';
+import { ProducerService } from 'apps/queue/src/producer/service';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), ProducerModule.forRoot()],
+})
+class CustomModule {}
+
+async function bootstrap() {
+  const appContext = await NestFactory.createApplicationContext(CustomModule);
+  const producer = await appContext.get(ProducerService, { strict: false });
+  await producer.addJob('Jira', {});
+  await appContext.close();
+}
+bootstrap();

--- a/scripts/tsconfig.script.json
+++ b/scripts/tsconfig.script.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../dist/scripts"
+  },
+  "paths": {
+    "apps/*": ["apps/*"]
+  }
+}


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing](../CONTRIBUTING.md) Documentation
- [x] This PR is using a `label` (bug, feature etc.)
- [ ] My code is has necessary documentation (if appropriate)
- [x] I have added any relevant tests
- [ ] This section (**⚠️ &nbsp;&nbsp;Pre Checklist**) will be removed when submitting PR

# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated

### Description

#### What Changes

The Plugin Execution: now all the tasks in the plugin would be schedule into the task queue and executed.

The Plugin Tasks:  if a plugin executed, the plugin entry executed method return the task dependency graph (it's a pipeline right now) to the task service. and the task service would executed task one by one in the dependency graph.

Dependency Resolve: a dependency resolver to load task class from entities. and with dependency entities in task class to load dependency task class into the dependency graph.

Task Code would like below
```
\\Task.Entity.ts
class SampleEntity {
}
\\Task.enricher.ts
@Imports([CollectorEntity])
@Export(SampleEntity)
class SampleEnricher {
}
\\Collector.Entity.ts
class CollectorEntity {
}
\\Task.collector.ts
@Export(CollectorEntity)
class SampleCollecotr {
}
```

by resolve the ```SampleEntity```, we would get a task pipeline: [SampleCollector, SampleEnricher]

from the pipeline [SampleCollector,  SampleEnricher] TaskService will create a task with id(A). And Schedule a SampleCollector with a jobid(B) into queue.  after job finished, queue would send job:completed event to the task service. 
task service get job(B) info from jobid and find the next taks SampleEnricher. so task service will add SampleEnricher with jobid(C) into queue.  While SampleEnricher(C) finished, the task service find there is no more task in the pipline. so the task(A) is finished.

#### Task Mapping!

Task could return some value in execution.Why? because the next task would rely on it.

I add some simple logic to make next task be split with different options. return an array is the way.

```
\\IssueCollector
class IssueCollector {
       execute(jiraSource):Promise<any[]> {
          return allSyncedIssues.map(issue => ({ ...jiraSource,  issue}) );
     }
}
```

the code above return a list of issues. so the next task would be split into jobs with different issue. a list of jobs would executed as below:

```
Task Start
Jira Issue Collector 
Jira Issue Changelog Collector [Issue -1]
Jira Issue Changelog Collector [Issue -2]
Jira Issue Changelog Collector [Issue -3]
Jira Issue Changelog  Collector [Issue -4]
...
Jira Issue Changelog Collector [Issue -n]
Jira Issue Leadtime Enricher
Task Finished
```

#### Why use the task service and events

suppose we run queue service container in k8s with replica 2.
and let do the Issue-Changelog-Leadtime  pipline described above in the cluster.
you could see output like this

|queue1 | queue 2|
|-|-|
|task start | - |
|-  | Jira Issue Collector |
|Jira Issue Changelog Collector [Issue -1]  | Jira Issue Changelog Collector [Issue -3] |
|Jira Issue Changelog Collector [Issue -2]  | Jira Issue Changelog Collector [Issue -4] |
| ... | ... |
| -  | Jira Issue Changelog Collector [Issue -n] |
| Jira Issue Leadtime Enricher  | ... |
| - | Task Finished |


#### view in console

start a queue service
```
npm run queue
```
push a plugin task into queue
```
npm run producer
```
the producer script add a Jira Plugin Task into queue, and you can see the console outputs in the queue service console

If you want to view how the cluster works. open an other console run ```npm run queue```. there maybe have an error message, just skip it.

### Does this close any open issues?

 #245 #246 

