### PR TITLE
DO NOT MERGE - feat: 819 poc - plugin pipeline execution with bulljs multiple-process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+node_modules
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)

--- a/proposal1/README.md
+++ b/proposal1/README.md
@@ -1,0 +1,98 @@
+# Plugin Execution Pipeline POC
+
+This is a POC demo to show how plugin pipeline could be done.
+
+# Assumption
+
+## Plugins
+
+1. `JiraPlugin` responsible for jira data collection and enrichment
+2. `GitlabPlugin` responsible for gitlab data collection and enrichment
+3. `QualityPlugin` is to calculate compound figures base on `JiraPlugin` and `GitlabPlugin`
+4. All plugin forms a DAG
+
+## Scenario
+
+1. Want to see some `Quality` figures, so he issue a api request to our api
+2. Server generate a pipeline base on Plugin Dependency DAG, which is:
+    Pipeline ( all jobs of a step executed in parallel)
+
+    | step   | parallel job 1 | parallel job 2 |
+    | ------ | -------------- | -------------- |
+    | step 1 | jira           | gitlab         |
+    | step 2 | quality        |                |
+
+## Problem
+
+Say if we can generate a pipeline like this:
+
+```js
+[
+    [
+         { plugin: 'jira', args: { boardId: 8, force: false } },
+         { plugin: 'gitlab', args: { projectId: 800012, force: false } }
+    ],
+    [
+         { plugin: 'quality', args: { boardId: 8, projectId: 800012, force: false } }
+    ]
+]
+```
+
+Can we leverage `bulljs` to run those tasks in multiple process?
+
+# Solution
+
+1. `worker.ts` is the daemon process listening task queue and execute them, it will spawn 5 `worker-process.ts` in this demo.
+2. `worker-process.ts` takes bulljs Job and call specific plugin
+3. `main.ts` simulates API Server pipeline execution
+
+# How to run
+
+1. checkout branch of this PR
+2. run `npm run compose` for `redis` service
+3. run `npx ts-node proposal1/worker.ts` and keep it running
+4. run `npx ts-node proposal1/main.ts` to simulate a pipeline execution
+5. expected output of `worker.ts`:
+
+```sh
+[15772|15][2021-08-20T11:00:22.453Z] <jira> start pipeline job { boardId: 8, force: false }
+[15766|16][2021-08-20T11:00:22.453Z] <gitlab> start pipeline job { projectId: 800012, force: false }
+[15766|16][2021-08-20T11:00:22.453Z] <gitlab> INFO >>> gitlab plugin start
+[15772|15][2021-08-20T11:00:22.453Z] <jira> INFO >>> jira plugin start
+[15766|16][2021-08-20T11:00:22.453Z] <gitlab> INFO >>> gitlab start collect repo data
+[15772|15][2021-08-20T11:00:22.453Z] <jira> INFO >>> jira start collect board data
+[15772|15][2021-08-20T11:00:23.454Z] <jira> progress: 10
+[15772|15][2021-08-20T11:00:23.454Z] <jira> INFO >>> jira end collect board data
+[15772|15][2021-08-20T11:00:23.454Z] <jira> INFO >>> jira start collect issues data
+[15766|16][2021-08-20T11:00:23.454Z] <gitlab> progress: 10
+[15766|16][2021-08-20T11:00:23.454Z] <gitlab> INFO >>> gitlab end collect repo data
+[15766|16][2021-08-20T11:00:23.454Z] <gitlab> INFO >>> gitlab start collect commits data
+[15772|15][2021-08-20T11:00:24.455Z] <jira> progress: 50
+[15772|15][2021-08-20T11:00:24.455Z] <jira> INFO >>> jira end collect issues data
+[15772|15][2021-08-20T11:00:24.455Z] <jira> INFO >>> jira start enricher issues data
+[15766|16][2021-08-20T11:00:24.455Z] <gitlab> progress: 50
+[15766|16][2021-08-20T11:00:24.456Z] <gitlab> INFO >>> gitlab end collect commits data
+[15766|16][2021-08-20T11:00:24.456Z] <gitlab> INFO >>> gitlab start enricher commits data
+[15766|16][2021-08-20T11:00:25.456Z] <gitlab> progress: 100
+[15766|16][2021-08-20T11:00:25.456Z] <gitlab> INFO >>> gitlab end enricher commits data
+[15766|16][2021-08-20T11:00:25.456Z] <gitlab> INFO >>> gitlab plugin end
+[15766|16][2021-08-20T11:00:25.456Z] <gitlab> end pipeline job { projectId: 800012, force: false }
+[15772|15][2021-08-20T11:00:25.456Z] <jira> progress: 100
+[15772|15][2021-08-20T11:00:25.457Z] <jira> INFO >>> jira end enricher issues data
+[15772|15][2021-08-20T11:00:25.457Z] <jira> INFO >>> jira plugin end
+[15772|15][2021-08-20T11:00:25.457Z] <jira> end pipeline job { boardId: 8, force: false }
+[15772|17][2021-08-20T11:00:25.460Z] <quality> start pipeline job { boardId: 8, projectId: 800012, force: false }
+[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> quality plugin start
+[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> we can use entities from parent plugins now, like:  function function
+[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> quality start calculating BUGS COUNT PER 1K LOC
+[15772|17][2021-08-20T11:00:26.461Z] <quality> progress: 50
+[15772|17][2021-08-20T11:00:26.461Z] <quality> INFO >>> quality end calculating BUGS COUNT PER 1K LOC
+[15772|17][2021-08-20T11:00:26.461Z] <quality> INFO >>> quality start calculating INCIDENTS COUNT PER 1K LOC
+[15772|17][2021-08-20T11:00:27.463Z] <quality> progress: 100
+[15772|17][2021-08-20T11:00:27.463Z] <quality> INFO >>> quality end calculating INCIDENTS COUNT PER 1K LOC
+[15772|17][2021-08-20T11:00:27.463Z] <quality> INFO >>> quality plugin end
+[15772|17][2021-08-20T11:00:27.463Z] <quality> end pipeline job { boardId: 8, projectId: 800012, force: false }
+```
+
+
+

--- a/proposal1/main.ts
+++ b/proposal1/main.ts
@@ -1,0 +1,22 @@
+import { waitAll } from './plugins/core'
+
+
+async function main() {
+    console.log(new Date().toJSON(), 'start pipeline')
+
+    // hardcoded pipeline for demo, should be generated dynamically
+    // pipeline step 1
+    await waitAll([
+        { plugin: 'jira', args: { boardId: 8, force: false } },
+        { plugin: 'gitlab', args: { projectId: 800012, force: false } }
+    ])
+    // pipeline step 2
+    await waitAll([
+        { plugin: 'quality', args: { boardId: 8, projectId: 800012, force: false } }
+    ])
+
+    console.log(new Date().toJSON(), 'end pipeline')
+    process.exit()
+}
+
+main()

--- a/proposal1/plugins/core/index.ts
+++ b/proposal1/plugins/core/index.ts
@@ -1,0 +1,34 @@
+import * as Queue from 'bull'
+
+export const queue = new Queue('lake', 'redis://localhost:6379')
+
+export class Context {
+    constructor(private jobId: string|number, private pluginName: string, args: any) {
+    }
+
+    log(...msg: any[]): void {
+        console.log(`[${process.pid}|${this.jobId}][${new Date().toJSON()}] <${this.pluginName}> ${msg[0]}`, ...msg.slice(1))
+    }
+
+    progress(percent: number): void {
+        this.log('progress: %d', percent)
+    }
+}
+
+export interface Plugin {
+    readonly dependencies?: string[];
+    execute?: (job: Context) => Promise<void>;
+}
+
+export interface TaskDesc {
+    plugin: string,
+    args: any
+}
+
+
+export async function waitAll(tasks: TaskDesc[]) {
+    // add all tasks to queue
+    const jobs = await Promise.all(tasks.map(t => queue.add(t, { attempts: 4 })))
+    // wait for all tasks to finish
+    await Promise.all(jobs.map(j => j.finished()))
+}

--- a/proposal1/plugins/gitlab/entities/commit.ts
+++ b/proposal1/plugins/gitlab/entities/commit.ts
@@ -1,0 +1,4 @@
+
+export default class Commit {
+
+}

--- a/proposal1/plugins/gitlab/entities/project.ts
+++ b/proposal1/plugins/gitlab/entities/project.ts
@@ -1,0 +1,4 @@
+
+export default class Project {
+
+}

--- a/proposal1/plugins/gitlab/index.ts
+++ b/proposal1/plugins/gitlab/index.ts
@@ -1,0 +1,25 @@
+import { Plugin, Context } from '../core'
+
+
+export default class JiraPlugin implements Plugin {
+    async execute(ctx: Context): Promise<void> {
+        ctx.log('INFO >>> gitlab plugin start')
+
+        ctx.log('INFO >>> gitlab start collect repo data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(10)
+        ctx.log('INFO >>> gitlab end collect repo data')
+
+        ctx.log('INFO >>> gitlab start collect commits data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(50)
+        ctx.log('INFO >>> gitlab end collect commits data')
+
+        ctx.log('INFO >>> gitlab start enricher commits data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(100)
+        ctx.log('INFO >>> gitlab end enricher commits data')
+
+        ctx.log('INFO >>> gitlab plugin end')
+    }
+}

--- a/proposal1/plugins/jira/entities/board.ts
+++ b/proposal1/plugins/jira/entities/board.ts
@@ -1,0 +1,3 @@
+export default class Board {
+
+}

--- a/proposal1/plugins/jira/entities/issue.ts
+++ b/proposal1/plugins/jira/entities/issue.ts
@@ -1,0 +1,2 @@
+export default class Issue {
+}

--- a/proposal1/plugins/jira/index.ts
+++ b/proposal1/plugins/jira/index.ts
@@ -1,0 +1,25 @@
+import { Plugin, Context } from '../core'
+
+
+export default class JiraPlugin implements Plugin {
+    async execute(ctx: Context): Promise<void> {
+        ctx.log('INFO >>> jira plugin start')
+
+        ctx.log('INFO >>> jira start collect board data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(10)
+        ctx.log('INFO >>> jira end collect board data')
+
+        ctx.log('INFO >>> jira start collect issues data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(50)
+        ctx.log('INFO >>> jira end collect issues data')
+
+        ctx.log('INFO >>> jira start enricher issues data')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(100)
+        ctx.log('INFO >>> jira end enricher issues data')
+
+        ctx.log('INFO >>> jira plugin end')
+    }
+}

--- a/proposal1/plugins/quality/index.ts
+++ b/proposal1/plugins/quality/index.ts
@@ -1,0 +1,27 @@
+import { Plugin, Context } from '../core'
+import Issue from '../jira/entities/issue'
+import Commit from '../gitlab/entities/commit'
+
+
+export default class JiraPlugin implements Plugin {
+
+    dependencies: ['jira', 'gitlab']
+
+    async execute(ctx: Context): Promise<void> {
+        ctx.log('INFO >>> quality plugin start')
+
+        ctx.log('INFO >>> we can use entities from parent plugins now, like: ', typeof Issue, typeof Commit)
+
+        ctx.log('INFO >>> quality start calculating BUGS COUNT PER 1K LOC')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(50)
+        ctx.log('INFO >>> quality end calculating BUGS COUNT PER 1K LOC')
+
+        ctx.log('INFO >>> quality start calculating INCIDENTS COUNT PER 1K LOC')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        ctx.progress(100)
+        ctx.log('INFO >>> quality end calculating INCIDENTS COUNT PER 1K LOC')
+
+        ctx.log('INFO >>> quality plugin end')
+    }
+}

--- a/proposal1/worker-process.ts
+++ b/proposal1/worker-process.ts
@@ -1,0 +1,20 @@
+import { Job } from 'bull'
+import { Plugin, Context } from './plugins/core'
+
+// hardcoded plugins for demo, should be loaded dynamically
+import Jira from './plugins/jira'
+import Gitlab from './plugins/gitlab'
+import Quality from './plugins/quality'
+const plugins: Record<string, Plugin> = {
+    jira: new Jira(),
+    gitlab: new Gitlab(),
+    quality: new Quality()
+}
+
+export default async function(job: Job) {
+    const { plugin, args } = job.data
+    const ctx = new Context(job.id, plugin, args)
+    ctx.log('start pipeline job', args)
+    await plugins[plugin].execute(ctx)
+    ctx.log('end pipeline job', args)
+}

--- a/proposal1/worker.ts
+++ b/proposal1/worker.ts
@@ -1,0 +1,7 @@
+import * as path from 'path'
+import { queue } from './plugins/core'
+
+
+console.log('initializing worker')
+queue.process(5, path.join(__dirname, 'worker-process.ts'))
+console.log('worker is ready')


### PR DESCRIPTION
# Plugin Execution Pipeline POC

This is a POC demo to show how plugin pipeline could be done. This PR is created to share idea and discuss, mainly focus on Plugin Execution Pipeline, other irrelevant stuff either hardcoded or just plain dummy entities.
NOT MEANT TO BE MERGED. 

# Assumption

## Plugins

1. `JiraPlugin` responsible for jira data collection and enrichment
2. `GitlabPlugin` responsible for gitlab data collection and enrichment
3. `QualityPlugin` is to calculate compound figures base on `JiraPlugin` and `GitlabPlugin`
4. All plugin forms a DAG

## Scenario

1. Want to see some `Quality` figures, so he issue a api request to our api
2. Server generate a pipeline base on Plugin Dependency DAG, which is:
    Pipeline ( all jobs of a step executed in parallel)

    | step   | parallel job 1 | parallel job 2 |
    | ------ | -------------- | -------------- |
    | step 1 | jira           | gitlab         |
    | step 2 | quality        |                |

## Problem

Say if we can generate a pipeline like this:

```js
[
    [
         { plugin: 'jira', args: { boardId: 8, force: false } },
         { plugin: 'gitlab', args: { projectId: 800012, force: false } }
    ],
    [
         { plugin: 'quality', args: { boardId: 8, projectId: 800012, force: false } }
    ]
]
```

Can we leverage `bulljs` to run those tasks in multiple process?

# Solution

1. `worker.ts` is the daemon process listening task queue and execute them, it will spawn 5 `worker-process.ts` in this demo.
2. `worker-process.ts` takes bulljs Job and call specific plugin
3. `main.ts` simulates API Server pipeline execution

# How to run

1. checkout branch of this PR
2. run `npm run compose` for `redis` service
3. run `npx ts-node proposal1/worker.ts` and keep it running
4. run `npx ts-node proposal1/main.ts` to simulate a pipeline execution
5. expected output of `worker.ts`:

```sh
[15772|15][2021-08-20T11:00:22.453Z] <jira> start pipeline job { boardId: 8, force: false }
[15766|16][2021-08-20T11:00:22.453Z] <gitlab> start pipeline job { projectId: 800012, force: false }
[15766|16][2021-08-20T11:00:22.453Z] <gitlab> INFO >>> gitlab plugin start
[15772|15][2021-08-20T11:00:22.453Z] <jira> INFO >>> jira plugin start
[15766|16][2021-08-20T11:00:22.453Z] <gitlab> INFO >>> gitlab start collect repo data
[15772|15][2021-08-20T11:00:22.453Z] <jira> INFO >>> jira start collect board data
[15772|15][2021-08-20T11:00:23.454Z] <jira> progress: 10
[15772|15][2021-08-20T11:00:23.454Z] <jira> INFO >>> jira end collect board data
[15772|15][2021-08-20T11:00:23.454Z] <jira> INFO >>> jira start collect issues data
[15766|16][2021-08-20T11:00:23.454Z] <gitlab> progress: 10
[15766|16][2021-08-20T11:00:23.454Z] <gitlab> INFO >>> gitlab end collect repo data
[15766|16][2021-08-20T11:00:23.454Z] <gitlab> INFO >>> gitlab start collect commits data
[15772|15][2021-08-20T11:00:24.455Z] <jira> progress: 50
[15772|15][2021-08-20T11:00:24.455Z] <jira> INFO >>> jira end collect issues data
[15772|15][2021-08-20T11:00:24.455Z] <jira> INFO >>> jira start enricher issues data
[15766|16][2021-08-20T11:00:24.455Z] <gitlab> progress: 50
[15766|16][2021-08-20T11:00:24.456Z] <gitlab> INFO >>> gitlab end collect commits data
[15766|16][2021-08-20T11:00:24.456Z] <gitlab> INFO >>> gitlab start enricher commits data
[15766|16][2021-08-20T11:00:25.456Z] <gitlab> progress: 100
[15766|16][2021-08-20T11:00:25.456Z] <gitlab> INFO >>> gitlab end enricher commits data
[15766|16][2021-08-20T11:00:25.456Z] <gitlab> INFO >>> gitlab plugin end
[15766|16][2021-08-20T11:00:25.456Z] <gitlab> end pipeline job { projectId: 800012, force: false }
[15772|15][2021-08-20T11:00:25.456Z] <jira> progress: 100
[15772|15][2021-08-20T11:00:25.457Z] <jira> INFO >>> jira end enricher issues data
[15772|15][2021-08-20T11:00:25.457Z] <jira> INFO >>> jira plugin end
[15772|15][2021-08-20T11:00:25.457Z] <jira> end pipeline job { boardId: 8, force: false }
[15772|17][2021-08-20T11:00:25.460Z] <quality> start pipeline job { boardId: 8, projectId: 800012, force: false }
[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> quality plugin start
[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> we can use entities from parent plugins now, like:  function function
[15772|17][2021-08-20T11:00:25.460Z] <quality> INFO >>> quality start calculating BUGS COUNT PER 1K LOC
[15772|17][2021-08-20T11:00:26.461Z] <quality> progress: 50
[15772|17][2021-08-20T11:00:26.461Z] <quality> INFO >>> quality end calculating BUGS COUNT PER 1K LOC
[15772|17][2021-08-20T11:00:26.461Z] <quality> INFO >>> quality start calculating INCIDENTS COUNT PER 1K LOC
[15772|17][2021-08-20T11:00:27.463Z] <quality> progress: 100
[15772|17][2021-08-20T11:00:27.463Z] <quality> INFO >>> quality end calculating INCIDENTS COUNT PER 1K LOC
[15772|17][2021-08-20T11:00:27.463Z] <quality> INFO >>> quality plugin end
[15772|17][2021-08-20T11:00:27.463Z] <quality> end pipeline job { boardId: 8, projectId: 800012, force: false }
```



