### PR TITLE
chore: update pipeline configuration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 65
         threshold: 1%
 comment:
   require_changes: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 12.x
       - run: 'npm install'
       - run: 'npm run test:cov'
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,9 +4,6 @@ on: [pull_request]
 jobs:
   e2e-mysql:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 15.x]
     env:
       DB_DATABASE: lake_db
       DB_USER: root
@@ -16,10 +13,10 @@ jobs:
       REDIS_URL: redis://localhost:6379/1
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 12.x
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12.x
       - run: 'npm install'
       - name: setup mysql
         run: |
@@ -30,31 +27,3 @@ jobs:
         with:
           redis-version: '6.x'
       - run: 'npm run test:e2e'
-  # e2e-postgres:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [12.x, 14.x, 15.x]
-  #   services:
-  #     postgres:
-  #       image: postgres
-  #       env:
-  #         POSTGRES_PASSWORD: postgres
-  #       ports:
-  #         - 5432:5432
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #   env:
-  #     DB_TYPE: postgres
-  #     DB_URL: postgresql://postgres:postgres@localhost:5432/postgres
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - run: 'npm install'
-  #     - run: 'npm run test:e2e'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 15.x]
+        node-version: [14.x, 16.x]
     env:
       DB_URL: mysql://root:root@localhost:3306/lake_db
       REDIS_URL: redis://localhost:6379/1


### PR DESCRIPTION
# Summary
This PR update pipeline settings, more info in #254 

### Key Points
- [x] This is a breaking change
- [ ] New or existing documentation is updated

### changes  

previous behavior is described in #254, current behaviors as following:
- coverage rate is at least 65% (75% after 9.15)
- covearge rate for added lines is at least 65% (75% after 9.15)
- unit test (node version 12.x, 14.x, 16.x)
- e2e test (node version 12.x)
- commit message lint
- eslint (prettier)

### Does this close any open issues?
#254

### Other Information
The target coverage rate is planed to 2 stages, now for 65% (current 68%), and 75% after 9.15.
