### PR TITLE
chore: update the readme and change the db name in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Main Database Connection String
-DB_URL=root:123456@tcp(127.0.0.1:3306)/lake?charset=utf8mb4&loc=Asia%2fShanghai&parseTime=True
+DB_URL=root:root@tcp(localhost:3306)/lake?charset=utf8mb4&loc=Asia%2fShanghai&parseTime=True
 
 # Rest configuration
 # Rest api port

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ Thumbs.db
 
 # yarn
 yarn.lock
+
+lake

--- a/README.md
+++ b/README.md
@@ -6,18 +6,31 @@
 - [Install Golang](https://golang.org/doc/install)
 
 ### Developer Setup
+
 ```shell
-# clone lake repository
-$ git clone https://github.com/merico-dev/lake.git
-# enter lake directory
-$ cd lake
-# get packages
-$ go get
-# build 
-$ go build
-# copy .env.example to .env
-$ cp .env.example .env
-$ ./lake
+git clone https://github.com/merico-dev/lake.git
+cd lake
+make get
+cp .env.example .env
+make build
+make compose
+
+```
+While docker is running, in a new terminal:
+```
+cd lake
+./lake
+```
+
+Then you can make a POST request:
+```
+curl --location --request POST 'localhost:8080/source' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "Plugin": "Jira",
+    "Options": {}
+    
+}'
 ```
 
 ### Makefile
@@ -37,3 +50,8 @@ We use https://github.com/lintingzhen/commitizen-go to author our commits.
 
 Then you can run:
 `make commit`
+
+### How to run the tests
+
+You can see a sample test in /test/example
+You can run the tests with `make test`

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       - 3306:3306
     platform: linux/x86_64
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: lake_db
-      MYSQL_USER: mysql
+      MYSQL_ROOT_PASSWORD: admin
+      MYSQL_DATABASE: lake
+      MYSQL_USER: root
       MYSQL_PASSWORD: root
   redis:
     image: redis:6


### PR DESCRIPTION
# Summary

- Better notes in README.md and update the db name.
- update of the .env.sample
- update DB name in the docker/compose file

### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

### Description
This is needed to run the api locally