### PR TITLE
Feat/add pokemon plugin

### DIFF
--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -127,11 +126,11 @@ func (apiClient *ApiClient) Get(
 	return apiClient.Do("GET", path, query, nil, headers)
 }
 
+// UnmarshalResponse - Uses the built in json decoder to
+// decode the response Body into the provided object
+// This saves us having to conver the io.Reader into
+// a []byte.
 func UnmarshalResponse(res *http.Response, v interface{}) error {
 	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(resBody, &v)
+	return json.NewDecoder(res.Body).Decode(v)
 }

--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestStruct - our JSON unmarshalling struct
+type TestStruct struct {
+	Name string
+	Age  int `json:"realAge"`
+}
+
+// TestRunner - struct we can keep updating with new test arguments
+type TestRunner struct {
+	Container *TestStruct
+	Response  *http.Response
+}
+
+// updateArgs - Updates the arguments for the next test run
+func (tr *TestRunner) updateArgs(newTestInput string) {
+	tr.Response.Body = io.NopCloser(strings.NewReader(newTestInput))
+	tr.Container = &TestStruct{}
+}
+
+// TestUnmarshalResponse - Tests for UnmarshalResponse
+// Since UnmarshalResponse basically just wraps the built-in java decoder
+// this test is not super necessary. That being said, it's good to have
+// in case we decide to change the implementation of UnmarshalResponse
+// in the future
+func TestUnmarshalResponse(t *testing.T) {
+
+	tr := &TestRunner{
+		Container: &TestStruct{},
+		Response:  &http.Response{},
+	}
+
+	// Try with valid JSON, we shouldn't get an error
+	tr.updateArgs(`{"Name": "Jane"}`)
+	err := UnmarshalResponse(tr.Response, tr.Container)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// Try with invalid JSON, we should get an error
+	tr.updateArgs(`{"Name": "}`)
+	err = UnmarshalResponse(tr.Response, tr.Container)
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	// Try with empty string, should fail
+	tr.updateArgs(``)
+	err = UnmarshalResponse(tr.Response, tr.Container)
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	// Try with second value in json object
+	tr.updateArgs(`{"Name": "Jane", "realAge": 30}`)
+	err = UnmarshalResponse(tr.Response, tr.Container)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if tr.Container.Age != 30 {
+		t.Errorf("Age is not %d", 30)
+	}
+}

--- a/plugins/pokemon/README.md
+++ b/plugins/pokemon/README.md
@@ -1,0 +1,13 @@
+# Pokemon Pond
+
+## Plan
+
+1. Get the plugin boilerplate in
+1. Write the pokemon model
+   - what attributes do we want to store in the model?
+1. Write pokemon collect task
+   - Do we want to query for every pokemon every time we run this? We could query for what we have locally and only get what's missing. e.g. in the case where there's new pokemon. Or we can
+1. Write item collect task
+   - this should query for the pokemon locally, and then query the pokemon API for their items
+   - plan for now is to update the pokemon model with a cost attribute
+1. Write some tests

--- a/plugins/pokemon/init.go
+++ b/plugins/pokemon/init.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/merico-dev/lake/models"
+	pok "github.com/merico-dev/lake/plugins/pokemon/models"
+)
+
+func (plugin Pokemon) Init() {
+	err := models.Db.AutoMigrate(&pok.Pokemon{})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/plugins/pokemon/models/pokemon.go
+++ b/plugins/pokemon/models/pokemon.go
@@ -1,0 +1,14 @@
+package models
+
+type Pokemon struct {
+	PID        uint `gorm:"primary_key"`
+	Name string `json:"name"`
+	URL string `json:"url"`
+}
+
+type PokemonCollection struct {
+	Count int
+	Next string
+	Previous string
+	Results []*Pokemon
+}

--- a/plugins/pokemon/pokemon.go
+++ b/plugins/pokemon/pokemon.go
@@ -1,0 +1,36 @@
+package main // must be main for plugin entry point
+
+import (
+	"time"
+
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/plugins/pokemon/tasks"
+)
+
+// A pseudo type for Plugin Interface implementation
+type Pokemon string
+
+func (plugin Pokemon) Description() string {
+	return "To collect and enrich data from https://pokeapi.co/"
+}
+
+func (plugin Pokemon) Execute(options map[string]interface{}, progress chan<- float32) {
+
+	err := tasks.CollectAllPokemon()
+
+	if err != nil {
+		logger.Error("Something went wrong: ", err.Error())
+	}
+
+	time.Sleep(1 * time.Second)
+	progress <- 0.1
+	time.Sleep(1 * time.Second)
+	progress <- 0.5
+	time.Sleep(1 * time.Second)
+	progress <- 1
+	logger.Print("end pokemon plugin execution")
+	close(progress)
+}
+
+// Export a variable named PluginEntry for Framework to search and load
+var PluginEntry Pokemon //nolint

--- a/plugins/pokemon/pokemon_test.go
+++ b/plugins/pokemon/pokemon_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestExecut(t *testing.T) {
+	opts := make(map[string]interface{})
+	progress := make(chan float32)
+
+	PluginEntry.Init()
+	go PluginEntry.Execute(opts, progress)
+	<-progress
+}

--- a/plugins/pokemon/tasks/pokemoncollector.go
+++ b/plugins/pokemon/tasks/pokemoncollector.go
@@ -1,0 +1,76 @@
+package tasks
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+
+	"github.com/merico-dev/lake/plugins/core"
+	pok "github.com/merico-dev/lake/plugins/pokemon/models"
+)
+
+// getQuery - returns the query parameters given a full URL
+func getQuery(fullURL string) (url.Values, error) {
+	parsedURL, err := url.Parse(fullURL)
+	if err != nil {
+		return map[string][]string{}, err
+	}
+
+	return url.ParseQuery(parsedURL.RawQuery)
+}
+
+func CollectAllPokemon() error {
+	pokemonClient := core.NewApiClient(
+		"https://pokeapi.co/api/v2/",
+		nil,
+		10*time.Second,
+		3,
+	)
+
+	var query url.Values
+
+	// loop through and get all the pokemon
+	for {
+		pokemonColl := &pok.PokemonCollection{}
+		logger.Debug("Fetching pokemon with query params: ", query)
+
+		res, err := pokemonClient.Get("/pokemon", &query, nil)
+		if err != nil {
+			return err
+		}
+
+		err = core.UnmarshalResponse(res, pokemonColl)
+		if err != nil {
+			logger.Error("Error unmarshalling pokemon response: ", err)
+			return nil
+		}
+
+		for _, pkmon := range pokemonColl.Results {
+			err = lakeModels.Db.Save(pkmon).Error
+			if err != nil {
+				logger.Error("Error saving pokemon: ", err)
+			}
+		}
+
+		query, err = getQuery(pokemonColl.Next)
+
+		// in the event of an error or when we have no 
+		// query params, break out of the loop
+		if err != nil || len(query) == 0 {
+			break
+		}
+
+		// when we have no more next, break
+		if pokemonColl.Next == "" {
+			break
+		}
+		
+		// primitive rate limitting so we don't hammer the API
+		<-time.After(1 * time.Second)
+
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Summary

<!--
Adding a pokemon plugin to the go codebase. The code will query for all available pokemon, and store some attributes in a mysql database.

Also including a small refactor to the UnmarshalResponse function in plugins.core.
-->

### Description
Adding the pokemon pond plugin, as well as a small refactor to UnmarshalResponse. 
UnmarshalResponse was using `io.ReadAll()` and `json.Unmarshall()`. json has a way of unmarshalling data without converting to a `[]byte`. Updated `UnmarshalResponse` to use the built in java.Decoder.

### New Behavior
New pokemon pond plugin is available for ingesting pokemon data.

### Other Information
I was thinking it might be nice to introduce some interfaces around the database and http client objects. It will make it easier to change implementations in the future, as well as give us an easy way to stub them out in the unit tests.