### PR TITLE
Gitlab collection - Merge Requests, Reviewers and Notes

### DIFF
--- a/models/base.go
+++ b/models/base.go
@@ -9,7 +9,6 @@ type Model struct {
 }
 
 type NoPKModel struct {
-	Status    int
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time

--- a/models/base.go
+++ b/models/base.go
@@ -7,3 +7,10 @@ type Model struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
+
+type NoPKModel struct {
+	Status    int
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+}

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -38,6 +38,11 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 		return
 	}
 
+	mergeRequestErr := tasks.CollectMergeRequests(projectIdInt)
+	if mergeRequestErr != nil {
+		logger.Error("Could not collect merge requests: ", mergeRequestErr)
+		return
+	}
 	progress <- 1
 
 	close(progress)

--- a/plugins/gitlab/init.go
+++ b/plugins/gitlab/init.go
@@ -8,7 +8,12 @@ import (
 
 func (plugin Gitlab) Init() {
 	logger.Info("INFO >>> init go plugin", true)
-	err := lakeModels.Db.AutoMigrate(&models.GitlabCommit{}, &models.GitlabProject{}, &models.GitlabMergeRequest{}, &models.GitlabReviewer{})
+	err := lakeModels.Db.AutoMigrate(
+		&models.GitlabCommit{},
+		&models.GitlabProject{},
+		&models.GitlabMergeRequest{},
+		&models.GitlabReviewer{},
+		&models.GitlabMergeRequestNote{})
 	if err != nil {
 		logger.Error("Error migrating gitlab: ", err)
 		panic(err)

--- a/plugins/gitlab/init.go
+++ b/plugins/gitlab/init.go
@@ -8,7 +8,7 @@ import (
 
 func (plugin Gitlab) Init() {
 	logger.Info("INFO >>> init go plugin", true)
-	err := lakeModels.Db.AutoMigrate(&models.GitlabCommit{}, &models.GitlabProject{})
+	err := lakeModels.Db.AutoMigrate(&models.GitlabCommit{}, &models.GitlabProject{}, &models.GitlabMergeRequest{}, &models.GitlabReviewer{})
 	if err != nil {
 		logger.Error("Error migrating gitlab: ", err)
 		panic(err)

--- a/plugins/gitlab/models/gitlabMergeRequest.go
+++ b/plugins/gitlab/models/gitlabMergeRequest.go
@@ -6,6 +6,7 @@ import (
 
 type GitlabMergeRequest struct {
 	GitlabId         int `gorm:"primary_key"`
+	Iid              int
 	ProjectId        int
 	State            string
 	Title            string

--- a/plugins/gitlab/models/gitlabMergeRequest.go
+++ b/plugins/gitlab/models/gitlabMergeRequest.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"github.com/merico-dev/lake/models"
+)
+
+type GitlabMergeRequest struct {
+	GitlabId         int `gorm:"primary_key"`
+	ProjectId        int
+	State            string
+	Title            string
+	WebUrl           string
+	UserNotesCount   int
+	WorkInProgress   bool
+	SourceBranch     string
+	MergedAt         string
+	GitlabCreatedAt  string
+	ClosedAt         string
+	MergedByUsername string
+	Description      string
+	AuthorUsername   string
+
+	models.NoPKModel
+}

--- a/plugins/gitlab/models/gitlabMergeRequestNote.go
+++ b/plugins/gitlab/models/gitlabMergeRequestNote.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"github.com/merico-dev/lake/models"
+)
+
+type GitlabMergeRequestNote struct {
+	GitlabId        int `gorm:"primary_key"`
+	NoteableId      int
+	NoteableIid     int
+	NoteableType    string
+	AuthorUsername  string
+	Body            string
+	GitlabCreatedAt string
+	Confidential    bool
+
+	models.NoPKModel
+}

--- a/plugins/gitlab/models/gitlabReviewers.go
+++ b/plugins/gitlab/models/gitlabReviewers.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"github.com/merico-dev/lake/models"
+)
+
+type GitlabReviewer struct {
+	GitlabId       int `gorm:"primary_key"`
+	MergeRequestId int
+	Name           string
+	Username       string
+	State          string
+	AvatarUrl      string
+	WebUrl         string
+	models.NoPKModel
+}

--- a/plugins/gitlab/models/gitlabcommit.go
+++ b/plugins/gitlab/models/gitlabcommit.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"time"
+	"github.com/merico-dev/lake/models"
 )
 
 type GitlabCommit struct {
@@ -20,8 +20,5 @@ type GitlabCommit struct {
 	Additions      int
 	Deletions      int
 	Total          int
-	Status         int
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	DeletedAt      *time.Time
+	models.NoPKModel
 }

--- a/plugins/gitlab/models/gitlabproject.go
+++ b/plugins/gitlab/models/gitlabproject.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/merico-dev/lake/models"
+
 type GitlabProject struct {
 	GitlabId          int `gorm:"primary_key"`
 	Name              string
@@ -8,4 +10,6 @@ type GitlabProject struct {
 	Visibility        string
 	OpenIssuesCount   int
 	StarCount         int
+
+	models.NoPKModel
 }

--- a/plugins/gitlab/tasks/gitlabMergeRequestCollector.go
+++ b/plugins/gitlab/tasks/gitlabMergeRequestCollector.go
@@ -1,0 +1,84 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/gitlab/models"
+	"gorm.io/gorm/clause"
+)
+
+type ApiMergeRequestResponse []struct {
+	GitlabId        int `json:"id"`
+	ProjectId       int `json:"project_id"`
+	State           string
+	Title           string
+	Description     string
+	WebUrl          string `json:"web_url"`
+	UserNotesCount  int    `json:"user_notes_count"`
+	WorkInProgress  bool   `json:"work_in_progress"`
+	SourceBranch    string `json:"source_branch"`
+	MergedAt        string `json:"merged_at"`
+	GitlabCreatedAt string `json:"created_at"`
+	ClosedAt        string `json:"closed_at"`
+	MergedBy        struct {
+		Username string `json:"username"`
+	} `json:"merged_by"`
+	Author struct {
+		Username string `json:"username"`
+	}
+	Reviewers []Reviewer
+}
+
+func CollectMergeRequests(projectId int) error {
+	gitlabApiClient := CreateApiClient()
+
+	res, err := gitlabApiClient.Get(fmt.Sprintf("projects/%v/merge_requests", projectId), nil, nil)
+	if err != nil {
+		return err
+	}
+
+	gitlabApiResponse := &ApiMergeRequestResponse{}
+
+	logger.Info("res", res)
+
+	err = core.UnmarshalResponse(res, gitlabApiResponse)
+
+	if err != nil {
+		logger.Error("Error: ", err)
+		return nil
+	}
+
+	for _, mr := range *gitlabApiResponse {
+		gitlabMergeRequest := &models.GitlabMergeRequest{
+			GitlabId:         mr.GitlabId,
+			ProjectId:        mr.ProjectId,
+			State:            mr.State,
+			Title:            mr.Title,
+			Description:      mr.Description,
+			WebUrl:           mr.WebUrl,
+			UserNotesCount:   mr.UserNotesCount,
+			WorkInProgress:   mr.WorkInProgress,
+			SourceBranch:     mr.SourceBranch,
+			MergedAt:         mr.MergedAt,
+			GitlabCreatedAt:  mr.GitlabCreatedAt,
+			ClosedAt:         mr.ClosedAt,
+			MergedByUsername: mr.MergedBy.Username,
+			AuthorUsername:   mr.Author.Username,
+		}
+
+		err = lakeModels.Db.Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).Create(&gitlabMergeRequest).Error
+
+		if err != nil {
+			logger.Error("Could not upsert: ", err)
+		}
+
+		CreateReviewers(mr.GitlabId, mr.Reviewers)
+	}
+
+	return nil
+}

--- a/plugins/gitlab/tasks/gitlabMergeRequestCollector.go
+++ b/plugins/gitlab/tasks/gitlabMergeRequestCollector.go
@@ -12,6 +12,7 @@ import (
 
 type ApiMergeRequestResponse []struct {
 	GitlabId        int `json:"id"`
+	Iid             int
 	ProjectId       int `json:"project_id"`
 	State           string
 	Title           string
@@ -54,6 +55,7 @@ func CollectMergeRequests(projectId int) error {
 	for _, mr := range *gitlabApiResponse {
 		gitlabMergeRequest := &models.GitlabMergeRequest{
 			GitlabId:         mr.GitlabId,
+			Iid:              mr.Iid,
 			ProjectId:        mr.ProjectId,
 			State:            mr.State,
 			Title:            mr.Title,
@@ -78,6 +80,12 @@ func CollectMergeRequests(projectId int) error {
 		}
 
 		CreateReviewers(mr.GitlabId, mr.Reviewers)
+
+		collectErr := CollectMergeRequestNotes(projectId, gitlabApiResponse)
+
+		if collectErr != nil {
+			logger.Error("Could not collect MR Notes", collectErr)
+		}
 	}
 
 	return nil

--- a/plugins/gitlab/tasks/gitlabMergeRequestNote.go
+++ b/plugins/gitlab/tasks/gitlabMergeRequestNote.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/gitlab/models"
+	"gorm.io/gorm/clause"
+)
+
+type ApiMergeRequestNoteResponse []struct {
+	GitlabId        int    `json:"id"`
+	NoteableId      int    `json:"noteable_id"`
+	NoteableIid     int    `json:"noteable_iid"`
+	NoteableType    string `json:"noteable_type"`
+	Body            string
+	GitlabCreatedAt string `json:"created_at"`
+	Confidential    bool
+	Author          struct {
+		Username string `json:"username"`
+	}
+}
+
+func CollectMergeRequestNotes(projectId int, mrResponse *ApiMergeRequestResponse) error {
+	gitlabApiClient := CreateApiClient()
+
+	for _, mr := range *mrResponse {
+		getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/notes?system=false", projectId, mr.Iid)
+		logger.Info("get URL: ", getUrl)
+		res, err := gitlabApiClient.Get(getUrl, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		gitlabApiResponse := &ApiMergeRequestNoteResponse{}
+
+		logger.Info("res", res)
+
+		err = core.UnmarshalResponse(res, gitlabApiResponse)
+
+		if err != nil {
+			logger.Error("Error: ", err)
+			return nil
+		}
+
+		for _, mrNote := range *gitlabApiResponse {
+			gitlabMergeRequestNote := &models.GitlabMergeRequestNote{
+				GitlabId:        mrNote.GitlabId,
+				NoteableId:      mrNote.NoteableId,
+				NoteableIid:     mrNote.NoteableIid,
+				NoteableType:    mrNote.NoteableType,
+				AuthorUsername:  mrNote.Author.Username,
+				Body:            mrNote.Body,
+				GitlabCreatedAt: mrNote.GitlabCreatedAt,
+				Confidential:    mrNote.Confidential,
+			}
+
+			err = lakeModels.Db.Clauses(clause.OnConflict{
+				UpdateAll: true,
+			}).Create(&gitlabMergeRequestNote).Error
+
+			if err != nil {
+				logger.Error("Could not upsert: ", err)
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/plugins/gitlab/tasks/gitlabMergeRequestReviewer.go
+++ b/plugins/gitlab/tasks/gitlabMergeRequestReviewer.go
@@ -1,0 +1,40 @@
+package tasks
+
+import (
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/gitlab/models"
+	"gorm.io/gorm/clause"
+)
+
+type Reviewer struct {
+	GitlabId       int `json:"id"`
+	MergeRequestId int
+	Name           string
+	Username       string
+	State          string
+	AvatarUrl      string `json:"avatar_url"`
+	WebUrl         string `json:"web_url"`
+}
+
+func CreateReviewers(mergeRequestId int, reviewers []Reviewer) {
+	for _, reviewer := range reviewers {
+
+		gitlabReviewer := &models.GitlabReviewer{
+			GitlabId:       reviewer.GitlabId,
+			MergeRequestId: mergeRequestId,
+			Username:       reviewer.Username,
+			Name:           reviewer.Name,
+			State:          reviewer.State,
+			AvatarUrl:      reviewer.AvatarUrl,
+			WebUrl:         reviewer.WebUrl,
+		}
+		err := lakeModels.Db.Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).Create(&gitlabReviewer).Error
+
+		if err != nil {
+			logger.Error("Could not upsert: ", err)
+		}
+	}
+}


### PR DESCRIPTION

### Description

This PR adds collection to the GitLab Plugin:
- Merge Request
- Merge Request Notes
- Merge Request Reviewers

### Does this close any open issues?
Yes. It closes this issue: https://github.com/merico-dev/lake/issues/309

### Current Behavior
GitLab Plugin did not collect all fields needed for metrics from GitLab API.

### New Behavior
We are now getting the data we need from GitLab API.

### Screenshots
Notes in the DB:

![image](https://user-images.githubusercontent.com/27032263/131706665-a9a51764-4e7d-473b-a040-1d839db9237c.png)


