### PR TITLE
fix: updated_at field could not be updated correctly

### DIFF
--- a/models/base.go
+++ b/models/base.go
@@ -4,6 +4,6 @@ import "time"
 
 type Model struct {
 	ID        uint64    `gorm:"primary_key"`
-	CreatedAt time.Time `gorm:"<-:create"`
-	UpdatedAt time.Time `gorm:"<-:update"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing](../CONTRIBUTING.md) Documentation
- [ ] This PR is using a `label` (bug, feature etc.)
- [ ] My code is has necessary documentation (if appropriate)
- [ ] I have added any relevant tests
- [ ] This section (**⚠️ &nbsp;&nbsp;Pre Checklist**) will be removed when submitting PR

# Summary

tag of gorm ``` 'gorm:"<-update"' ``` means this field could not be set in update query,  that would make gorm could. not set updated_at field automatic in creation and update.

https://gorm.io/docs/models.html#Conventions

GORM defined a gorm.Model struct, which includes fields ID, CreatedAt, UpdatedAt, DeletedAt

```
// gorm.Model definition
type Model struct 
  ID        uint           `gorm:"primaryKey"` 
  CreatedAt time.Time  
  UpdatedAt time.Time  
  DeletedAt gorm.DeletedAt `gorm:"index"`
}
```

these fields in gorm have default implement

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Please mention the issues here.

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
