### PR TITLE
feat: allow post to task with many tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ MODE=debug
 
 # Jira configuration
 JIRA_ENDPOINT=https://merico.atlassian.net/rest
+# ex: echo -n <jira login email>:<jira token> | base64
 JIRA_BASIC_AUTH_ENCODED=emhl..........................................a0QzQUE=
 JIRA_ISSUE_EPIC_KEY_FIELD=customfield_10014
 JIRA_WORKLOAD_COEFFICIENT=1

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ All the details on provisioning, and customizing a dashboard can be found in the
     ```
     curl --location --request POST 'localhost:8080/task' \
     --header 'Content-Type: application/json' \
-    --data-raw '{
+    --data-raw '[{
         "Plugin": "jira",
         "Options": {
             "boardId": 8
         }
-    }'
+    }]'
     ```
 
 7. Collect & enrich data from selected sources and plugins
@@ -122,11 +122,11 @@ All the details on provisioning, and customizing a dashboard can be found in the
     ```sh
     curl --location --request POST 'localhost:8080/source' \
     --header 'Content-Type: application/json' \
-    --data-raw '{
+    --data-raw '[{
         "Plugin": "Jira",
         "Options": {}
 
-    }'
+    }]'
     ```
 
 8. Visualize the data in the Grafana Dashboard

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -5,20 +5,31 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/services"
 )
 
 func Post(ctx *gin.Context) {
-	var data services.NewTask
+	var data []services.NewTask
+
 	err := ctx.MustBindWith(&data, binding.JSON)
 	if err != nil {
-		_ = ctx.AbortWithError(http.StatusBadRequest, err)
+		logger.Error("", err)
+		ctx.JSON(http.StatusBadRequest, "You must send down an array of objects")
 		return
 	}
-	task, err := services.CreateTask(data)
-	if err != nil {
-		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
+
+	tasks := make([]models.Task, len(data))
+
+	for _, value := range data {
+		task, err := services.CreateTask(value)
+		if err != nil {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+		tasks = append(tasks, *task)
 	}
-	ctx.JSON(http.StatusCreated, task)
+
+	ctx.JSON(http.StatusCreated, tasks)
 }

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -20,7 +20,7 @@ func Post(ctx *gin.Context) {
 		return
 	}
 
-	tasks := make([]models.Task, len(data))
+	var tasks []models.Task
 
 	for _, value := range data {
 		task, err := services.CreateTask(value)

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -17,16 +17,16 @@ func TestNewTask(t *testing.T) {
 	api.RegisterRouter(r)
 
 	w := httptest.NewRecorder()
-	params := strings.NewReader(`{ "plugin": "jira", "options": { "host": "www.jira.com" } }`)
+	params := strings.NewReader(`[{ "plugin": "jira", "options": { "host": "www.jira.com" } }]`)
 	req, _ := http.NewRequest("POST", "/task", params)
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, w.Code, http.StatusCreated)
 	resp := w.Body.String()
-	task, err := utils.JsonToMap(resp)
+	tasks, err := utils.JsonToMap(resp)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, task["Plugin"], "jira")
+	assert.Equal(t, tasks[1]["Plugin"], "jira")
 }

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -28,5 +28,5 @@ func TestNewTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, tasks[1]["Plugin"], "jira")
+	assert.Equal(t, tasks[0]["Plugin"], "jira")
 }

--- a/utils/json.go
+++ b/utils/json.go
@@ -2,8 +2,8 @@ package utils
 
 import "encoding/json"
 
-func JsonToMap(jsonString string) (map[string]interface{}, error) {
-	m := make(map[string]interface{})
+func JsonToMap(jsonString string) ([]map[string]interface{}, error) {
+	m := make([]map[string]interface{}, 999)
 	err := json.Unmarshal([]byte(jsonString), &m)
 	return m, err
 }


### PR DESCRIPTION

# Summary

Users need to be able to query many tasks at once with the api

IE:

```
curl --location --request POST 'localhost:8080/task' \
--header 'Content-Type: application/json' \
--data-raw '[
    {
        "Plugin": "gitlab",
        "Options": {
            "projectId": 20103385
        }
    },
    {
        "Plugin": "jira",
        "Options": {
            "boardId": 8
        }
    }
]'
```

NOTE: This means you will have to send down an array of json objects. Otherwise, you get this error:

<img width="1176" alt="Screen Shot 2021-09-02 at 10 51 07 AM" src="https://user-images.githubusercontent.com/3011407/131856430-cb40661a-bc7d-44db-8b8f-0ad23194d69b.png">


### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

<img width="691" alt="Screen Shot 2021-09-02 at 10 55 11 AM" src="https://user-images.githubusercontent.com/3011407/131856480-bf90fe2d-4634-4da3-9a5e-01b42a9d5db4.png">
