### PR TITLE
docs: add user setup in readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM golang:latest as builder
+FROM alpine:edge as builder
+RUN apk update
+RUN apk upgrade
+RUN apk add --update go=1.16.7-r0 gcc=10.3.1_git20210625-r1 g++=10.3.1_git20210625-r1
 
-COPY . /go/src/lake
+WORKDIR /app
+COPY . /app
 
-WORKDIR /go/src/lake
-RUN go build -o lake && sh scripts/compile-plugins.sh
+RUN CGO_ENABLE=1 GOOS=linux go build -o lake && sh scripts/compile-plugins.sh
 
-FROM alpine
+FROM alpine:edge
 EXPOSE 8080
-RUN apk add --no-cache git make build-base
-COPY --from=builder /go/src/lake/lake /bin/app/lake
-COPY --from=builder /go/src/lake/plugins/ /bin/app/plugins
+COPY --from=builder /app/lake /bin/app/lake
+COPY --from=builder /app/plugins/ /bin/app/plugins
 
 WORKDIR /bin/app
 CMD ["/bin/sh", "-c", "./lake"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:latest as builder
+
+COPY . /go/src/lake
+
+WORKDIR /go/src/lake
+RUN go build -o lake && sh scripts/compile-plugins.sh
+
+FROM alpine
+EXPOSE 8080
+RUN apk add --no-cache git make build-base
+COPY --from=builder /go/src/lake/lake /bin/app/lake
+COPY --from=builder /go/src/lake/plugins/ /bin/app/plugins
+
+WORKDIR /bin/app
+CMD ["/bin/sh", "-c", "./lake"]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ docker-compose -f ./devops/docker-compose.yml --project-directory ./ up -d
 docker-compose -f ./devops/docker-compose.yml --project-directory ./ ps
 ```
 
-5. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body.
+5. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)  
 ```shell
 curl --location --request POST 'localhost:8080/task' \
 --header 'Content-Type: application/json' \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,71 @@ All the details on provisioning, and customizing a dashboard can be found in the
   - Windows: [Download](http://gnuwin32.sourceforge.net/packages/make.htm)
   - Ubuntu: `sudo apt-get install build-essential`
 
-## Setup<a id="setup"></a>
+## User setup
+
+**NOTE: If you only plan to run the product, this is the only section you should need**
+**NOTE: Commands written `like this` are to be run in your terminal**
+
+### Required Packages to Install<a id="requirements"></a>
+
+- <a href="https://docs.docker.com/get-docker" target="_blank">Docker</a>
+
+**NOTE:** After installing docker, you may need to run the docker application and restart your terminal
+
+### Commands to run in your terminal
+
+1. Navigate to where you would like to install this project and clone the repository  
+```shell
+# TODO: should change default branch to go-main
+git clone https://github.com/merico-dev/lake.git
+cd lake
+```
+
+2. Copy an `.env` file from `.env.example`
+```shell
+cp .env.example .env
+```
+
+3. Fill the values in `Jira`, `Gitlab` and `Jenkins` sections with your deployments.
+```shell
+vi .env
+```
+
+4. Start the services and check services' status
+```shell
+# start all services
+docker-compose -f ./devops/docker-compose.yml --project-directory ./ up -d
+# check service status 
+docker-compose -f ./devops/docker-compose.yml --project-directory ./ ps
+```
+
+5. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body.
+```shell
+curl --location --request POST 'localhost:8080/task' \
+--header 'Content-Type: application/json' \
+--data-raw '[
+    {
+        "Plugin": "gitlab",
+        "Options": {
+            "projectId": 20103385
+        }
+    },
+    {
+        "Plugin": "jira",
+        "Options": {
+            "boardId": 8
+        }
+    },
+    {
+        "Plugin": "jenkins",
+        "Options": {}
+    }
+]'
+```
+
+6. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
+
+## Development Setup<a id="setup"></a>
 
 1. Navigate to where you would like to install this project and clone the repository
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ All the details on provisioning, and customizing a dashboard can be found in the
   - Windows: [Download](http://gnuwin32.sourceforge.net/packages/make.htm)
   - Ubuntu: `sudo apt-get install build-essential`
 
-## User setup
+## User setup<a id="user-setup"></a>
 
 **NOTE: If you only plan to run the product, this is the only section you should need**
 **NOTE: Commands written `like this` are to be run in your terminal**
 
-### Required Packages to Install<a id="requirements"></a>
+### Required Packages to Install<a id="user-setup-requirements"></a>
 
 - <a href="https://docs.docker.com/get-docker" target="_blank">Docker</a>
 
 **NOTE:** After installing docker, you may need to run the docker application and restart your terminal
 
-### Commands to run in your terminal
+### Commands to run in your terminal<a id="user-setup-commands"></a>
 
 1. Navigate to where you would like to install this project and clone the repository  
 ```shell
@@ -133,7 +133,7 @@ curl --location --request POST 'localhost:8080/task' \
 
 6. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
 
-## Development Setup<a id="setup"></a>
+## Development Setup<a id="development-setup"></a>
 
 1. Navigate to where you would like to install this project and clone the repository
 
@@ -218,7 +218,7 @@ Sample tests can be found in `/test/example`
 
 To run the tests: `make test`
 
-  ## Contributing
+## Contributing
 
 [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ cp .env.example .env
 ```
 
 3. Fill the values in `Jira`, `Gitlab` and `Jenkins` sections with your deployments.
-```shell
-vi .env
-```
+> For more info on how to configure plugins, please refer to the [data source plugins](#data-source-plugins) section
+
+> TODO: ~~To map a custom status for a plugin refer to /config/plugins.js
+Ex: In Jira, if you're using Rejected as a Bug type, refer to the statusMappings sections for issues mapped to "Bug"
+All statusMappings contain 2 objects. an open status (first object), and a closed status (second object)~~
 
 4. Start the services and check services' status
 ```shell
@@ -101,6 +103,8 @@ vi .env
 docker-compose -f ./devops/docker-compose.yml --project-directory ./ up -d
 # check service status 
 docker-compose -f ./devops/docker-compose.yml --project-directory ./ ps
+# stop all services
+# docker-compose -f ./devops/docker-compose.yml --project-directory ./ down -d
 ```
 
 5. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)  

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: always
     ports:
       - 127.0.0.1:3306:3306
-    platform: linux/x86_64
+    # platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_DATABASE: lake
@@ -30,6 +30,13 @@ services:
       - ./grafana/img/grafana_icon.svg:/usr/share/grafana/public/img/grafana_icon.svg:rw
     env_file:
       - ./grafana/grafana.config
+    restart: always
+  lake:
+    image: go-lake
+    ports:
+      - 127.0.0.1:8080:8080
+    env_file:
+      - ./.env
     restart: always
 volumes:
   mysql-storage: {}

--- a/devops/docker-compose.yml
+++ b/devops/docker-compose.yml
@@ -1,4 +1,3 @@
-
 version: "3"
 services:
   mysql:
@@ -14,10 +13,10 @@ services:
       MYSQL_DATABASE: lake
       MYSQL_USER: merico
       MYSQL_PASSWORD: merico
-  redis:
-    image: redis:6
-    ports:
-      - 127.0.0.1:6379:6379
+  # redis:
+  #   image: redis:6
+  #   ports:
+  #     - 127.0.0.1:6379:6379
   grafana:
     hostname: grafana
     image: grafana/grafana:8.0.6
@@ -32,7 +31,8 @@ services:
       - ./grafana/grafana.config
     restart: always
   lake:
-    image: go-lake
+    # TODO: change it to lake official image when ready
+    image: narrowizard/lake 
     ports:
       - 127.0.0.1:8080:8080
     env_file:


### PR DESCRIPTION
# Summary
Add user setup section in README.md and setup docker quick start.

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
Notice: 
- This PR depend on #330 
- Finish all `TODOs` before merge

TODOs:
- [ ] Switch lake's default branch to go-main (this is not required before merge)
- [x] Finish jira status map design and develop @klesh 
- [ ] Update document for jira status map (in `Commands to run in your terminal` section)
- [ ] Register a docker hub account for lake @hezyin 
- [ ] Build and push lake image to docker hub
- [ ] Update `devops/docker-compose.yml#L35`, using official image.
- [ ] Check if the document in this PR is readable. @joncodo 

### Build and push lake image to docker hub
```shell
docker build -t ${docker hub account}/lake:${version} .
docker login
docker push ${docker hub account}/lake:${version}
```