### PR TITLE
feat: adds FirstCommentTime to GL MRs

### DIFF
--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -32,12 +32,12 @@ To collect data, you can make a POST request to `/task`
     ```
     curl --location --request POST 'localhost:8080/task' \
     --header 'Content-Type: application/json' \
-    --data-raw '{
+    --data-raw '[{
         "Plugin": "gitlab",
         "Options": {
             "projectId": <Your gitlab project id>
         }
-    }'
+    }]'
     ```
 
 ## Finding Project Id

--- a/plugins/gitlab/models/gitlab_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request.go
@@ -21,6 +21,7 @@ type GitlabMergeRequest struct {
 	MergedByUsername string
 	Description      string
 	AuthorUsername   string
+	FirstCommentTime string
 
 	models.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_note.go
+++ b/plugins/gitlab/models/gitlab_merge_request_note.go
@@ -14,6 +14,7 @@ type GitlabMergeRequestNote struct {
 	Body            string
 	GitlabCreatedAt string
 	Confidential    bool
+	Resolvable      bool // Resolvable means a comment is a code review comment
 
 	models.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_note.go
+++ b/plugins/gitlab/models/gitlab_merge_request_note.go
@@ -15,6 +15,7 @@ type GitlabMergeRequestNote struct {
 	GitlabCreatedAt string
 	Confidential    bool
 	Resolvable      bool // Resolvable means a comment is a code review comment
+	System          bool // System means the comment is generated automatically
 
 	models.NoPKModel
 }

--- a/plugins/gitlab/tasks/gitlab_merge_request_collector.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_collector.go
@@ -77,7 +77,7 @@ func CollectMergeRequests(projectId int) error {
 
 				CreateReviewers(mr.GitlabId, mr.Reviewers)
 
-				collectErr := CollectMergeRequestNotes(projectId, mr.Iid)
+				collectErr := CollectMergeRequestNotes(projectId, gitlabMergeRequest)
 
 				if collectErr != nil {
 					logger.Error("Could not collect MR Notes", collectErr)

--- a/plugins/gitlab/tasks/gitlab_merge_request_note.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_note.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -11,7 +12,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-type ApiMergeRequestNoteResponse []struct {
+type MergeRequestNote struct {
 	GitlabId        int    `json:"id"`
 	NoteableId      int    `json:"noteable_id"`
 	MergeRequestIid int    `json:"noteable_iid"`
@@ -23,11 +24,49 @@ type ApiMergeRequestNoteResponse []struct {
 		Username string `json:"username"`
 	}
 }
+type ApiMergeRequestNoteResponse []MergeRequestNote
 
-func CollectMergeRequestNotes(projectId int, mrId int) error {
+func FindEarliestNote(notes *ApiMergeRequestNoteResponse) (*MergeRequestNote, error) {
+	var earliestNote *MergeRequestNote
+
+	earliestTime := time.Now()
+	for _, note := range *notes {
+		noteTime, parseErr := time.Parse(time.RFC3339, note.GitlabCreatedAt)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		if noteTime.Before(earliestTime) {
+			earliestTime = noteTime
+			earliestNote = &note
+		}
+	}
+	return earliestNote, nil
+}
+
+// we need a metric that measures a merge request duration as the time from first comment to MR close
+func updateMergeRequestWithFirstCommentTime(notes *ApiMergeRequestNoteResponse, mr *models.GitlabMergeRequest) error {
+	earliestNote, err := FindEarliestNote(notes)
+	if err != nil {
+		return err
+	}
+	if earliestNote != nil {
+		mr.FirstCommentTime = earliestNote.GitlabCreatedAt
+
+		err = lakeModels.Db.Model(&mr).Where("gitlab_id = ?", mr.GitlabId).Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).Update("FirstCommentTime", mr.FirstCommentTime).Error
+
+		if err != nil {
+			logger.Error("Could not upsert: ", err)
+			return err
+		}
+	}
+	return nil
+}
+func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest) error {
 	gitlabApiClient := CreateApiClient()
 
-	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/notes?system=false", projectId, mrId)
+	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/notes?system=false", projectId, mr.Iid)
 	return gitlabApiClient.FetchWithPaginationAnts(getUrl, "100",
 		func(res *http.Response) error {
 
@@ -59,6 +98,10 @@ func CollectMergeRequestNotes(projectId int, mrId int) error {
 					logger.Error("Could not upsert: ", err)
 					return err
 				}
+			}
+			mergeRequestUpdateErr := updateMergeRequestWithFirstCommentTime(gitlabApiResponse, mr)
+			if mergeRequestUpdateErr != nil {
+				return err
 			}
 			return nil
 		})

--- a/plugins/gitlab/tasks/gitlab_merge_request_note.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_note.go
@@ -20,6 +20,7 @@ type MergeRequestNote struct {
 	Body            string
 	GitlabCreatedAt string `json:"created_at"`
 	Confidential    bool
+	Resolvable      bool `json:"resolvable"`
 	Author          struct {
 		Username string `json:"username"`
 	}
@@ -31,6 +32,9 @@ func FindEarliestNote(notes *ApiMergeRequestNoteResponse) (*MergeRequestNote, er
 
 	earliestTime := time.Now()
 	for _, note := range *notes {
+		if !note.Resolvable {
+			continue
+		}
 		noteTime, parseErr := time.Parse(time.RFC3339, note.GitlabCreatedAt)
 		if parseErr != nil {
 			return nil, parseErr
@@ -88,6 +92,7 @@ func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest) erro
 					Body:            mrNote.Body,
 					GitlabCreatedAt: mrNote.GitlabCreatedAt,
 					Confidential:    mrNote.Confidential,
+					Resolvable:      mrNote.Resolvable,
 				}
 
 				err = lakeModels.Db.Clauses(clause.OnConflict{

--- a/plugins/gitlab/tasks/gitlab_merge_request_note.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_note.go
@@ -21,6 +21,7 @@ type MergeRequestNote struct {
 	GitlabCreatedAt string `json:"created_at"`
 	Confidential    bool
 	Resolvable      bool `json:"resolvable"`
+	System          bool `json:"system"`
 	Author          struct {
 		Username string `json:"username"`
 	}
@@ -32,7 +33,7 @@ func FindEarliestNote(notes *ApiMergeRequestNoteResponse) (*MergeRequestNote, er
 
 	earliestTime := time.Now()
 	for _, note := range *notes {
-		if !note.Resolvable {
+		if note.System || !note.Resolvable {
 			continue
 		}
 		noteTime, parseErr := time.Parse(time.RFC3339, note.GitlabCreatedAt)
@@ -93,6 +94,7 @@ func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest) erro
 					GitlabCreatedAt: mrNote.GitlabCreatedAt,
 					Confidential:    mrNote.Confidential,
 					Resolvable:      mrNote.Resolvable,
+					System:          mrNote.System,
 				}
 
 				err = lakeModels.Db.Clauses(clause.OnConflict{


### PR DESCRIPTION

### Description

To calculate some metrics, we need to have the first comment time on our merge requests.

### Does this close any open issues?
No.

