### PR TITLE
feat: read jira change log faster(parallelization across issue)

### DIFF
--- a/plugins/jira/tasks/jiraapiclient.go
+++ b/plugins/jira/tasks/jiraapiclient.go
@@ -42,7 +42,7 @@ type JiraPagination struct {
 
 type JiraPaginationHandler func(res *http.Response) error
 
-func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, handler JiraPaginationHandler) error {
+func (jiraApiClient *JiraApiClient) FetchPages(scheduler *utils.WorkerScheduler, path string, query *url.Values, handler JiraPaginationHandler) error {
 	if query == nil {
 		query = &url.Values{}
 	}
@@ -65,12 +65,6 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 		return nil
 	}
 	total = jiraApiResponse.Total
-
-	scheduler, err := utils.NewWorkerScheduler(10, 50)
-	if err != nil {
-		return err
-	}
-	defer scheduler.Release()
 
 	for nextStart < total {
 		nextStartTmp := nextStart
@@ -104,6 +98,5 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 		}
 		nextStart += pageSize
 	}
-	scheduler.WaitUntilFinish()
 	return nil
 }


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
Now request change logs is one issue by one issue. We need request more parallel.

### New Behavior
New Code allow change logs are requested parallel across issue. Now request about 200page/min change logs (It means 400request/min or 2w/min at most or ≈2000/min)
