### PR TITLE
feat: move docker-compose to root folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,19 @@ hello:
 build:
 	go build
 
-dev: 
+dev:
 	@sh ./scripts/dev.sh
 
 run:
 	go run main.go
 
-compose: 
-	docker-compose -f ./devops/docker-compose.yml --project-directory ./ up
+compose:
+	docker-compose up
 
-compose-down: 
-	docker-compose -f ./devops/docker-compose.yml --project-directory ./ down
+compose-down:
+	docker-compose down
 
-commit: 
+commit:
 	git cz
 
 install:
@@ -32,9 +32,9 @@ test: unit-test e2e-test
 unit-test:
 	@sh ./scripts/unit-test.sh
 
-e2e-test: 
+e2e-test:
 	@sh ./scripts/e2e-test.sh
 
-lint: 
+lint:
 	golangci-lint run
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ All statusMappings contain 2 objects. an open status (first object), and a close
 4. Start the services and check services' status
 ```shell
 # start all services
-docker-compose -f ./devops/docker-compose.yml --project-directory ./ up -d
-# check service status 
-docker-compose -f ./devops/docker-compose.yml --project-directory ./ ps
+docker-compose up -d
+# check service status
+docker-compose ps
 # stop all services
-# docker-compose -f ./devops/docker-compose.yml --project-directory ./ down -d
+# docker-compose down
 ```
 
 5. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     restart: always
     ports:
       - 127.0.0.1:3306:3306
-    # platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_DATABASE: lake


### PR DESCRIPTION
 So user can run `docker-compose` command easier, for example: run
 `docker-compose ps` to see if all containers were up and ready

### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing](../CONTRIBUTING.md) Documentation
- [x] This PR is using a `label` (bug, feature etc.)
- [x] My code is has necessary documentation (if appropriate)
- [ ] I have added any relevant tests
- [ ] This section (**⚠️ &nbsp;&nbsp;Pre Checklist**) will be removed when submitting PR

# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Please mention the issues here.

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
