### PR TITLE
feat: remove fk from gitlab plugin

### DIFF
--- a/plugins/gitlab/models/gitlab_commit.go
+++ b/plugins/gitlab/models/gitlab_commit.go
@@ -7,7 +7,6 @@ import (
 type GitlabCommit struct {
 	GitlabId       string `gorm:"primary_key"`
 	ProjectId      int
-	Project        GitlabProject `gorm:"foreignKey:ProjectId"`
 	Title          string
 	Message        string
 	ShortId        string

--- a/plugins/gitlab/models/gitlab_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request.go
@@ -8,7 +8,7 @@ type GitlabMergeRequest struct {
 	GitlabId         int `gorm:"primary_key"`
 	Iid              int `gorm:"index"`
 	ProjectId        int
-	Project          GitlabProject `gorm:"foreignKey:ProjectId"`
+	Project          int
 	State            string
 	Title            string
 	WebUrl           string

--- a/plugins/gitlab/models/gitlab_merge_request_note.go
+++ b/plugins/gitlab/models/gitlab_merge_request_note.go
@@ -8,7 +8,7 @@ type GitlabMergeRequestNote struct {
 	GitlabId        int `gorm:"primary_key"`
 	NoteableId      int
 	MergeRequestId  int
-	MergeRequest    GitlabMergeRequest `gorm:"foreignKey:MergeRequestId;references:Iid"`
+	MergeRequest    int
 	NoteableType    string
 	AuthorUsername  string
 	Body            string

--- a/plugins/gitlab/models/gitlab_reviewer.go
+++ b/plugins/gitlab/models/gitlab_reviewer.go
@@ -8,7 +8,7 @@ type GitlabReviewer struct {
 	GitlabId       int `gorm:"primary_key"`
 	MergeRequestId int
 	ProjectId      int
-	MergeRequest   GitlabMergeRequest `gorm:"foreignKey:MergeRequestId"`
+	MergeRequest   int
 	Name           string
 	Username       string
 	State          string


### PR DESCRIPTION

# Summary
 
Remove FK since we are only collecting data and we do not want to store based on data integrity.

From @hezyin 👍 

```
I think there's a misconception, foreign key is not a performance tool. It's meant to ensure the data integrity. It actually degrades performance slightly during insert / update / delete due to the time spent on checking the foreign key constraint. What helps with performance is index. They're two different things. 

I guess what confuses you is that people often create indexes on those foreign key columns, which mixes these two things up a little bit.
```

Removed all the gorm foreign keys but left the primary keys.

### How I tested this

- dropped all DB tables
- removed fk on models
- restarted with `make dev`
- Sent post request to gitlab plugin
- All data was still stored and no FK existed
- Checked for records in all tables

These tables were affected:

<img width="253" alt="Screen Shot 2021-09-07 at 1 12 17 PM" src="https://user-images.githubusercontent.com/3011407/132377884-0d8a1a2a-7d42-468c-890d-5e07e83a6089.png">

This is the log output showing it working

<img width="1745" alt="Screen Shot 2021-09-07 at 1 12 09 PM" src="https://user-images.githubusercontent.com/3011407/132377921-01af7e55-24bb-4624-a27f-9b21d51becd7.png">

