### PR TITLE
feat: extract total out of fetch paged

### DIFF
--- a/plugins/gitlab/tasks/gitlab_commit_collector.go
+++ b/plugins/gitlab/tasks/gitlab_commit_collector.go
@@ -8,6 +8,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitlab/models"
+	"github.com/merico-dev/lake/plugins/gitlab/util"
 	"gorm.io/gorm/clause"
 )
 
@@ -31,10 +32,18 @@ type ApiCommitResponse []struct {
 	}
 }
 
+func getTotalCommits() {
+	// GET https://gitlab.com/api/v4/projects/20103385?statistics=true
+
+	// res.statistics.commit_count
+}
+
 func CollectCommits(projectId int) error {
 	gitlabApiClient := CreateApiClient()
 
-	return gitlabApiClient.FetchWithPaginationAnts(fmt.Sprintf("projects/%v/repository/commits?with_stats=true", projectId), "100",
+	total, _ := util.GetTotalByXTotal()
+
+	return gitlabApiClient.FetchWithPaginationAnts(fmt.Sprintf("projects/%v/repository/commits?with_stats=true", projectId), "100", total,
 		func(res *http.Response) error {
 
 			gitlabApiResponse := &ApiCommitResponse{}

--- a/plugins/gitlab/tasks/gitlab_merge_request_collector.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_collector.go
@@ -34,10 +34,12 @@ type ApiMergeRequestResponse []struct {
 	Reviewers []Reviewer
 }
 
+
+
 func CollectMergeRequests(projectId int) error {
 	gitlabApiClient := CreateApiClient()
 
-	return gitlabApiClient.FetchWithPaginationAnts(fmt.Sprintf("projects/%v/merge_requests", projectId), "100",
+	return gitlabApiClient.FetchWithPaginationAnts(fmt.Sprintf("projects/%v/merge_requests", projectId), "100", total,
 		func(res *http.Response) error {
 			gitlabApiResponse := &ApiMergeRequestResponse{}
 

--- a/plugins/gitlab/util/util.go
+++ b/plugins/gitlab/util/util.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/merico-dev/lake/logger"
+)
+
+func GetTotalByXTotal(url string) (int, error) {
+	gitlabApiClient := CreateApiClient()
+
+	// jsut get the first page of results. The response has a head that tells the total pages
+	page := 0
+	page_size := 1
+	res, err := gitlabApiClient.Get(fmt.Sprintf(url, page_size, page), nil, nil)
+
+	if err != nil {
+		return 0, err
+	}
+
+	total := res.Header.Get("X-Total")
+	totalInt, err := convertStringToInt(total)
+	if err != nil {
+		return 0, err
+	}
+
+	logger.Info("JON >>> totalInt", totalInt)
+	return totalInt, nil
+}


### PR DESCRIPTION

# Summary

When paging gitlab data, you need a count of total records. This allows us to send out requests to all of the at once.

Some queries in gitlab use a header on the response called X-Total.

Others use totally separate queries.

This means that each model needs to calcuate their own total of records from the API and pass it into FetchPagedWithAnts
### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

