### PR TITLE
feat: parallelize changelogs collection on issue level 

### DIFF
--- a/plugins/jira/tasks/jiraapiclient.go
+++ b/plugins/jira/tasks/jiraapiclient.go
@@ -51,10 +51,12 @@ func (jiraApiClient *JiraApiClient) FetchPages(scheduler *utils.WorkerScheduler,
 	// 获取issue总数
 	// get issue count
 	pageQuery := &url.Values{}
-	*pageQuery = *query
+	for key, value := range *query {
+		(*pageQuery)[key] = value
+	}
 	pageQuery.Set("maxResults", "0")
 	// make a call to the api just to get the paging details
-	res, err := jiraApiClient.Get(path, query, nil)
+	res, err := jiraApiClient.Get(path, pageQuery, nil)
 	if err != nil {
 		return err
 	}
@@ -71,10 +73,12 @@ func (jiraApiClient *JiraApiClient) FetchPages(scheduler *utils.WorkerScheduler,
 		err = scheduler.Submit(func() error {
 			// fetch page
 			detailQuery := &url.Values{}
-			*detailQuery = *query
+			for key, value := range *query {
+				(*detailQuery)[key] = value
+			}
 			detailQuery.Set("maxResults", strconv.Itoa(pageSize))
 			detailQuery.Set("startAt", strconv.Itoa(nextStartTmp))
-			res, err := jiraApiClient.Get(path, query, nil)
+			res, err := jiraApiClient.Get(path, detailQuery, nil)
 			if err != nil {
 				return err
 			}

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e
+
+LAKE_ENDPOINT=${LAKE_ENDPOINT-'http://localhost:8080'}
+LAKE_TASK_URL=$LAKE_ENDPOINT/task
+
+debug() {
+    scripts/compile-plugins.sh -gcflags=all="-N -l"
+    dlv debug
+}
+
+jira() {
+    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
+    [
+        {
+            "plugin": "jira",
+            "options": {
+                "boardId": 8
+            }
+        }
+    ]
+    JSON
+}
+
+jira_enrich_issues() {
+    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
+    [
+        {
+            "plugin": "jira",
+            "options": {
+                "boardId": 8,
+                "tasks": [ "enrichIssues" ]
+            }
+        }
+    ]
+    JSON
+}
+
+"$@"


### PR DESCRIPTION
# Summary

Parallelize changelogs collection on issue level

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Previous changelogs collection parallelization on changelog level which can collect mulitple pages for one issue at a time, changelogs from different issue still ran on sequential manner.
This PR added a issue scheduler to address the bottleneck

### Does this close any open issues?
No
