### PR TITLE
fix: jira board complains `created_at` being 0

### DIFF
--- a/plugins/jira/tasks/jiraboardcollector.go
+++ b/plugins/jira/tasks/jiraboardcollector.go
@@ -7,6 +7,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/jira/models"
+	"gorm.io/gorm/clause"
 )
 
 type JiraApiLocation struct {
@@ -49,7 +50,9 @@ func CollectBoard(boardId uint64) error {
 		Self:      jiraApiBoard.Self,
 		Type:      jiraApiBoard.Type,
 	}
-	err = lakeModels.Db.Save(jiraBoard).Error
+	err = lakeModels.Db.Clauses(clause.OnConflict{
+		UpdateAll: true,
+	}).Create(jiraBoard).Error
 	if err != nil {
 		logger.Error("Error: ", err)
 	}

--- a/plugins/jira/tasks/jiraissuecollector.go
+++ b/plugins/jira/tasks/jiraissuecollector.go
@@ -76,7 +76,7 @@ func CollectIssues(boardId uint64) error {
 				// issue
 				err = lakeModels.Db.Clauses(clause.OnConflict{
 					UpdateAll: true,
-				}).Create(&jiraIssue).Error
+				}).Create(jiraIssue).Error
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Summary

jira board updation would fail due to `created_at` being `0000-00`

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description

This fix makes jira board information update works

