### PR TITLE
feat: add step concurrency for gitlab apiclient

### DIFF
--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -169,6 +169,7 @@ func UnmarshalResponse(res *http.Response, v interface{}) error {
 	defer res.Body.Close()
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
+		logger.Print(fmt.Sprintf("UnmarshalResponse failed: %v\n%v\n\n", res.Request.URL.String(), string(resBody)))
 		return err
 	}
 	return json.Unmarshal(resBody, &v)

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+notes() {
+    curl -v "$GITLAB_ENDPOINT/projects/8967944/merge_requests/1349/notes?system=false&per_page=100&page=1" \
+        -H "Authorization: Bearer $GITLAB_AUTH"
+}
+
+commits() {
+    SIZE=${1-100}
+    PAGE=${2-1}
+    PROJ=${3-8967944}
+    curl -v "$GITLAB_ENDPOINT/projects/$PROJ/repository/commits?with_stats=true&per_page=$SIZE&page=$PAGE" \
+        -H "Authorization: Bearer $GITLAB_AUTH"
+}
+
+"$@"

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -10,6 +10,11 @@ debug() {
     dlv debug
 }
 
+run() {
+    scripts/compile-plugins.sh
+    go run main.go
+}
+
 jira() {
     curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
     [
@@ -33,6 +38,42 @@ jira_enrich_issues() {
                 "tasks": [ "enrichIssues" ]
             }
         }
+    ]
+    JSON
+}
+
+all() {
+    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
+    [
+            {
+                "plugin": "gitlab",
+                "options": {
+                    "projectId": 8967944
+                }
+            },
+            {
+                "plugin": "jira",
+                "options": {
+                    "boardId": 8
+                }
+            },
+            {
+                "plugin": "jenkins",
+                "options": {}
+            }
+    ]
+    JSON
+}
+
+gitlab() {
+    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
+    [
+            {
+                "plugin": "gitlab",
+                "options": {
+                    "projectId": 8967944
+                }
+            }
     ]
     JSON
 }


### PR DESCRIPTION
# Summary

To handle some pagination api doesn't return `x-Token` header

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Some gitlab api like commits doesn't provide `x-total` header, causing plugin collect only the first page for gitlab_commits .
This PR handles this situation in step concurrency manner.
1. For each STEP, send out 1...10 request for each page
2. If page 10 has 'x-next-page' header, go for next STEP
3. If page 1..10 has no 'x-next-page' header, break the loop
