### PR TITLE
fix: added index to model fields, rm extra fields

### DIFF
--- a/plugins/gitlab/models/gitlab_commit.go
+++ b/plugins/gitlab/models/gitlab_commit.go
@@ -6,7 +6,7 @@ import (
 
 type GitlabCommit struct {
 	GitlabId       string `gorm:"primary_key"`
-	ProjectId      int
+	ProjectId      int    `gorm:"index"`
 	Title          string
 	Message        string
 	ShortId        string

--- a/plugins/gitlab/models/gitlab_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request.go
@@ -7,8 +7,7 @@ import (
 type GitlabMergeRequest struct {
 	GitlabId         int `gorm:"primary_key"`
 	Iid              int `gorm:"index"`
-	ProjectId        int
-	Project          int
+	ProjectId        int `gorm:"index"`
 	State            string
 	Title            string
 	WebUrl           string

--- a/plugins/gitlab/models/gitlab_merge_request_note.go
+++ b/plugins/gitlab/models/gitlab_merge_request_note.go
@@ -7,8 +7,7 @@ import (
 type GitlabMergeRequestNote struct {
 	GitlabId        int `gorm:"primary_key"`
 	NoteableId      int
-	MergeRequestId  int
-	MergeRequest    int
+	MergeRequestId  int `gorm:"index"`
 	NoteableType    string
 	AuthorUsername  string
 	Body            string

--- a/plugins/gitlab/models/gitlab_reviewer.go
+++ b/plugins/gitlab/models/gitlab_reviewer.go
@@ -6,9 +6,8 @@ import (
 
 type GitlabReviewer struct {
 	GitlabId       int `gorm:"primary_key"`
-	MergeRequestId int
-	ProjectId      int
-	MergeRequest   int
+	MergeRequestId int `gorm:"index"`
+	ProjectId      int `gorm:"index"`
 	Name           string
 	Username       string
 	State          string


### PR DESCRIPTION

### Description
We have removed foreign keys, but we need to add an index on those fields.

We also can clean them up by removing the additional GORM syntax (ie. MergeRequest int) for MergeRequestId foreign key.

