### PR TITLE
chore: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:edge as builder
-RUN apk update
-RUN apk upgrade
-RUN apk add --update go=1.16.7-r0 gcc=10.3.1_git20210625-r1 g++=10.3.1_git20210625-r1
+FROM lake-builder:0.0.1 as builder
 
+# docker build --build-arg GOPROXY=https://goproxy.io,direct -t lake .
+ARG GOPROXY=
 WORKDIR /app
 COPY . /app
 

--- a/devops/lake-builder/Dockerfile
+++ b/devops/lake-builder/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.17.0-alpine3.13 as builder
+RUN apk update
+RUN apk upgrade
+RUN apk add --update gcc=10.3.1_git20210625-r1 g++=10.3.1_git20210625-r1

--- a/devops/lake-builder/README.md
+++ b/devops/lake-builder/README.md
@@ -1,0 +1,11 @@
+# lake-builder
+golang builder image for lake, including go1.17.0 gcc10.3.1 g++10.3.1, based on alpine linux 3.13.
+
+https://hub.docker.com/r/mericodev/lake-builder
+
+## release
+```shell
+export VERSION=0.0.1
+docker build -t mericodev/lake-builder:$VERSION .
+docker push mericodev/lake-builder:$VERSION
+```


### PR DESCRIPTION
# Summary
This PR enhenced docker build process. Before merge this PR, we should finish below things:
- [ ] build a lake-builder image and push it to mericodev/lake-builder

Now we can use ` docker build --build-arg GOPROXY=https://goproxy.io,direct -t lake .` to build lake behind a proxy.

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
- support goproxy
- use go1.17
- create lake-builder
