### PR TITLE
docs: add lake-cli usage to user setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ All the details on provisioning, and customizing a dashboard can be found in the
 
 5. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
 
+### Setup cron job
+Commonly, we have requirement to synchorize data periodly. We providered a tool called `lake-cli` to meet that requirement. Check `lake-cli` usage at [here](./cmd/lake-cli/README.md).  
+
+Otherwise, if you just want to use the cron job, please check `docker-compose` version at [here](./devops/sync/README.md)
+
 ## Development Setup<a id="development-setup"></a>
 
 1. Navigate to where you would like to install this project and clone the repository

--- a/devops/sync/docker-compose.yml
+++ b/devops/sync/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     image: mericodev/lake:latest
     volumes:
       - ./req.json:/bin/app/req.json
+    # This command will request task api every 60 mins 
     command: lake-cli api task -m POST --cron "@every 60m" --body ./req.json 
     network_mode: host


### PR DESCRIPTION
# Summary
Add lake-cli usage (cron sync job) to user setup

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated
