### PR TITLE
fix: export env remove all comments

### DIFF
--- a/scripts/export-env.sh
+++ b/scripts/export-env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 FILE=.env
 if [ -f "$FILE" ]; then
-    export $(grep -v '^#' .env | xargs)
+    export $(grep -v '^#' .env | sed 's/#.*$//g' | xargs)
 else 
     echo "$FILE does not exist."
 fi


### PR DESCRIPTION
This failed before in .env

```
DB_URL=foobar # nnnnnn
```

Since the script only removes lines that start with '#'. I changed it to remove end of line comments too.

`export $(grep -v '^#' .env | sed 's/#.*$//g' | xargs)`

<img width="733" alt="Screen Shot 2021-09-10 at 2 48 27 PM" src="https://user-images.githubusercontent.com/3011407/132896020-3fc0ac29-5baa-4020-b188-50cd241849e1.png">

