### PR TITLE
fix: remove timezone from db connection string to avoid connection failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 PLUGIN_DIR=bin/plugins
 
 # Lake Database Connection String
-DB_URL=merico:merico@tcp(mysql:3306)/lake?charset=utf8mb4&loc=Asia%2fShanghai&parseTime=True
+DB_URL=merico:merico@tcp(mysql:3306)/lake?charset=utf8mb4
 
 # Lake REST API
 PORT=:8080


### PR DESCRIPTION
## Description

To fix the `MySQL connection failed: unknown timezone Asia/Shanghai` error, this PR temporarily removes the timezone info from the connection string.