### PR TITLE
feat: trigger ui and doc adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ configure-dev:
 	cd config-ui; yarn; npm run dev;
 
 compose:
-	docker-compose up grafana devlake
+	docker-compose up grafana
 
 compose-down:
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ run:
 	go run main.go
 
 configure:
+	docker-compose up config-ui
+
+configure-dev:
 	cd config-ui; yarn; npm run dev;
 
 compose:
-	docker-compose up grafana
+	docker-compose up grafana devlake
 
 compose-down:
 	docker-compose down

--- a/README.md
+++ b/README.md
@@ -62,30 +62,26 @@ Jenkins | Metrics, Generating API Token | [Link](plugins/jenkins/README.md)
 
 ### Commands to run in your terminal<a id="user-setup-commands"></a>
 
-1. Create a directory and download files
-
-2. Run the following commands:
+1. Clone repository
 
    ```sh
    git clone https://github.com/merico-dev/lake.git devlake
    cd devlake
-   git checkout go-main
    cp .env.example .env
    ```
-
-3. Run `make configure` to start up the configuration interface
-
-4. Run `make compose` to start up the other services
+2. Run `docker-compose up config-ui` to start up the configuration interface
 
 > For more info on how to configure plugins, please refer to the [data source plugins](#data-source-plugins) section
 
-5. Visit `localhost:4000` to setup configuration files
+3. Visit `localhost:4000` to setup configuration files
 
-6. Visit `localhost:4000/triggers` to run collection triggers for plugins
+4. Run `docker-compose up -d` to start up the other services
+
+5. Visit `localhost:4000/triggers` to run collection triggers for plugins
 
 > Please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)
 
-7. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
+6. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
 
 ### Setup cron job
 Commonly, we have requirement to synchorize data periodly. We providered a tool called `lake-cli` to meet that requirement. Check `lake-cli` usage at [here](./cmd/lake-cli/README.md).  

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Jenkins | Metrics, Generating API Token | [Link](plugins/jenkins/README.md)
 
 1. Create a directory and download files
 
+2. Run the following commands:
+
    ```sh
    git clone https://github.com/merico-dev/lake.git devlake
    cd devlake
@@ -71,42 +73,19 @@ Jenkins | Metrics, Generating API Token | [Link](plugins/jenkins/README.md)
    cp .env.example .env
    ```
 
-2. Open `.env` file with your editor, fill the values in `Jira`, `Gitlab` and `Jenkins` sections with your deployments.
+3. Run `make configure` to start up the configuration interface
+
+4. Run `make compose` to start up the other services
 
 > For more info on how to configure plugins, please refer to the [data source plugins](#data-source-plugins) section
 
-3. Launch `docker-compose`
+5. Visit `localhost:4000` to setup configuration files
 
-   ```shell
-   make compose
-   ```
+6. Visit `localhost:4000/triggers` to run collection triggers for plugins
 
-4. Create a http request to trigger data collect tasks, please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)
+> Please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)
 
-   ```shell
-   curl -XPOST 'http://localhost:8080/task' \
-   -H 'Content-Type: application/json' \
-   -d '[
-       {
-           "plugin": "gitlab",
-           "options": {
-               "projectId": 8967944
-           }
-       },
-       {
-           "plugin": "jira",
-           "options": {
-               "boardId": 8
-           }
-       },
-       {
-           "plugin": "jenkins",
-           "options": {}
-       }
-   ]'
-   ```
-
-5. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
+7. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
 
 ### Setup cron job
 Commonly, we have requirement to synchorize data periodly. We providered a tool called `lake-cli` to meet that requirement. Check `lake-cli` usage at [here](./cmd/lake-cli/README.md).  

--- a/config-ui/components/Sidebar.js
+++ b/config-ui/components/Sidebar.js
@@ -1,7 +1,10 @@
-import { Button, Card, Elevation, Icon } from "@blueprintjs/core"
+import { useRouter } from 'next/router'
+import { Button, Card, Elevation, Icon } from '@blueprintjs/core'
 import styles from '../styles/Sidebar.module.css'
 
 const Sidebar = () => {
+  const { asPath } = useRouter()
+
   return <Card interactive={false} elevation={Elevation.ZERO} className={styles.card}>
 
     <img src="/logo.svg" className={styles.logo} />
@@ -10,12 +13,19 @@ const Sidebar = () => {
     </a>
 
     <ul className={styles.sidebarMenu}>
-      <a href="/">
+      <a href="/" className={asPath === "/" ? styles.sidebarMenuActive : ''}>
         <li>
           <Icon icon="layout-grid" size={16} className={styles.sidebarMenuListIcon} />
           Configuration
         </li>
-          <div className={styles.sidebarMenuDash}></div>
+          {asPath === "/" && <div className={styles.sidebarMenuDash}></div>}
+      </a>
+      <a href="/triggers" className={asPath === "/triggers" ? styles.sidebarMenuActive: ''}>
+        <li>
+          <Icon icon="repeat" size={16} className={styles.sidebarMenuListIcon} />
+          Triggers
+        </li>
+          {asPath === "/triggers" && <div className={styles.sidebarMenuDash}></div>}
       </a>
     </ul>
   </Card>

--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.49.1",
+    "axios": "^0.21.4",
     "dotenv": "^10.0.0",
     "next": "11.1.2",
     "react": "17.0.2",

--- a/config-ui/pages/api/triggers/task.js
+++ b/config-ui/pages/api/triggers/task.js
@@ -1,0 +1,10 @@
+import axios from 'axios'
+
+export default function handler(req, res) {
+
+  axios.post('http://localhost:8080/task', req.body ).then(res => {
+    console.log(res.data)
+  }).catch(e => {
+    console.log(e)
+  })
+}

--- a/config-ui/pages/index.js
+++ b/config-ui/pages/index.js
@@ -23,7 +23,7 @@ export default function Home(props) {
   const [gitlabAuth, setGitlabAuth] = useState(env.GITLAB_AUTH)
 
   function updateEnv(key, value) {
-    fetch(`http://localhost:4000/api/setenv/${key}/${encodeURIComponent(value)}`)
+    fetch(`/api/setenv/${key}/${encodeURIComponent(value)}`)
   }
 
   function saveAll(e) {

--- a/config-ui/pages/triggers.js
+++ b/config-ui/pages/triggers.js
@@ -1,0 +1,96 @@
+import Head from 'next/head'
+import { useState } from 'react'
+import axios from 'axios'
+import styles from '../styles/Home.module.css'
+import { FormGroup, InputGroup, Button, TextArea, Intent } from "@blueprintjs/core"
+import Nav from '../components/Nav'
+import Sidebar from '../components/Sidebar'
+import Content from '../components/Content'
+
+const defaultValue = [
+  {
+    "plugin": "gitlab",
+    "options": {
+      "projectId": 8967944
+    }
+  },
+  {
+    "plugin": "jira",
+    "options": {
+      "boardId": 8
+    }
+  },
+  {
+    "plugin": "jenkins",
+    "options": {}
+  }
+]
+
+export default function Home(props) {
+
+  const [textAreaBody, setTextAreaBody] = useState(JSON.stringify(defaultValue, null, 2))
+
+  const sendTrigger = async (e) => {
+    e.preventDefault()
+
+    try {
+      await axios.post(
+        `/api/triggers/task`,
+        textAreaBody,
+        { headers: { "Content-Type": "application/json" }},
+      )
+    } catch (e) {
+      console.error(e)
+    }
+
+  }
+
+  return (
+    <div className={styles.container}>
+
+      <Head>
+        <title>Devlake Config-UI</title>
+        <meta name="description" content="Lake: Config" />
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@500;600&display=swap" rel="stylesheet" />
+      </Head>
+
+      <Nav />
+      <Sidebar />
+      <Content>
+        <main className={styles.main}>
+
+          <div className={styles.headlineContainer}>
+            <h1>Triggers</h1>
+            <p className={styles.description}>Trigger data collection on your plugins</p>
+          </div>
+
+          <form className={styles.form}>
+            <div className={styles.headlineContainer}>
+            <p className={styles.description}>Create a http request to trigger data collect tasks, please replace
+            your <code>gitlab projectId</code> and <code>jira boardId</code> in the request body. This can take up
+            to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)</p>
+            </div>
+
+            <div className={styles.formContainer}>
+              <TextArea
+                growVertically={true}
+                large={true}
+                intent={Intent.PRIMARY}
+                fill={true}
+                className={styles.codeArea}
+                defaultValue={textAreaBody}
+                onChange={(e) => setTextAreaBody(e.target.value)}
+              />
+            </div>
+
+            <Button outlined={true} large={true} className={styles.saveBtn} onClick={sendTrigger}>Trigger Collection</Button>
+          </form>
+        </main>
+      </Content>
+    </div>
+  )
+}

--- a/config-ui/styles/Home.module.css
+++ b/config-ui/styles/Home.module.css
@@ -10,13 +10,14 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
 }
 
 .description {
   display: block;
   margin-bottom: 1.6rem;
+  max-width: 600px;
 }
 
 .logo {
@@ -30,6 +31,14 @@
 
 .input, .form {
   width: 100%;
+}
+
+.codeArea {
+  width: 100%;
+  max-width: 600px !important;
+  height: 384px !important;
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
 }
 
 .formGroup {

--- a/config-ui/styles/Sidebar.module.css
+++ b/config-ui/styles/Sidebar.module.css
@@ -42,16 +42,25 @@
   width: calc(100% + 40px);
 }
 
-.sidebarMenu a {
-  background: #FFDBC2;
+.sidebarMenu a,
+.sidebarMenuActive {
   display: block;
   padding: 12px 20px;
-  color: #E8471C;
   position: relative;
   text-decoration: none;
 }
 
 .sidebarMenu a:hover {
+  color: #303033;
+}
+
+.sidebarMenuActive {
+  color: #E8471C !important;
+  background: #FFDBC2;
+}
+
+.sidebarMenuActive:hover {
+  color: #E8471C;
   background-color: #ffdac6;
 }
 


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
Main update to this PR is a new `/trigger` page to the config ui. This allows us to trigger data collection.

Other updates:
- Updated `README.md` for user focused setup (now that we have containerized config ui)
- `Makefile` now has `make configure` and `make configure-dev`. dev will just run yarn/node. `make configure` will run through docker compose (and most recent docker hub image)

### Current Behavior
Only way to trigger data collection is through the CLI. We want to offer users (especially non-devs) a way to do it easily through the browser)

### New Behavior
Offer an option to trigger data collection through the configuration UI. Also change the docs for better user onboarding. 

### Screenshots
![Screen Shot 2021-09-13 at 4 49 04 PM](https://user-images.githubusercontent.com/3789273/133158111-ee3b68b9-4e65-4488-909a-b0f88286c80f.png)

### Other Information
- We will need to update docker hub image (config-ui) to see the latest changes for user setup (running `make configure`)
- Testing of this PR would involve mainly changing config info in the `localhost:4000/triggers` page. and monitoring what data is collected in the `devlake` logs
- Future will be good to have `/triggers` page using form/input elements and not just raw json in a textarea. If we extracted the data to inputs, it would be a lot easier on the user. We could also offer both, input/forms and raw json editing
- Currently no visual indicator for data being collected on button press (specifically in browser, on `/trigger` page). We should add in some indication somehow in the UI. But I think that can be another PR

