### PR TITLE
fix: add parsetime back to connection string

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 PLUGIN_DIR=bin/plugins
 
 # Lake Database Connection String
-DB_URL=merico:merico@tcp(mysql:3306)/lake?charset=utf8mb4
+DB_URL=merico:merico@tcp(mysql:3306)/lake?charset=utf8mb4&parseTime=True
 
 # Lake REST API
 PORT=:8080


### PR DESCRIPTION
## Description

When I deleted timezone from the connection string in `.env.example`, I accidentally deleted the `parseTime=True`, which is needed to auto parse `Date` to `time.Time`.
