### PR TITLE
Show tasks progress on config-ui

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
 [*.go]
 indent_style = tab
 indent_size = 4
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Jenkins | Metrics, Generating API Token | [Link](plugins/jenkins/README.md)
 
 > Please replace your [gitlab projectId](plugins/gitlab/README.md#finding-project-id) and [jira boardId](plugins/jira/README.md#find-board-id) in the request body. This can take up to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)
 
-6. Navigate to grafana dashboard `http://localhost:3002` (username: `admin`, password: `admin`).
+6. Click *Go to grafana* when done (username: `admin`, password: `admin`)
 
 ### Setup cron job
 Commonly, we have requirement to synchorize data periodly. We providered a tool called `lake-cli` to meet that requirement. Check `lake-cli` usage at [here](./cmd/lake-cli/README.md).  

--- a/api/router.go
+++ b/api/router.go
@@ -7,4 +7,5 @@ import (
 
 func RegisterRouter(r *gin.Engine) {
 	r.POST("/task", task.Post)
+	r.GET("/task", task.Get)
 }

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -33,3 +33,12 @@ func Post(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusCreated, tasks)
 }
+
+func Get(ctx *gin.Context) {
+	tasks, err := services.GetTasks(ctx.Query("status"))
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks})
+}

--- a/config-ui/pages/api/triggers/config.js
+++ b/config-ui/pages/api/triggers/config.js
@@ -1,0 +1,2 @@
+export const DEVLAKE_ENDPOINT = process.env.DEVLAKENDPOINT || 'http://localhost:8080'
+export const GRAFANA_PORT = process.env.GRAFANA_PORT || '3002'

--- a/config-ui/pages/api/triggers/pendings.js
+++ b/config-ui/pages/api/triggers/pendings.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+import { DEVLAKE_ENDPOINT, GRAFANA_PORT } from './config'
+
+export default function handler(req, res) {
+
+  axios.get(`${DEVLAKE_ENDPOINT}/task?status=TASK_CREATED`).then(r => {
+      res.status(200).json({
+          grafanaPort: GRAFANA_PORT,
+          tasks: r.data.tasks
+      })
+    console.log(res.data)
+  }).catch(e => {
+    console.log(e)
+  })
+}

--- a/config-ui/pages/api/triggers/task.js
+++ b/config-ui/pages/api/triggers/task.js
@@ -1,8 +1,9 @@
 import axios from 'axios'
+import { DEVLAKE_ENDPOINT } from './config'
 
 export default function handler(req, res) {
 
-  axios.post('http://localhost:8080/task', req.body ).then(res => {
+  axios.post(`${DEVLAKE_ENDPOINT}/task`, req.body ).then(res => {
     console.log(res.data)
   }).catch(e => {
     console.log(e)

--- a/config-ui/pages/index.js
+++ b/config-ui/pages/index.js
@@ -354,7 +354,7 @@ export default function Home(props) {
                 label="GITLAB_AUTH"
                 inline={true}
                 labelFor="gitlab-auth"
-                helperText="Gitlab Auth Token"
+                helperText="Should be encoded using command `echo -n <jira login email>:<jira token> | base64`"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >

--- a/config-ui/pages/index.js
+++ b/config-ui/pages/index.js
@@ -19,8 +19,17 @@ export default function Home(props) {
   const [jiraEndpoint, setJiraEndpoint] = useState(env.JIRA_ENDPOINT)
   const [jiraBasicAuthEncoded, setJiraBasicAuthEncoded] = useState(env.JIRA_BASIC_AUTH_ENCODED)
   const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState(env.JIRA_ISSUE_EPIC_KEY_FIELD)
+  const [jiraIssueTypeMapping, setJiraIssueTypeMapping] = useState(env.JIRA_ISSUE_TYPE_MAPPING)
+  const [jiraIssueBugStatusMapping, setJiraIssueBugStatusMapping] = useState(env.JIRA_ISSUE_BUG_STATUS_MAPPING)
+  const [jiraIssueIncidentStatusMapping, setJiraIssueIncidentStatusMapping] = useState(env.JIRA_ISSUE_INCIDENT_STATUS_MAPPING)
+  const [jiraIssueStoryStatusMapping, setJiraIssueStoryStatusMapping] = useState(env.JIRA_ISSUE_STORY_STATUS_MAPPING)
+  const [jiraIssueStoryCoefficient, setJiraIssueStoryCoefficient] = useState(env.JIRA_ISSUE_STORYPOINT_COEFFICIENT)
+  const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState(env.JIRA_ISSUE_STORYPOINT_FIELD)
   const [gitlabEndpoint, setGitlabEndpoint] = useState(env.GITLAB_ENDPOINT)
   const [gitlabAuth, setGitlabAuth] = useState(env.GITLAB_AUTH)
+  const [jenkinsEndpoint, setJenkinsEndpoint] = useState(env.JENKINS_ENDPOINT)
+  const [jenkinsUsername, setJenkinsUsername] = useState(env.JENKINS_USERNAME)
+  const [jenkinsPassword, setJenkinsPassword] = useState(env.JENKINS_PASSWORD)
 
   function updateEnv(key, value) {
     fetch(`/api/setenv/${key}/${encodeURIComponent(value)}`)
@@ -34,8 +43,17 @@ export default function Home(props) {
     updateEnv('JIRA_ENDPOINT', jiraEndpoint)
     updateEnv('JIRA_BASIC_AUTH_ENCODED', jiraBasicAuthEncoded)
     updateEnv('JIRA_ISSUE_EPIC_KEY_FIELD', jiraIssueEpicKeyField)
+    updateEnv('JIRA_ISSUE_TYPE_MAPPING', jiraIssueTypeMapping)
+    updateEnv('JIRA_ISSUE_BUG_STATUS_MAPPING', jiraIssueBugStatusMapping)
+    updateEnv('JIRA_ISSUE_INCIDENT_STATUS_MAPPING', jiraIssueIncidentStatusMapping)
+    updateEnv('JIRA_ISSUE_STORY_STATUS_MAPPING', jiraIssueStoryStatusMapping)
+    updateEnv('JIRA_ISSUE_STORYPOINT_COEFFICIENT', jiraIssueStoryCoefficient)
+    updateEnv('JIRA_ISSUE_STORYPOINT_FIELD', jiraIssueStoryPointField)
     updateEnv('GITLAB_ENDPOINT', gitlabEndpoint)
     updateEnv('GITLAB_AUTH', gitlabAuth)
+    updateEnv('JENKINS_ENDPOINT', jenkinsEndpoint)
+    updateEnv('JENKINS_USERNAME', jenkinsUsername)
+    updateEnv('JENKINS_PASSWORD', jenkinsPassword)
     alert('Config file updated, please restart devlake to apply new configuration')
   }
 
@@ -192,6 +210,121 @@ export default function Home(props) {
               </FormGroup>
             </div>
 
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_TYPE_MAPPING"
+                inline={true}
+                labelFor="jira-issue-type-mapping"
+                helperText="Map your custom type to Devlake standard type"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-issue-type-mapping"
+                  placeholder="STANDARD_TYPE_1:ORIGIN_TYPE_1,ORIGIN_TYPE_2;STANDARD_TYPE_2:....
+"
+                  defaultValue={jiraIssueTypeMapping}
+                  onChange={(e) => setJiraIssueTypeMapping(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_BUG_STATUS_MAPPING"
+                inline={true}
+                labelFor="jira-bug-status-mapping"
+                helperText="Map your custom bug status to Devlake standard status"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-bug-status-mapping"
+                  placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                  defaultValue={jiraIssueBugStatusMapping}
+                  onChange={(e) => setJiraIssueBugStatusMapping(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_INCIDENT_STATUS_MAPPING"
+                inline={true}
+                labelFor="jira-incident-status-mapping"
+                helperText="Map your custom incident status to Devlake standard status"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-incident-status-mapping"
+                  placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                  defaultValue={jiraIssueIncidentStatusMapping}
+                  onChange={(e) => setJiraIssueIncidentStatusMapping(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_STORY_STATUS_MAPPING"
+                inline={true}
+                labelFor="jira-story-status-mapping"
+                helperText="Map your custom story status to Devlake standard status"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-story-status-mapping"
+                  placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                  defaultValue={jiraIssueStoryStatusMapping}
+                  onChange={(e) => setJiraIssueStoryStatusMapping(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_STORYPOINT_COEFFICIENT"
+                inline={true}
+                labelFor="jira-storypoint-coef"
+                helperText="Your custom story point coefficent (optional)"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-storypoint-coef"
+                  placeholder="Enter Jira Story Point Coefficient"
+                  defaultValue={jiraIssueStoryCoefficient}
+                  onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JIRA_ISSUE_STORYPOINT_FIELD"
+                inline={true}
+                labelFor="jira-storypoint-field"
+                helperText="Your custom story point key field (optional)"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-storypoint-field"
+                  placeholder="Enter Jira Story Point Field"
+                  defaultValue={jiraIssueStoryPointField}
+                  onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
             <div className={styles.headlineContainer}>
               <h2 className={styles.headline}>Gitlab Configuration</h2>
               <p className={styles.description}>Gitlab account and config settings</p>
@@ -230,6 +363,68 @@ export default function Home(props) {
                   placeholder="Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz"
                   defaultValue={gitlabAuth}
                   onChange={(e) => setGitlabAuth(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.headlineContainer}>
+              <h2 className={styles.headline}>Jenkins Configuration</h2>
+              <p className={styles.description}>Jenkins account and config settings</p>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JENKINS_ENDPOINT"
+                inline={true}
+                labelFor="jenkins-endpoint"
+                helperText="Jenkins API Endpoint"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-endpoint"
+                  placeholder="Enter Jenkins API endpoint"
+                  defaultValue={jenkinsEndpoint}
+                  onChange={(e) => setJenkinsEndpoint(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JENKINS_USERNAME"
+                inline={true}
+                labelFor="jenkins-username"
+                helperText="Jenkins Username"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-username"
+                  placeholder="Enter Jenkins Username"
+                  defaultValue={jenkinsUsername}
+                  onChange={(e) => setJenkinsUsername(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="JENKINS_PASSWORD"
+                inline={true}
+                labelFor="jenkins-password"
+                helperText="Jenkins Password"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-password"
+                  placeholder="Enter Jenkins Password"
+                  defaultValue={jenkinsPassword}
+                  onChange={(e) => setJenkinsPassword(e.target.value)}
                   className={styles.input}
                 />
               </FormGroup>

--- a/config-ui/pages/triggers.js
+++ b/config-ui/pages/triggers.js
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import axios from 'axios'
 import styles from '../styles/Home.module.css'
 import { FormGroup, InputGroup, Button, TextArea, Intent } from "@blueprintjs/core"
@@ -45,6 +45,24 @@ export default function Home(props) {
 
   }
 
+  const [pendingTasks, setPendingTasks] = useState([])
+  const [stage, setStage] = useState(0)
+  const [grafanaUrl, setGrafanaUrl] = useState(3002)
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const res = await axios.get("/api/triggers/pendings")
+      console.log(res)
+      if (res.data.tasks.length > 0) {
+        setStage(1)
+      } else if (stage === 1) {
+        setStage(2)
+      }
+      setPendingTasks(res.data.tasks)
+      setGrafanaUrl(`${location.protocol}//${location.hostname}:${res.data.grafanaPort}`)
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [])
+
   return (
     <div className={styles.container}>
 
@@ -62,33 +80,56 @@ export default function Home(props) {
       <Sidebar />
       <Content>
         <main className={styles.main}>
-
-          <div className={styles.headlineContainer}>
-            <h1>Triggers</h1>
-            <p className={styles.description}>Trigger data collection on your plugins</p>
-          </div>
-
-          <form className={styles.form}>
-            <div className={styles.headlineContainer}>
-            <p className={styles.description}>Create a http request to trigger data collect tasks, please replace
-            your <code>gitlab projectId</code> and <code>jira boardId</code> in the request body. This can take up
-            to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)</p>
+          {stage === 2 &&
+            <div>
+              <div className={styles.headlineContainer}>
+                <h1>Done</h1>
+                <p className={styles.description}>Please open grafana to observe dev metrics...</p>
+                <a href={grafanaUrl}>Go to grafana</a>
+              </div>
             </div>
-
-            <div className={styles.formContainer}>
-              <TextArea
-                growVertically={true}
-                large={true}
-                intent={Intent.PRIMARY}
-                fill={true}
-                className={styles.codeArea}
-                defaultValue={textAreaBody}
-                onChange={(e) => setTextAreaBody(e.target.value)}
-              />
+          }
+          {stage === 1 &&
+            <div>
+              <div className={styles.headlineContainer}>
+                <h1>Work in progress</h1>
+                <p className={styles.description}>Please wait...</p>
+              </div>
+              {pendingTasks.map(task =>
+                <div>{task.plugin}: {task.progress * 100}%</div>
+              )}
             </div>
+          }
+          {stage === 0 &&
+            <div>
+              <div className={styles.headlineContainer}>
+                <h1>Triggers</h1>
+                <p className={styles.description}>Trigger data collection on your plugins</p>
+              </div>
 
-            <Button outlined={true} large={true} className={styles.saveBtn} onClick={sendTrigger}>Trigger Collection</Button>
-          </form>
+              <form className={styles.form}>
+                <div className={styles.headlineContainer}>
+                <p className={styles.description}>Create a http request to trigger data collect tasks, please replace
+                your <code>gitlab projectId</code> and <code>jira boardId</code> in the request body. This can take up
+                to 20 minutes for large projects. (gitlab 10k+ commits or jira 5k+ issues)</p>
+                </div>
+
+                <div className={styles.formContainer}>
+                  <TextArea
+                    growVertically={true}
+                    large={true}
+                    intent={Intent.PRIMARY}
+                    fill={true}
+                    className={styles.codeArea}
+                    defaultValue={textAreaBody}
+                    onChange={(e) => setTextAreaBody(e.target.value)}
+                  />
+                </div>
+
+                <Button outlined={true} large={true} className={styles.saveBtn} onClick={sendTrigger}>Trigger Collection</Button>
+              </form>
+            </div>
+          }
         </main>
       </Content>
     </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       - ENV_FILEPATH=/.env
       - DEVLAKE_ENDPOINT=http://devlake:8080
-      - GRAFANA_PORT=3002
+      - GRAFANA_PORT=3002/d/RXJZNpMnz/homepage?orgId=1
     volumes:
       - ./.env:/.env:rw
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - 127.0.0.1:4000:4000
     environment:
       - ENV_FILEPATH=/.env
+      - DEVLAKE_ENDPOINT=http://devlake:8080
+      - GRAFANA_PORT=3002
     volumes:
       - ./.env:/.env:rw
 volumes:

--- a/models/task.go
+++ b/models/task.go
@@ -6,8 +6,9 @@ import (
 
 type Task struct {
 	Model
-	Plugin  string
-	Options datatypes.JSON
-	Status  string
-	Message string
+	Plugin   string         `json:"plugin"`
+	Options  datatypes.JSON `json:"options"`
+	Status   string         `json:"status"`
+	Message  string         `json:"message"`
+	Progress float32        `json:"progress"`
 }

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -34,8 +34,8 @@ To collect data, you can make a POST request to `/task`
     curl --location --request POST 'localhost:8080/task' \
     --header 'Content-Type: application/json' \
     --data-raw '[{
-        "Plugin": "gitlab",
-        "Options": {
+        "plugin": "gitlab",
+        "options": {
             "projectId": <Your gitlab project id>
         }
     }]'

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -34,12 +34,14 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 		return
 	}
 
+	progress <- 0.1
+
 	if err := tasks.CollectCommits(projectIdInt); err != nil {
 		logger.Error("Could not collect commits: ", err)
 		return
 	}
 
-	progress <- 0.2
+	progress <- 0.3
 
 	mergeRequestErr := tasks.CollectMergeRequests(projectIdInt)
 	if mergeRequestErr != nil {
@@ -47,7 +49,7 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 		return
 	}
 
-	progress <- 0.5
+	progress <- 0.4
 
 	// find all mrs from db
 	var mrs []gitlabModels.GitlabMergeRequest
@@ -84,6 +86,7 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	}
 
 	scheduler.WaitUntilFinish()
+	progress <- 0.8
 
 	enrichErr := tasks.EnrichMergeRequests()
 	if enrichErr != nil {

--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -28,7 +28,7 @@ To collect data, you can make a POST request to `/task`
 curl --location --request POST 'localhost:8080/task' \
   --header 'Content-Type: application/json' \
   --data-raw '[{
-      "Plugin": "jenkins",
-      "Options": {}
+      "plugin": "jenkins",
+      "options": {}
   }]'
 ```

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -110,8 +110,8 @@ JIRA_ISSUE_TYPE_MAPPING=Requirement:Story
 ## Generating API token
 1. Once logged into Jira, visit the url `https://id.atlassian.com/manage-profile/security/api-tokens`
 2. Click the **Create API Token** button, and give it any label name
-
 ![image](https://user-images.githubusercontent.com/27032263/129363611-af5077c9-7a27-474a-a685-4ad52366608b.png)
+3. Encode with login email using command `echo -n <jira login email>:<jira token> | base64`
 
 ## How do I find the custom field ID in Jira?
 Using URL

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -98,4 +98,8 @@ truncate() {
     echo "SET FOREIGN_KEY_CHECKS=1;"
 }
 
+tasks() {
+    curl -v $LAKE_TASK_URL?status=$1 | jq
+}
+
 "$@"

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -28,5 +28,5 @@ func TestNewTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, tasks[0]["Plugin"], "jira")
+	assert.Equal(t, tasks[0]["plugin"], "jira")
 }


### PR DESCRIPTION
# Summary

Add logic to show tasks progress on config-ui trigger page
![1](https://user-images.githubusercontent.com/61080/133199823-b5f3c15d-72af-46ee-8302-f1093414a46b.png)
![2](https://user-images.githubusercontent.com/61080/133199830-52ba3f59-5e06-4d25-a66d-4eaf67d4fb2a.png)
![3](https://user-images.githubusercontent.com/61080/133199832-d521a027-de81-484b-a6b0-9f02ff243d5b.png)


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
