### PR TITLE
fix: apple m1 would fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   mysql:
     hostname: mysqldb
     image: mysql:8.0.26
+    platform: linux/x86_64
     volumes:
       - mysql-storage:/var/lib/mysql
     restart: always
@@ -31,6 +32,7 @@ services:
       - mysql
   devlake:
     image: mericodev/lake:latest
+    platform: linux/x86_64
     ports:
       - 127.0.0.1:8080:8080
     env_file:


### PR DESCRIPTION
# Summary

Mysql and devlake would fail to start, and causing 500 error on config-ui，this fix should not affect other platform
![image](https://user-images.githubusercontent.com/61080/133248938-a50661df-4abf-4fc9-b8c0-ae12f44fcdd8.png)


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
