### PR TITLE
docs: polish of Jira readme

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -43,16 +43,19 @@ issues.
 
 
 ## Issue type mapping<a id="issue-type-mapping"></a>
-Same as status mapping, different company might use different issue type to represent their Bug/Incident/Requirement,
-type mapping is for Devlake to recognize your specific setup.
-Devlake supports three different standard types:
+Same as status mapping, different companies might use different issue types to represent their Bug/Incident/Requirement,
+type mappings allow Devlake to recognize your specific setup with respect to Jira statuses.
+Devlake supports three different standard status types:
 
  - `Bug`
  - `Incident`
  - `Requirement`
 
-Say we were using `Story` to represent our Requirement, what we have to do is setting the following
+For example, say we were using `Story` to represent our Requirement, what we have to do is setting the following
 `Environment Variables` before running Devlake:
+
+Example: 
+
 ```sh
 # JIRA_ISSUE_TYPE_MAPPING=<STANDARD_TYPE>:<YOUR_TYPE_1>,<YOUR_TYPE_2>;....
 JIRA_ISSUE_TYPE_MAPPING=Requirement:Story

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -21,28 +21,37 @@ Incident Count | Number of issues with type "Incident"<br><i>incidents are found
 Incident Age | Lead time of issues with type "Incident"
 Incident Count per 1k Lines of Code | Amount of incidents per 1000 lines of code
 
+## Configuration
 
-## Issue status mapping<a id="issue-status-mapping"></a>
-Jira is highly customizable, different company may use different `status name` to represent whether a issue was
-resolved or not, one may named it "Done" and others might named it "Finished".
-In order to collect life-cycle information correctly, you'll have to map your specific status to Devlake's standard
-status, Devlake supports two standard status:
+In order to fully use this plugin, you will need to set various config variables in the root of this project in the `.env` file.
 
- - `Resolved`: issue was ended successfully
- - `Rejected`: issue was ended by termination or cancellation
+### Set JIRA_ENDPOINT
 
-Say we were using `Done` and `Cancelled` to represent the final stage of `Story` issues, what we have to do is setting
-the following `Environment Variables` before running Devlake:
-```sh
-#JIRA_ISSUE_<YOUR_TYPE>_STATUS_MAPPING=<STANDARD_STATUS>:<YOUR_STATUS>;...
-JIRA_ISSUE_STORY_STATUS_MAPPING=Resolved:Done;Rejected:Cancelled
-```
+This is the setting that is used as the base of all Jira API calls. You can see this in all of your Jira Urls as the start of the Url.
 
-Status mapping is critical for metrics like **Lead Time**, the `leadtime`s are calculated only for those **Resolved**
-issues.
+**Example:** 
 
+If you see `https://mydomain.atlassian.net/secure/RapidBoard.jspa?rapidView=999&projectKey=XXX`, you will need to set `JIRA_ENDPOINT=https://mydomain.atlassian.net` in your `.env` file.
 
-## Issue type mapping<a id="issue-type-mapping"></a>
+### Set JIRA_BASIC_AUTH_ENCODED
+
+1. Once logged into Jira, visit the url `https://id.atlassian.com/manage-profile/security/api-tokens`
+2. Click the **Create API Token** button, and give it any label name
+![image](https://user-images.githubusercontent.com/27032263/129363611-af5077c9-7a27-474a-a685-4ad52366608b.png)
+3. Encode with login email using command `echo -n <jira login email>:<jira token> | base64`
+
+### Set Jira Custom Fields
+
+This applies to JIRA_ISSUE_STORYPOINT_FIELD and JIRA_ISSUE_EPIC_KEY_FIELD
+
+Custom fields can be applied to Jira stories. We use this to set `JIRA_ISSUE_EPIC_KEY_FIELD` in the `.env` file.
+
+**Example:** `JIRA_ISSUE_EPIC_KEY_FIELD=customfield_10024`
+
+Please follow this guide: [How to find Jira the custom field ID in Jira? · merico-dev/lake Wiki](https://github.com/merico-dev/lake/wiki/How-to-find-Jira-the-custom-field-ID-in-Jira)
+
+### Set Issue Type Mapping<a id="issue-type-mapping"></a>
+
 Same as status mapping, different companies might use different issue types to represent their Bug/Incident/Requirement,
 type mappings allow Devlake to recognize your specific setup with respect to Jira statuses.
 Devlake supports three different standard status types:
@@ -54,33 +63,78 @@ Devlake supports three different standard status types:
 For example, say we were using `Story` to represent our Requirement, what we have to do is setting the following
 `Environment Variables` before running Devlake:
 
-Example: 
+**Example:** 
 
 ```sh
 # JIRA_ISSUE_TYPE_MAPPING=<STANDARD_TYPE>:<YOUR_TYPE_1>,<YOUR_TYPE_2>;....
-JIRA_ISSUE_TYPE_MAPPING=Requirement:Story
+JIRA_ISSUE_TYPE_MAPPING=Requirement:Story;Incident:CustomerComplaint;Bug:QABug;
 ```
 
 Type mapping is critical for some metrics, like **Requirement Count**, make sure to map your custom type correctly.
 
+### Set Issue status mapping<a id="issue-status-mapping"></a>
 
-## Find Board Id
+Jira is highly customizable, different companies may use different `status` names to represent whether an issue was
+resolved or not. One company may name it "Done" and others might name it "Finished".
+
+In order to collect life-cycle information correctly, you'll have to map your specific status to Devlake's standard
+status, Devlake supports two standard status:
+
+ - `Resolved`: issue was ended successfully
+ - `Rejected`: issue was ended by termination or cancellation
+
+For example, say we were using `Done` and `Cancelled` to represent the final stages of `Story` issues. We will have to set
+the following `Environment Variables` in the `.env` file at the root of this project before running Devlake:
+
+```sh
+#JIRA_ISSUE_<YOUR_TYPE>_STATUS_MAPPING=<STANDARD_STATUS>:<YOUR_STATUS>;...
+JIRA_ISSUE_BUG_STATUS_MAPPING=Resolved:Done;Rejected:Cancelled
+JIRA_ISSUE_INCIDENT_STATUS_MAPPING=Resolved:Done;Rejected:Cancelled
+JIRA_ISSUE_STORY_STATUS_MAPPING=Resolved:Done;Rejected:Cancelled
+```
+
+Status mapping is critical for metrics like **Lead Time** since the `leadtime` that we store in the database is calculated only for **Resolved** issues.
+
+NOTE: You can see your project's issue statuses here:
+
+<img width="2035" alt="Screen Shot 2021-09-10 at 4 01 56 PM" src="https://user-images.githubusercontent.com/2908155/133310611-2c5e1254-3456-4e15-9c3c-458fed03c6d3.png">
+
+Or you can make a cUrl request to see the statuses:
+
+```
+curl --location --request GET 'https://<YOUR_JIRA_ENDPOINT>/rest/api/2/project/<PROJECT_ID>/statuses' \
+--header 'Authorization: Basic <BASE64_ENCODED_TOKEN>' \
+--header 'Content-Type: application/json'
+```
+
+### Set JIRA_ISSUE_STORYPOINT_COEFFICIENT
+
+This is a value you can set to something other than the default of 1 if you want to skew the results of story points.
+
+## How to Trigger Data Collection for This Plugin
+
+### Find Board Id
+
 1. Navigate to the Jira board in the browser
 2. in the URL bar, get the board id from the parameter `?rapidView=`
 
 **Example:**
-`https://<your_jira_url>/secure/RapidBoard.jspa?rapidView=51`
+
+`https://<your_jira_endpoint>/secure/RapidBoard.jspa?rapidView=51`
 
 ![Screen Shot 2021-08-13 at 10 07 19 AM](https://user-images.githubusercontent.com/27032263/129363083-df0afa18-e147-4612-baf9-d284a8bb7a59.png)
 
-> Use this board ID in your requests, to collect data from this board
+Your board id is used in all REST requests to DevLake. You do not need to set this in your `.env` file. 
 
-## Generating API token
-1. Once logged into Jira, visit the url `https://id.atlassian.com/manage-profile/security/api-tokens`
-2. Click the **Create API Token** button, and give it any label name
-![image](https://user-images.githubusercontent.com/27032263/129363611-af5077c9-7a27-474a-a685-4ad52366608b.png)
-3. Encode with login email using command `echo -n <jira login email>:<jira token> | base64`
+**Example:** 
 
-## How do I find the custom field ID in Jira?
-
-Please follow this guide: [How to find Jira the custom field ID in Jira? · merico-dev/lake Wiki](https://github.com/merico-dev/lake/wiki/How-to-find-Jira-the-custom-field-ID-in-Jira%3F)
+```
+curl -XPOST 'localhost:8080/task' \
+-H 'Content-Type: application/json' \
+-d '[{
+    "plugin": "jira",
+    "options": {
+        "boardId": 8
+    }
+}]'
+```


### PR DESCRIPTION
Fixes: https://github.com/merico-dev/lake/issues/395

The status mappings are the most confusing to the reader I think. This should help wth that.

UPDATE:

- Added main section called `Configuration` with notes on the `.env` file
- re-ordered sections based on team feedback to match config UI
- Added some more detailed examples
- Added @hezyin 's screenshot for statuses
- General english grammar updates

Questions:

1. @klesh @narrowizard @jaxzhou is this a valid example: `JIRA_ISSUE_TYPE_MAPPING=Requirement:Story;Incident:CustomerComplaint;Bug:QABug;`

2. @hezyin since I rebased, I see that some information was added to the wiki here: https://github.com/merico-dev/lake/wiki/How-to-find-Jira-the-custom-field-ID-in-Jira. Can you tell me which parts of our information belong in the wiki and which belong in markdown files? Would you like me to move more of this content to the wiki?