### PR TITLE
Fix data source `mysql` uneditable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,6 @@
 indent_style = tab
 indent_size = 4
 
-[*.js]
+[*.{js,jsx}]
 indent_style = space
 indent_size = 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,11 @@ services:
       - ./grafana/dashboards:/etc/grafana/dashboards
       - ./grafana/img/grafana_icon.svg:/usr/share/grafana/public/img/grafana_icon.svg:rw
       - ./grafana/img:/usr/share/grafana/public/img/lake:ro
-    env_file:
-      - ./grafana/grafana.config
+    environment:
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_JSON_ENABLED=true
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+      - GF_LIVE_ALLOWED_ORIGINS=*
     restart: always
     depends_on:
       - mysql

--- a/grafana/grafana.config
+++ b/grafana/grafana.config
@@ -1,5 +1,0 @@
-# Config Options
-GF_USERS_ALLOW_SIGN_UP=false
-GF_DASHBOARDS_JSON_ENABLED=true
-GF_INSTALL_PLUGINS=grafana-piechart-panel
-GF_LIVE_ALLOWED_ORIGINS=http://localhost:3002

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -9,3 +9,4 @@ datasources:
     user: merico
     secureJsonData:
       password: "merico"
+    editable: true

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -51,7 +51,7 @@ To get the project id for a specific Gitlab repository:
 
 > Use this project id in your requests, to collect data from this project
 
-## ⚠️ (WIP) Create a Gitlab API Token
+## ⚠️ (WIP) Create a Gitlab API Token <a id="gitlab-api-token"></a>
 
 1. When logged into Gitlab visit `https://gitlab.com/-/profile/personal_access_tokens`
 2. Give the token any name, no expiration date and all scopes (excluding write access)


### PR DESCRIPTION
# Summary

1. `editable: true` is critical for user to change the mysql password for security.
2. `grafana.confg` file is unnecessary and make configuration harder.
3. add missing anchor for gitlab api token

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated
