### PR TITLE
feat: replace native alert with in browser dialog

### DIFF
--- a/config-ui/components/SaveAlert.jsx
+++ b/config-ui/components/SaveAlert.jsx
@@ -1,0 +1,17 @@
+import { Alert } from '@blueprintjs/core'
+
+const SaveAlert = ({alertOpen, onClose}) => {
+
+  return <Alert
+    canEscapeKeyCancel={true}
+    canOutsideClickCancel={true}
+    confirmButtonText="Ok"
+    isOpen={alertOpen}
+    onClose={onClose}
+    >
+    <h4>Config File Updated</h4>
+    <p>To apply new configuration, restart devlake by running: <br/><br/><code>docker-compose up -d</code></p>
+  </Alert>
+}
+
+export default SaveAlert

--- a/config-ui/pages/index.jsx
+++ b/config-ui/pages/index.jsx
@@ -9,14 +9,15 @@ import { FormGroup, InputGroup, Button, Alert, Tooltip, Position } from '@bluepr
 import Nav from '../components/Nav'
 import Sidebar from '../components/Sidebar'
 import Content from '../components/Content'
+import SaveAlert from '../components/SaveAlert'
 
 export default function Home(props) {
   const { env } = props
 
+  const [alertOpen, setAlertOpen] = useState(false)
   const [dbUrl, setDbUrl] = useState(env.DB_URL)
   const [port, setPort] = useState(env.PORT)
   const [mode, setMode] = useState(env.MODE)
-  const [alertOpen, setAlertOpen] = useState(false)
 
   function updateEnv(key, value) {
     fetch(`/api/setenv/${key}/${encodeURIComponent(value)}`)
@@ -134,15 +135,7 @@ export default function Home(props) {
       </Content>
     </div>
 
-    <Alert
-      canEscapeKeyCancel={true}
-      canOutsideClickCancel={true}
-      confirmButtonText="Ok"
-      isOpen={alertOpen}
-      onClose={() => setAlertOpen(false)}>
-      <h4>Config File Updated</h4>
-      <p>To apply new configuration, restart devlake by running: <br/><br/><code>docker-compose up -d</code></p>
-    </Alert>
+    <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
     </>
   )
 }

--- a/config-ui/pages/plugins/gitlab.jsx
+++ b/config-ui/pages/plugins/gitlab.jsx
@@ -9,10 +9,12 @@ import { existsSync } from 'fs'
 import Nav from '../../components/Nav'
 import Sidebar from '../../components/Sidebar'
 import Content from '../../components/Content'
+import SaveAlert from '../../components/SaveAlert'
 
 export default function Home(props) {
   const { env } = props
 
+  const [alertOpen, setAlertOpen] = useState(false)
   const [gitlabEndpoint, setGitlabEndpoint] = useState(env.GITLAB_ENDPOINT)
   const [gitlabAuth, setGitlabAuth] = useState(env.GITLAB_AUTH)
 
@@ -24,7 +26,7 @@ export default function Home(props) {
     e.preventDefault()
     updateEnv('GITLAB_ENDPOINT', gitlabEndpoint)
     updateEnv('GITLAB_AUTH', gitlabAuth)
-    alert('Config file updated, please restart devlake by running: \'docker-compose restart\' to apply new configuration')
+    setAlertOpen(true)
   }
 
   return (
@@ -50,45 +52,51 @@ export default function Home(props) {
             <p className={styles.description}>Gitlab account and config settings</p>
           </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="API&nbsp;Endpoint"
-              inline={true}
-              labelFor="gitlab-endpoint"
-              helperText="GITLAB_ENDPOINT"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="gitlab-endpoint"
-                placeholder="Enter Gitlab API endpoint"
-                defaultValue={gitlabEndpoint}
-                onChange={(e) => setGitlabEndpoint(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+          <form className={styles.form}>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Auth&nbsp;Token"
-              inline={true}
-              labelFor="gitlab-auth"
-              helperText="GITLAB_AUTH"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="gitlab-auth"
-                placeholder="Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz"
-                defaultValue={gitlabAuth}
-                onChange={(e) => setGitlabAuth(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="API&nbsp;Endpoint"
+                inline={true}
+                labelFor="gitlab-endpoint"
+                helperText="GITLAB_ENDPOINT"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="gitlab-endpoint"
+                  placeholder="Enter Gitlab API endpoint"
+                  defaultValue={gitlabEndpoint}
+                  onChange={(e) => setGitlabEndpoint(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
 
-          <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Auth&nbsp;Token"
+                inline={true}
+                labelFor="gitlab-auth"
+                helperText="GITLAB_AUTH"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="gitlab-auth"
+                  placeholder="Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz"
+                  defaultValue={gitlabAuth}
+                  onChange={(e) => setGitlabAuth(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
+
+          </form>
+
+          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>

--- a/config-ui/pages/plugins/jenkins.jsx
+++ b/config-ui/pages/plugins/jenkins.jsx
@@ -9,10 +9,12 @@ import { existsSync } from 'fs'
 import Nav from '../../components/Nav'
 import Sidebar from '../../components/Sidebar'
 import Content from '../../components/Content'
+import SaveAlert from '../../components/SaveAlert'
 
 export default function Home(props) {
   const { env } = props
 
+  const [alertOpen, setAlertOpen] = useState(false)
   const [jenkinsEndpoint, setJenkinsEndpoint] = useState(env.JENKINS_ENDPOINT)
   const [jenkinsUsername, setJenkinsUsername] = useState(env.JENKINS_USERNAME)
   const [jenkinsPassword, setJenkinsPassword] = useState(env.JENKINS_PASSWORD)
@@ -26,7 +28,7 @@ export default function Home(props) {
     updateEnv('JENKINS_ENDPOINT', jenkinsEndpoint)
     updateEnv('JENKINS_USERNAME', jenkinsUsername)
     updateEnv('JENKINS_PASSWORD', jenkinsPassword)
-    alert('Config file updated, please restart devlake by running: \'docker-compose restart\' to apply new configuration')
+    setAlertOpen(true)
   }
 
   return (
@@ -52,64 +54,70 @@ export default function Home(props) {
             <p className={styles.description}>Jenkins account and config settings</p>
           </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="API&nbsp;Endpoint"
-              inline={true}
-              labelFor="jenkins-endpoint"
-              helperText="JENKINS_ENDPOINT"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="jenkins-endpoint"
-                placeholder="Enter Jenkins API endpoint"
-                defaultValue={jenkinsEndpoint}
-                onChange={(e) => setJenkinsEndpoint(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+          <form className={styles.form}>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Username"
-              inline={true}
-              labelFor="jenkins-username"
-              helperText="JENKINS_USERNAME"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="jenkins-username"
-                placeholder="Enter Jenkins Username"
-                defaultValue={jenkinsUsername}
-                onChange={(e) => setJenkinsUsername(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="API&nbsp;Endpoint"
+                inline={true}
+                labelFor="jenkins-endpoint"
+                helperText="JENKINS_ENDPOINT"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-endpoint"
+                  placeholder="Enter Jenkins API endpoint"
+                  defaultValue={jenkinsEndpoint}
+                  onChange={(e) => setJenkinsEndpoint(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Password"
-              inline={true}
-              labelFor="jenkins-password"
-              helperText="JENKINS_PASSWORD"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="jenkins-password"
-                placeholder="Enter Jenkins Password"
-                defaultValue={jenkinsPassword}
-                onChange={(e) => setJenkinsPassword(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Username"
+                inline={true}
+                labelFor="jenkins-username"
+                helperText="JENKINS_USERNAME"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-username"
+                  placeholder="Enter Jenkins Username"
+                  defaultValue={jenkinsUsername}
+                  onChange={(e) => setJenkinsUsername(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
 
-          <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Password"
+                inline={true}
+                labelFor="jenkins-password"
+                helperText="JENKINS_PASSWORD"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jenkins-password"
+                  placeholder="Enter Jenkins Password"
+                  defaultValue={jenkinsPassword}
+                  onChange={(e) => setJenkinsPassword(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
+
+          </form>
+
+          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>

--- a/config-ui/pages/plugins/jira.jsx
+++ b/config-ui/pages/plugins/jira.jsx
@@ -9,10 +9,12 @@ import { existsSync } from 'fs'
 import Nav from '../../components/Nav'
 import Sidebar from '../../components/Sidebar'
 import Content from '../../components/Content'
+import SaveAlert from '../../components/SaveAlert'
 
 export default function Home(props) {
   const { env } = props
 
+  const [alertOpen, setAlertOpen] = useState(false)
   const [jiraEndpoint, setJiraEndpoint] = useState(env.JIRA_ENDPOINT)
   const [jiraBasicAuthEncoded, setJiraBasicAuthEncoded] = useState(env.JIRA_BASIC_AUTH_ENCODED)
   const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState(env.JIRA_ISSUE_EPIC_KEY_FIELD)
@@ -38,7 +40,7 @@ export default function Home(props) {
     updateEnv('JIRA_ISSUE_STORY_STATUS_MAPPING', jiraIssueStoryStatusMapping)
     updateEnv('JIRA_ISSUE_STORYPOINT_COEFFICIENT', jiraIssueStoryCoefficient)
     updateEnv('JIRA_ISSUE_STORYPOINT_FIELD', jiraIssueStoryPointField)
-    alert('Config file updated, please restart devlake by running: \'docker-compose restart\' to apply new configuration')
+    setAlertOpen(true)
   }
 
   return (
@@ -64,213 +66,219 @@ export default function Home(props) {
             <p className={styles.description}>Jira Account and config settings</p>
           </div>
 
-          <div className={styles.headlineContainer}>
-            <h3 className={styles.headline}>URL Endpoint</h3>
-            <p className={styles.description}>The custom endpoint URL for your Jira project</p>
-          </div>
+          <form className={styles.form}>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Endpoint&nbsp;URL"
-              inline={true}
-              labelFor="jira-endpoint"
-              helperText="JIRA_ENDPOINT"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="jira-endpoint"
-                placeholder="Enter Jira endpoint eg. https://merico.atlassian.net"
-                defaultValue={jiraEndpoint}
-                onChange={(e) => setJiraEndpoint(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
+            <div className={styles.headlineContainer}>
+              <h3 className={styles.headline}>URL Endpoint</h3>
+              <p className={styles.description}>The custom endpoint URL for your Jira project</p>
+            </div>
 
-          <div className={styles.headlineContainer}>
-            <h3 className={styles.headline}>API Token</h3>
-            <p className={styles.description}>Your Jira specific API auth token. Should be encoded using command: <br/><br/><code>{`echo -n `}<b>{`<jira login email>`}</b>:<b>{`<jira token>`}</b>{` | base64`}</code></p>
-          </div>
-
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Basic&nbsp;Auth&nbsp;Token"
-              inline={true}
-              labelFor="jira-basic-auth"
-              helperText="JIRA_BASIC_AUTH_ENCODED"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <InputGroup
-                id="jira-basic-auth"
-                placeholder="Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47"
-                defaultValue={jiraBasicAuthEncoded}
-                onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
-                className={styles.input}
-              />
-            </FormGroup>
-          </div>
-
-          <div className={styles.headlineContainer}>
-            <h3 className={styles.headline}>Status Mappings</h3>
-            <p className={styles.description}>Map your custom Jira status to the correct values</p>
-          </div>
-
-          <div className={styles.formContainer}>
+            <div className={styles.formContainer}>
               <FormGroup
-                label="Issue&nbsp;Type"
+                label="Endpoint&nbsp;URL"
                 inline={true}
-                labelFor="jira-issue-type-mapping"
-                helperText="JIRA_ISSUE_TYPE_MAPPING"
+                labelFor="jira-endpoint"
+                helperText="JIRA_ENDPOINT"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <Tooltip content="Map your custom type to Devlake standard type" position={Position.TOP}>
+                <InputGroup
+                  id="jira-endpoint"
+                  placeholder="Enter Jira endpoint eg. https://merico.atlassian.net"
+                  defaultValue={jiraEndpoint}
+                  onChange={(e) => setJiraEndpoint(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.headlineContainer}>
+              <h3 className={styles.headline}>API Token</h3>
+              <p className={styles.description}>Your Jira specific API auth token. Should be encoded using command: <br/><br/><code>{`echo -n `}<b>{`<jira login email>`}</b>:<b>{`<jira token>`}</b>{` | base64`}</code></p>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Basic&nbsp;Auth&nbsp;Token"
+                inline={true}
+                labelFor="jira-basic-auth"
+                helperText="JIRA_BASIC_AUTH_ENCODED"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <InputGroup
+                  id="jira-basic-auth"
+                  placeholder="Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47"
+                  defaultValue={jiraBasicAuthEncoded}
+                  onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
+                  className={styles.input}
+                />
+              </FormGroup>
+            </div>
+
+            <div className={styles.headlineContainer}>
+              <h3 className={styles.headline}>Status Mappings</h3>
+              <p className={styles.description}>Map your custom Jira status to the correct values</p>
+            </div>
+
+            <div className={styles.formContainer}>
+                <FormGroup
+                  label="Issue&nbsp;Type"
+                  inline={true}
+                  labelFor="jira-issue-type-mapping"
+                  helperText="JIRA_ISSUE_TYPE_MAPPING"
+                  className={styles.formGroup}
+                  contentClassName={styles.formGroup}
+                >
+                  <Tooltip content="Map your custom type to Devlake standard type" position={Position.TOP}>
+                    <InputGroup
+                      id="jira-issue-type-mapping"
+                      placeholder="STANDARD_TYPE_1:ORIGIN_TYPE_1,ORIGIN_TYPE_2;STANDARD_TYPE_2:....
+      "
+                      defaultValue={jiraIssueTypeMapping}
+                      onChange={(e) => setJiraIssueTypeMapping(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Tooltip>
+                </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Bug"
+                inline={true}
+                labelFor="jira-bug-status-mapping"
+                helperText="JIRA_ISSUE_BUG_STATUS_MAPPING"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Map your custom bug status to Devlake standard status" position={Position.TOP}>
                   <InputGroup
-                    id="jira-issue-type-mapping"
-                    placeholder="STANDARD_TYPE_1:ORIGIN_TYPE_1,ORIGIN_TYPE_2;STANDARD_TYPE_2:....
-    "
-                    defaultValue={jiraIssueTypeMapping}
-                    onChange={(e) => setJiraIssueTypeMapping(e.target.value)}
+                    id="jira-bug-status-mapping"
+                    placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                    defaultValue={jiraIssueBugStatusMapping}
+                    onChange={(e) => setJiraIssueBugStatusMapping(e.target.value)}
                     className={styles.input}
                   />
                 </Tooltip>
               </FormGroup>
-          </div>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Bug"
-              inline={true}
-              labelFor="jira-bug-status-mapping"
-              helperText="JIRA_ISSUE_BUG_STATUS_MAPPING"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Map your custom bug status to Devlake standard status" position={Position.TOP}>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Incident"
+                inline={true}
+                labelFor="jira-incident-status-mapping"
+                helperText="JIRA_ISSUE_INCIDENT_STATUS_MAPPING"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Map your custom incident status to Devlake standard status" position={Position.TOP}>
                 <InputGroup
-                  id="jira-bug-status-mapping"
+                  id="jira-incident-status-mapping"
                   placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
-                  defaultValue={jiraIssueBugStatusMapping}
-                  onChange={(e) => setJiraIssueBugStatusMapping(e.target.value)}
+                  defaultValue={jiraIssueIncidentStatusMapping}
+                  onChange={(e) => setJiraIssueIncidentStatusMapping(e.target.value)}
                   className={styles.input}
                 />
-              </Tooltip>
-            </FormGroup>
-          </div>
+                </Tooltip>
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Incident"
-              inline={true}
-              labelFor="jira-incident-status-mapping"
-              helperText="JIRA_ISSUE_INCIDENT_STATUS_MAPPING"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Map your custom incident status to Devlake standard status" position={Position.TOP}>
-              <InputGroup
-                id="jira-incident-status-mapping"
-                placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
-                defaultValue={jiraIssueIncidentStatusMapping}
-                onChange={(e) => setJiraIssueIncidentStatusMapping(e.target.value)}
-                className={styles.input}
-              />
-              </Tooltip>
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Story"
+                inline={true}
+                labelFor="jira-story-status-mapping"
+                helperText="JIRA_ISSUE_STORY_STATUS_MAPPING"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Map your custom story status to Devlake standard status" position={Position.TOP}>
+                  <InputGroup
+                    id="jira-story-status-mapping"
+                    placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                    defaultValue={jiraIssueStoryStatusMapping}
+                    onChange={(e) => setJiraIssueStoryStatusMapping(e.target.value)}
+                    className={styles.input}
+                  />
+                </Tooltip>
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Story"
-              inline={true}
-              labelFor="jira-story-status-mapping"
-              helperText="JIRA_ISSUE_STORY_STATUS_MAPPING"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Map your custom story status to Devlake standard status" position={Position.TOP}>
-                <InputGroup
-                  id="jira-story-status-mapping"
-                  placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
-                  defaultValue={jiraIssueStoryStatusMapping}
-                  onChange={(e) => setJiraIssueStoryStatusMapping(e.target.value)}
-                  className={styles.input}
-                />
-              </Tooltip>
-            </FormGroup>
-          </div>
+            <div className={styles.headlineContainer}>
+              <h3 className={styles.headline}>Additional Customization Settings</h3>
+              <p className={styles.description}>Additional Jira settings</p>
+            </div>
 
-          <div className={styles.headlineContainer}>
-            <h3 className={styles.headline}>Additional Customization Settings</h3>
-            <p className={styles.description}>Additional Jira settings</p>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Epic&nbsp;Key&nbsp;Field"
+                inline={true}
+                labelFor="jira-epic-key"
+                helperText="JIRA_ISSUE_EPIC_KEY_FIELD"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Your custom epic key field (optional)" position={Position.TOP}>
+                  <InputGroup
+                    id="jira-epic-key"
+                    placeholder="Enter Jira epic key field"
+                    defaultValue={jiraIssueEpicKeyField}
+                    onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
+                    className={styles.input}
+                  />
+                </Tooltip>
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Epic&nbsp;Key&nbsp;Field"
-              inline={true}
-              labelFor="jira-epic-key"
-              helperText="JIRA_ISSUE_EPIC_KEY_FIELD"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Your custom epic key field (optional)" position={Position.TOP}>
-                <InputGroup
-                  id="jira-epic-key"
-                  placeholder="Enter Jira epic key field"
-                  defaultValue={jiraIssueEpicKeyField}
-                  onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
-                  className={styles.input}
-                />
-              </Tooltip>
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Storypoint&nbsp;Coefficient"
+                inline={true}
+                labelFor="jira-storypoint-coef"
+                helperText="JIRA_ISSUE_STORYPOINT_COEFFICIENT"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Your custom story point coefficent (optional)" position={Position.TOP}>
+                  <InputGroup
+                    id="jira-storypoint-coef"
+                    placeholder="Enter Jira Story Point Coefficient"
+                    defaultValue={jiraIssueStoryCoefficient}
+                    onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
+                    className={styles.input}
+                  />
+                </Tooltip>
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Storypoint&nbsp;Coefficient"
-              inline={true}
-              labelFor="jira-storypoint-coef"
-              helperText="JIRA_ISSUE_STORYPOINT_COEFFICIENT"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Your custom story point coefficent (optional)" position={Position.TOP}>
-                <InputGroup
-                  id="jira-storypoint-coef"
-                  placeholder="Enter Jira Story Point Coefficient"
-                  defaultValue={jiraIssueStoryCoefficient}
-                  onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
-                  className={styles.input}
-                />
-              </Tooltip>
-            </FormGroup>
-          </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                label="Issue&nbsp;Storypoint&nbsp;Field"
+                inline={true}
+                labelFor="jira-storypoint-field"
+                helperText="JIRA_ISSUE_STORYPOINT_FIELD"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Your custom story point key field (optional)" position={Position.TOP}>
+                  <InputGroup
+                    id="jira-storypoint-field"
+                    placeholder="Enter Jira Story Point Field"
+                    defaultValue={jiraIssueStoryPointField}
+                    onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
+                    className={styles.input}
+                  />
+                </Tooltip>
+              </FormGroup>
+            </div>
 
-          <div className={styles.formContainer}>
-            <FormGroup
-              label="Issue&nbsp;Storypoint&nbsp;Field"
-              inline={true}
-              labelFor="jira-storypoint-field"
-              helperText="JIRA_ISSUE_STORYPOINT_FIELD"
-              className={styles.formGroup}
-              contentClassName={styles.formGroup}
-            >
-              <Tooltip content="Your custom story point key field (optional)" position={Position.TOP}>
-                <InputGroup
-                  id="jira-storypoint-field"
-                  placeholder="Enter Jira Story Point Field"
-                  defaultValue={jiraIssueStoryPointField}
-                  onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
-                  className={styles.input}
-                />
-              </Tooltip>
-            </FormGroup>
-          </div>
+            <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
 
-          <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
+          </form>
+
+          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Replace native `alert()` messages on form submit for all form pages (configuration/plugins) with a nicer, in browser dialog UI component

### Does this close any open issues?
no

### Current Behavior
native alert on form submit isnt the best user experience, and we can't control much

### New Behavior
New dialog lets us (in the first steps at least) show to user better how to restart server

### Screenshots
![Screen Shot 2021-09-16 at 2 12 53 PM](https://user-images.githubusercontent.com/3789273/133664374-f0926832-b710-47d5-a464-02237455eb0e.png)


