### PR TITLE
feat: add new required forms setup and help icons

### DIFF
--- a/config-ui/pages/index.jsx
+++ b/config-ui/pages/index.jsx
@@ -5,7 +5,7 @@ import path from 'path'
 import * as fs from 'fs/promises'
 import { existsSync } from 'fs';
 import styles from '../styles/Home.module.css'
-import { FormGroup, InputGroup, Button, Alert, Tooltip, Position } from '@blueprintjs/core'
+import { FormGroup, InputGroup, Button, Alert, Tooltip, Position, Label } from '@blueprintjs/core'
 import Nav from '../components/Nav'
 import Sidebar from '../components/Sidebar'
 import Content from '../components/Content'
@@ -63,7 +63,6 @@ export default function Home(props) {
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Database&nbsp;URL"
                 inline={true}
                 labelFor="db-url"
                 className={styles.formGroup}
@@ -71,13 +70,16 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="The URL Connection string to the database" position={Position.TOP}>
-                  <InputGroup
-                    id="db-url"
-                    placeholder="Enter DB Connection String"
-                    defaultValue={dbUrl}
-                    onChange={(e) => setDbUrl(e.target.value)}
-                    className={styles.input}
-                  />
+                  <Label>
+                    Database&nbsp;URL <span className={styles.requiredStar}>*</span>
+                    <InputGroup
+                      id="db-url"
+                      placeholder="Enter DB Connection String"
+                      defaultValue={dbUrl}
+                      onChange={(e) => setDbUrl(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
@@ -89,7 +91,6 @@ export default function Home(props) {
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Port"
                 inline={true}
                 labelFor="port"
                 className={styles.formGroup}
@@ -97,20 +98,22 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="The main port for the REST server" position={Position.TOP}>
-                  <InputGroup
-                    id="port"
-                    placeholder="Enter Port eg. :8080"
-                    defaultValue={port}
-                    onChange={(e) => setPort(e.target.value)}
-                    className={styles.input}
-                  />
+                  <Label>
+                    Port <span className={styles.requiredStar}>*</span>
+                    <InputGroup
+                      id="port"
+                      placeholder="Enter Port eg. :8080"
+                      defaultValue={port}
+                      onChange={(e) => setPort(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Mode"
                 inline={true}
                 labelFor="mode"
                 className={styles.formGroup}
@@ -118,13 +121,16 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="The development mode for the server" position={Position.TOP}>
-                  <InputGroup
-                    id="mode"
-                    placeholder="Enter Mode eg. debug"
-                    defaultValue={mode}
-                    onChange={(e) => setMode(e.target.value)}
-                    className={styles.input}
-                  />
+                  <Label>
+                    Mode
+                    <InputGroup
+                      id="mode"
+                      placeholder="Enter Mode eg. debug"
+                      defaultValue={mode}
+                      onChange={(e) => setMode(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>

--- a/config-ui/pages/plugins/gitlab.jsx
+++ b/config-ui/pages/plugins/gitlab.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import { useState, useEffect } from 'react'
 import styles from '../../styles/Home.module.css'
-import { FormGroup, InputGroup, Button, TextArea, Intent } from "@blueprintjs/core"
+import { FormGroup, InputGroup, Button, Label } from "@blueprintjs/core"
 import dotenv from 'dotenv'
 import path from 'path'
 import * as fs from 'fs/promises'
@@ -47,56 +47,58 @@ export default function Home(props) {
       <Content>
         <main className={styles.main}>
 
-          <div className={styles.headlineContainer}>
-            <h2 className={styles.headline}>Gitlab Configuration</h2>
-            <p className={styles.description}>Gitlab account and config settings</p>
-          </div>
-
           <form className={styles.form}>
+            <div className={styles.headlineContainer}>
+              <h2 className={styles.headline}>Gitlab Configuration</h2>
+              <p className={styles.description}>Gitlab account and config settings</p>
+            </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="API&nbsp;Endpoint"
                 inline={true}
                 labelFor="gitlab-endpoint"
                 helperText="GITLAB_ENDPOINT"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="gitlab-endpoint"
-                  placeholder="Enter Gitlab API endpoint"
-                  defaultValue={gitlabEndpoint}
-                  onChange={(e) => setGitlabEndpoint(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  API&nbsp;Endpoint <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="gitlab-endpoint"
+                    placeholder="Enter Gitlab API endpoint"
+                    defaultValue={gitlabEndpoint}
+                    onChange={(e) => setGitlabEndpoint(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Auth&nbsp;Token"
                 inline={true}
                 labelFor="gitlab-auth"
                 helperText="GITLAB_AUTH"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="gitlab-auth"
-                  placeholder="Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz"
-                  defaultValue={gitlabAuth}
-                  onChange={(e) => setGitlabAuth(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Auth&nbsp;Token <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="gitlab-auth"
+                    placeholder="Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz"
+                    defaultValue={gitlabAuth}
+                    onChange={(e) => setGitlabAuth(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
             <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
 
+            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
           </form>
-
-          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>

--- a/config-ui/pages/plugins/jenkins.jsx
+++ b/config-ui/pages/plugins/jenkins.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import { useState, useEffect } from 'react'
 import styles from '../../styles/Home.module.css'
-import { FormGroup, InputGroup, Button, TextArea, Intent } from "@blueprintjs/core"
+import { FormGroup, InputGroup, Button, Label } from "@blueprintjs/core"
 import dotenv from 'dotenv'
 import path from 'path'
 import * as fs from 'fs/promises'
@@ -48,76 +48,79 @@ export default function Home(props) {
       <Sidebar />
       <Content>
         <main className={styles.main}>
-
-          <div className={styles.headlineContainer}>
-            <h2 className={styles.headline}>Jenkins Configuration</h2>
-            <p className={styles.description}>Jenkins account and config settings</p>
-          </div>
-
           <form className={styles.form}>
+
+            <div className={styles.headlineContainer}>
+              <h2 className={styles.headline}>Jenkins Configuration</h2>
+              <p className={styles.description}>Jenkins account and config settings</p>
+            </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="API&nbsp;Endpoint"
                 inline={true}
                 labelFor="jenkins-endpoint"
                 helperText="JENKINS_ENDPOINT"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="jenkins-endpoint"
-                  placeholder="Enter Jenkins API endpoint"
-                  defaultValue={jenkinsEndpoint}
-                  onChange={(e) => setJenkinsEndpoint(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  API&nbsp;Endpoint <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="jenkins-endpoint"
+                    placeholder="Enter Jenkins API endpoint"
+                    defaultValue={jenkinsEndpoint}
+                    onChange={(e) => setJenkinsEndpoint(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Username"
                 inline={true}
                 labelFor="jenkins-username"
                 helperText="JENKINS_USERNAME"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="jenkins-username"
-                  placeholder="Enter Jenkins Username"
-                  defaultValue={jenkinsUsername}
-                  onChange={(e) => setJenkinsUsername(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Username <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="jenkins-username"
+                    placeholder="Enter Jenkins Username"
+                    defaultValue={jenkinsUsername}
+                    onChange={(e) => setJenkinsUsername(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Password"
                 inline={true}
                 labelFor="jenkins-password"
                 helperText="JENKINS_PASSWORD"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="jenkins-password"
-                  placeholder="Enter Jenkins Password"
-                  defaultValue={jenkinsPassword}
-                  onChange={(e) => setJenkinsPassword(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Password <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="jenkins-password"
+                    placeholder="Enter Jenkins Password"
+                    defaultValue={jenkinsPassword}
+                    onChange={(e) => setJenkinsPassword(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
+            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
             <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
-
           </form>
-
-          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>

--- a/config-ui/pages/plugins/jira.jsx
+++ b/config-ui/pages/plugins/jira.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import { useState, useEffect } from 'react'
 import styles from '../../styles/Home.module.css'
-import { Tooltip, Position, FormGroup, InputGroup, Button } from '@blueprintjs/core'
+import { Tooltip, Position, FormGroup, InputGroup, Button, Label, Icon } from '@blueprintjs/core'
 import dotenv from 'dotenv'
 import path from 'path'
 import * as fs from 'fs/promises'
@@ -63,91 +63,86 @@ export default function Home(props) {
       <Content>
         <main className={styles.main}>
 
-          <div className={styles.headlineContainer}>
-            <h2 className={styles.headline}>Jira Plugin</h2>
-            <p className={styles.description}>Jira Account and config settings</p>
-          </div>
-
           <form className={styles.form}>
 
             <div className={styles.headlineContainer}>
-              <h3 className={styles.headline}>URL Endpoint</h3>
-              <p className={styles.description}>The custom endpoint URL for your Jira project</p>
+              <h2 className={styles.headline}>Jira Plugin</h2>
+              <p className={styles.description}>Jira Account and config settings</p>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Endpoint&nbsp;URL"
+                label=""
                 inline={true}
                 labelFor="jira-endpoint"
                 helperText="JIRA_ENDPOINT"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="jira-endpoint"
-                  placeholder="Enter Jira endpoint eg. https://merico.atlassian.net"
-                  defaultValue={jiraEndpoint}
-                  onChange={(e) => setJiraEndpoint(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Endpoint&nbsp;URL <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="jira-endpoint"
+                    placeholder="Enter Jira endpoint eg. https://merico.atlassian.net"
+                    defaultValue={jiraEndpoint}
+                    onChange={(e) => setJiraEndpoint(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
-            </div>
-
-            <div className={styles.headlineContainer}>
-              <h3 className={styles.headline}>API Token</h3>
-              <p className={styles.description}>Your Jira specific API auth token. Should be encoded using command: <br/><br/><code>{`echo -n `}<b>{`<jira login email>`}</b>:<b>{`<jira token>`}</b>{` | base64`}</code></p>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Basic&nbsp;Auth&nbsp;Token"
                 inline={true}
                 labelFor="jira-basic-auth"
                 helperText="JIRA_BASIC_AUTH_ENCODED"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <InputGroup
-                  id="jira-basic-auth"
-                  placeholder="Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47"
-                  defaultValue={jiraBasicAuthEncoded}
-                  onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Basic&nbsp;Auth&nbsp;Token <span className={styles.requiredStar}>*</span>
+                  <InputGroup
+                    id="jira-basic-auth"
+                    placeholder="Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47"
+                    defaultValue={jiraBasicAuthEncoded}
+                    onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </FormGroup>
             </div>
 
-            <div className={styles.headlineContainer}>
-              <h3 className={styles.headline}>Status Mappings</h3>
-              <p className={styles.description}>Map your custom Jira status to the correct values</p>
-            </div>
+              <div className={styles.headlineContainer}>
+                <h3 className={styles.headline}>Status Mappings</h3>
+                <p className={styles.description}>Map your custom Jira status to the correct values</p>
+              </div>
 
-            <div className={styles.formContainer}>
-                <FormGroup
-                  label="Issue&nbsp;Type"
-                  inline={true}
-                  labelFor="jira-issue-type-mapping"
-                  helperText="JIRA_ISSUE_TYPE_MAPPING"
-                  className={styles.formGroup}
-                  contentClassName={styles.formGroup}
-                >
-                  <Tooltip content="Map your custom type to Devlake standard type" position={Position.TOP}>
-                    <InputGroup
-                      id="jira-issue-type-mapping"
-                      placeholder="STANDARD_TYPE_1:ORIGIN_TYPE_1,ORIGIN_TYPE_2;STANDARD_TYPE_2:....
-      "
-                      defaultValue={jiraIssueTypeMapping}
-                      onChange={(e) => setJiraIssueTypeMapping(e.target.value)}
-                      className={styles.input}
-                    />
-                  </Tooltip>
-                </FormGroup>
-            </div>
+              <div className={styles.formContainer}>
+                  <FormGroup
+                    inline={true}
+                    labelFor="jira-issue-type-mapping"
+                    helperText="JIRA_ISSUE_TYPE_MAPPING"
+                    className={styles.formGroup}
+                    contentClassName={styles.formGroup}
+                  >
+                    <Tooltip content="Map your custom type to Devlake standard type" position={Position.TOP}>
+                      <Label>
+                      Issue&nbsp;Type
+                      <InputGroup
+                        id="jira-issue-type-mapping"
+                        placeholder="STANDARD_TYPE_1:ORIGIN_TYPE_1,ORIGIN_TYPE_2;STANDARD_TYPE_2:...."
+                        defaultValue={jiraIssueTypeMapping}
+                        onChange={(e) => setJiraIssueTypeMapping(e.target.value)}
+                        className={styles.input}
+                      />
+                      </Label>
+                    </Tooltip>
+                  </FormGroup>
+              </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Issue&nbsp;Bug"
                 inline={true}
                 labelFor="jira-bug-status-mapping"
                 helperText="JIRA_ISSUE_BUG_STATUS_MAPPING"
@@ -155,21 +150,22 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="Map your custom bug status to Devlake standard status" position={Position.TOP}>
-                  <InputGroup
-                    id="jira-issue-type-mapping"
-                    placeholder="STANDARD_TYPE_1:YOUR_TYPE_1,YOUR_TYPE_2;STANDARD_TYPE_2:....
-    "
-                    defaultValue={jiraIssueBugStatusMapping}
-                    onChange={(e) => setJiraIssueBugStatusMapping(e.target.value)}
-                    className={styles.input}
-                  />
+                  <Label>
+                    Issue&nbsp;Bug
+                    <InputGroup
+                      id="jira-bug-status-mapping"
+                      placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                      defaultValue={jiraIssueBugStatusMapping}
+                      onChange={(e) => setJiraIssueBugStatusMapping(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Issue&nbsp;Incident"
                 inline={true}
                 labelFor="jira-incident-status-mapping"
                 helperText="JIRA_ISSUE_INCIDENT_STATUS_MAPPING"
@@ -177,20 +173,22 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="Map your custom incident status to Devlake standard status" position={Position.TOP}>
-                <InputGroup
-                  id="jira-bug-status-mapping"
-                  placeholder="<STANDARD_STATUS_1>:<YOUR_STATUS_1>,<YOUR_STATUS_2>;<STANDARD_STATUS_2>"
-                  defaultValue={jiraIssueIncidentStatusMapping}
-                  onChange={(e) => setJiraIssueIncidentStatusMapping(e.target.value)}
-                  className={styles.input}
-                />
+                  <Label>
+                    Issue&nbsp;Incident
+                    <InputGroup
+                      id="jira-bug-status-mapping"
+                      placeholder="<STANDARD_STATUS_1>:<YOUR_STATUS_1>,<YOUR_STATUS_2>;<STANDARD_STATUS_2>"
+                      defaultValue={jiraIssueIncidentStatusMapping}
+                      onChange={(e) => setJiraIssueIncidentStatusMapping(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
 
           <div className={styles.formContainer}>
             <FormGroup
-              label="Issue&nbsp;Story"
               inline={true}
               labelFor="jira-story-status-mapping"
               helperText="JIRA_ISSUE_STORY_STATUS_MAPPING"
@@ -198,6 +196,8 @@ export default function Home(props) {
               contentClassName={styles.formGroup}
             >
               <Tooltip content="Map your custom story status to Devlake standard status" position={Position.TOP}>
+                <Label>
+                Issue&nbsp;Story
                 <InputGroup
                   id="jira-story-status-mapping"
                   placeholder="<STANDARD_STATUS_1>:<YOUR_STATUS_1>,<YOUR_STATUS_2>;<STANDARD_STATUS_2>"
@@ -205,6 +205,7 @@ export default function Home(props) {
                   onChange={(e) => setJiraIssueStoryStatusMapping(e.target.value)}
                   className={styles.input}
                 />
+                </Label>
               </Tooltip>
             </FormGroup>
           </div>
@@ -216,7 +217,6 @@ export default function Home(props) {
 
             <div className={styles.formContainer}>
             <FormGroup
-              label="Jira&nbsp;Board&nbsp;Gitlab&nbsp;Projects"
               inline={true}
               labelFor="jira-board-projects"
               helperText="JIRA_BOARD_GITLAB_PROJECTS"
@@ -224,13 +224,16 @@ export default function Home(props) {
               contentClassName={styles.formGroup}
             >
               <Tooltip content="Jira board and Gitlab projects relationship" position={Position.TOP}>
-                <InputGroup
-                  id="jira-storypoint-field"
-                  placeholder="<JIRA_BOARD>:<GITLAB_PROJECT_ID>,...; eg. 8:8967944,8967945;9:8967946,8967947"
-                  defaultValue={jiraBoardGitlabeProjects}
-                  onChange={(e) => setJiraBoardGitlabeProjects(e.target.value)}
-                  className={styles.input}
-                />
+                <Label>
+                  Jira&nbsp;Board&nbsp;Gitlab&nbsp;Projects
+                  <InputGroup
+                    id="jira-storypoint-field"
+                    placeholder="<JIRA_BOARD>:<GITLAB_PROJECT_ID>,...; eg. 8:8967944,8967945;9:8967946,8967947"
+                    defaultValue={jiraBoardGitlabeProjects}
+                    onChange={(e) => setJiraBoardGitlabeProjects(e.target.value)}
+                    className={styles.input}
+                  />
+                </Label>
               </Tooltip>
             </FormGroup>
           </div>
@@ -239,10 +242,65 @@ export default function Home(props) {
             <h3 className={styles.headline}>Additional Customization Settings</h3>
             <p className={styles.description}>Additional Jira settings</p>
           </div>
+            <div className={styles.formContainer}>
+              <FormGroup
+                inline={true}
+                labelFor="jira-story-status-mapping"
+                helperText="JIRA_ISSUE_STORY_STATUS_MAPPING"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                <Tooltip content="Map your custom story status to Devlake standard status" position={Position.TOP}>
+                  <Label>
+                    Issue&nbsp;Story
+                    <InputGroup
+                      id="jira-story-status-mapping"
+                      placeholder="<STANDARD_STATUS_1>:<ORIGIN_STATUS_1>,<ORIGIN_STATUS_2>;<STANDARD_STATUS_2>"
+                      defaultValue={jiraIssueStoryStatusMapping}
+                      onChange={(e) => setJiraIssueStoryStatusMapping(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
+                </Tooltip>
+              </FormGroup>
+            </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Issue&nbsp;Storypoint&nbsp;Coefficient"
+                inline={true}
+                labelFor="jira-epic-key"
+                helperText="JIRA_ISSUE_EPIC_KEY_FIELD"
+                className={styles.formGroup}
+                contentClassName={styles.formGroup}
+              >
+                  <Label>
+                    Issue&nbsp;Epic&nbsp;Key&nbsp;Field <span className={styles.requiredStar}>*</span>
+
+                    <div>
+                      <Tooltip content="Get help with Issue Epic Key Field" position={Position.TOP}>
+                        <a href="https://github.com/merico-dev/lake/tree/main/plugins/jira#how-do-i-find-the-custom-field-id-in-jira"
+                          target="_blank"
+                          className={styles.helpIcon}>
+                            <Icon icon="help" size={15} />
+                        </a>
+                      </Tooltip>
+                    </div>
+
+                    <Tooltip content="Your custom epic key field" position={Position.TOP}>
+                      <InputGroup
+                        id="jira-epic-key"
+                        placeholder="Enter Jira epic key field"
+                        defaultValue={jiraIssueEpicKeyField}
+                        onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
+                        className={styles.helperInput}
+                      />
+                    </Tooltip>
+                  </Label>
+              </FormGroup>
+            </div>
+
+            <div className={styles.formContainer}>
+              <FormGroup
                 inline={true}
                 labelFor="jira-storypoint-coef"
                 helperText="JIRA_ISSUE_STORYPOINT_COEFFICIENT"
@@ -250,43 +308,46 @@ export default function Home(props) {
                 contentClassName={styles.formGroup}
               >
                 <Tooltip content="Your custom story point coefficent (optional)" position={Position.TOP}>
-                  <InputGroup
-                    id="jira-storypoint-coef"
-                    placeholder="Enter Jira Story Point Coefficient"
-                    defaultValue={jiraIssueStoryCoefficient}
-                    onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
-                    className={styles.input}
-                  />
+                  <Label>
+                    Issue&nbsp;Storypoint&nbsp;Coefficient <span className={styles.requiredStar}>*</span>
+                    <InputGroup
+                      id="jira-storypoint-coef"
+                      placeholder="Enter Jira Story Point Coefficient"
+                      defaultValue={jiraIssueStoryCoefficient}
+                      onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
 
             <div className={styles.formContainer}>
               <FormGroup
-                label="Issue&nbsp;Storypoint&nbsp;Field"
                 inline={true}
                 labelFor="jira-storypoint-field"
                 helperText="JIRA_ISSUE_STORYPOINT_FIELD"
                 className={styles.formGroup}
                 contentClassName={styles.formGroup}
               >
-                <Tooltip content="Your custom story point key field (optional)" position={Position.TOP}>
-                  <InputGroup
-                    id="jira-storypoint-field"
-                    placeholder="Enter Jira Story Point Field"
-                    defaultValue={jiraIssueStoryPointField}
-                    onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
-                    className={styles.input}
-                  />
+                <Tooltip content="Your custom story point key field" position={Position.TOP}>
+                  <Label>
+                    Issue&nbsp;Storypoint&nbsp;Field
+                    <InputGroup
+                      id="jira-storypoint-field"
+                      placeholder="Enter Jira Story Point Field"
+                      defaultValue={jiraIssueStoryPointField}
+                      onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
+                      className={styles.input}
+                    />
+                  </Label>
                 </Tooltip>
               </FormGroup>
             </div>
 
+            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
             <Button type="submit" outlined={true} large={true} className={styles.saveBtn} onClick={saveAll}>Save Config</Button>
-
           </form>
-
-          <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
         </main>
       </Content>
     </div>

--- a/config-ui/styles/Home.module.css
+++ b/config-ui/styles/Home.module.css
@@ -3,6 +3,7 @@
   justify-content: space-evenly;
   padding-top: 50px;
   min-height: 100vh;
+  overflow: hidden;
 }
 
 .main {
@@ -29,8 +30,30 @@
   margin-right: 0.2rem;
 }
 
-.input, .form {
+.input,
+.helperInput {
+  margin-left: 0.75rem;
+}
+
+.input input,
+.helperInput input {
+  margin-top: 0 !important;
+}
+
+.input, .helperInput, .form {
   width: 100%;
+}
+
+.helperInput {
+  margin-top: -10px;
+  width: calc(100% - 12px) !important;
+}
+
+.requiredStar {
+  color: #F83E3E;
+  font-weight: 600;
+  font-size: 1.2rem;
+  margin-left: 0.25rem;
 }
 
 .codeArea {
@@ -47,6 +70,12 @@
   max-width: 600px;
 }
 
+.helpIcon {
+  margin-left: 0.5rem;
+  position: relative;
+  top: -0.4rem;
+}
+
 .formGroup {
   width: 100%;
   max-width: 600px;
@@ -58,6 +87,9 @@
 
 .formGroup label {
   color: #4B4D58;
+  display: flex;
+  align-items: center;
+  margin-right: 0 !important;
 }
 
 .button {

--- a/config-ui/styles/libraries/blueprint.css
+++ b/config-ui/styles/libraries/blueprint.css
@@ -39,6 +39,7 @@
 }
 
 .bp3-form-helper-text {
-  font-size: 10px !important;
-  opacity: 0.65 !important;
+  font-size: 11px !important;
+  opacity: 0.8 !important;
+  text-align: right;
 }


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
- Add new label setup to all inputs (`<Label>` component now vs a prop). Even on components without a required "`*`", for consistency
- Add required star to new layout setup, of required fields
- Added helper icon functionality. Only one help link right now. Plenty of places we can add more, and build out better docs for specific parts. But its setup now to build on (click `?` link and open docs in new tab). Adding help docs to other fields should be another PR, as we lack docs for a lot of them too.
- Moved env var captions to the right (out of the way) to clear the clutter visually (ex. DB_URL) etc

### Does this close any open issues?
Closes point 3 on [https://github.com/merico-dev/lake/issues/409](https://github.com/merico-dev/lake/issues/409)

### Current Behavior
no visual indication of what fields are required, and no way to help the user be redirected to further docs if they require more help.

### New Behavior
Now have a `*` on required fields and a help icon build in to the layout. 

### Screenshots
![Screen Shot 2021-09-16 at 6 34 28 PM](https://user-images.githubusercontent.com/3789273/133694885-519d7798-f30f-49a7-bb98-810c9c87e582.png)
![Screen Shot 2021-09-16 at 6 34 30 PM](https://user-images.githubusercontent.com/3789273/133695059-9181b020-e5aa-45ed-b558-c8bb1caec80a.png)
![Screen Shot 2021-09-16 at 4 07 52 PM](https://user-images.githubusercontent.com/3789273/133695072-7f74e17c-44f6-41f5-9a8c-1f3654a9bbea.png)

### Other Information
Form validation (ensure required fields have text, formatted properly etc) isn't built yet, will be setup in another PR
