### PR TITLE
GitHub plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,9 @@ JENKINS_ENDPOINT=
 JENKINS_USERNAME=
 JENKINS_PASSWORD=
 
+########################
+# GitHub configuration #
+########################
+
+GITHUB_ENDPOINT=https://api.github.com/
+GITHUB_AUTH=***

--- a/cmd/lake-cli/api/client.go
+++ b/cmd/lake-cli/api/client.go
@@ -63,7 +63,6 @@ func (o *apiOptions) Validate(cmd *cobra.Command, args []string) error {
 }
 
 func (o *apiOptions) Run(cmd *cobra.Command, args []string) error {
-	fmt.Println(args)
 	if strings.TrimSpace(o.Body) != "" {
 		o.Body = readBodyFromFile(o.Body)
 	}

--- a/plugins/compound/compound.go
+++ b/plugins/compound/compound.go
@@ -24,13 +24,11 @@ func (plugin Compound) Init() {
 	if text == "" {
 		return
 	}
-	fmt.Printf("text: %v\n", text)
 	rows := make([]*models.JiraBoardGitlabProject, 0)
 	for _, comp := range strings.Split(text, ";") {
 		if comp == "" {
 			continue
 		}
-		fmt.Printf("comp: %v\n", comp)
 		tmp := strings.Split(comp, ":")
 		if len(tmp) != 2 {
 			panic(fmt.Errorf("[compound] invalid config %v", text))
@@ -47,7 +45,6 @@ func (plugin Compound) Init() {
 		}
 		for _, pid := range projectIds {
 			projectId, _ := strconv.ParseUint(pid, 10, 64)
-			fmt.Printf("boardId: %v, projectId: %v\n", boardId, projectId)
 			if projectId == 0 {
 				panic(fmt.Errorf("[compound] invalid projectId %v", pid))
 			}
@@ -59,7 +56,6 @@ func (plugin Compound) Init() {
 		panic(fmt.Errorf("[compound] failed to truncate jira_board_gitlab_projects"))
 	}
 	for _, row := range rows {
-		fmt.Printf("row: %v\n", row)
 		if row == nil {
 			continue
 		}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -1,0 +1,43 @@
+package main // must be main for plugin entry point
+
+import (
+	"github.com/merico-dev/lake/logger" // A pseudo type for Plugin Interface implementation
+	"github.com/merico-dev/lake/plugins/github/tasks"
+)
+
+type Github string
+
+func (plugin Github) Description() string {
+	return "To collect and enrich data from GitHub"
+}
+
+func (plugin Github) Execute(options map[string]interface{}, progress chan<- float32) {
+	logger.Print("start github plugin execution")
+
+	owner, ok := options["owner"]
+	if !ok {
+		logger.Print("owner is required for github execution")
+		return
+	}
+	ownerString := owner.(string)
+
+	repositoryName, ok := options["repositoryName"]
+	if !ok {
+		logger.Print("repositoryName is required for github execution")
+		return
+	}
+	repositoryNameString := repositoryName.(string)
+
+	if err := tasks.CollectRepository(ownerString, repositoryNameString); err != nil {
+		logger.Error("Could not collect repositories: ", err)
+		return
+	}
+
+	progress <- 1
+
+	close(progress)
+
+}
+
+// Export a variable named PluginEntry for Framework to search and load
+var PluginEntry Github //nolint

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -28,17 +28,23 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	repositoryNameString := repositoryName.(string)
 
-	repoId, err := tasks.CollectRepository(ownerString, repositoryNameString)
-	if err != nil {
-		logger.Error("Could not collect repositories: ", err)
+	repoId, collectRepoErr := tasks.CollectRepository(ownerString, repositoryNameString)
+	if collectRepoErr != nil {
+		logger.Error("Could not collect repositories: ", collectRepoErr)
 		return
 	}
 
-	if err := tasks.CollectCommits(ownerString, repositoryNameString, repoId); err != nil {
-		logger.Error("Could not collect repositories: ", err)
+	collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId)
+	if collectCommitsErr != nil {
+		logger.Error("Could not collect commits: ", collectCommitsErr)
 		return
 	}
 
+	collectPRsErr := tasks.CollectPullRequests(ownerString, repositoryNameString, repoId)
+	if collectPRsErr != nil {
+		logger.Error("Could not collect pull requests: ", collectPRsErr)
+		return
+	}
 	progress <- 1
 
 	close(progress)

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -28,12 +28,13 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	repositoryNameString := repositoryName.(string)
 
-	if err := tasks.CollectRepository(ownerString, repositoryNameString); err != nil {
+	repoId, err := tasks.CollectRepository(ownerString, repositoryNameString)
+	if err != nil {
 		logger.Error("Could not collect repositories: ", err)
 		return
 	}
 
-	if err := tasks.CollectCommits(ownerString, repositoryNameString); err != nil {
+	if err := tasks.CollectCommits(ownerString, repositoryNameString, repoId); err != nil {
 		logger.Error("Could not collect repositories: ", err)
 		return
 	}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -33,6 +33,11 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		return
 	}
 
+	if err := tasks.CollectCommits(ownerString, repositoryNameString); err != nil {
+		logger.Error("Could not collect repositories: ", err)
+		return
+	}
+
 	progress <- 1
 
 	close(progress)

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -16,14 +16,14 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 
 	owner, ok := options["owner"]
 	if !ok {
-		logger.Print("owner is required for github execution")
+		logger.Print("owner is required for GitHub execution")
 		return
 	}
 	ownerString := owner.(string)
 
 	repositoryName, ok := options["repositoryName"]
 	if !ok {
-		logger.Print("repositoryName is required for github execution")
+		logger.Print("repositoryName is required for GitHub execution")
 		return
 	}
 	repositoryNameString := repositoryName.(string)

--- a/plugins/github/init.go
+++ b/plugins/github/init.go
@@ -11,6 +11,7 @@ func (plugin Github) Init() {
 	err := lakeModels.Db.AutoMigrate(
 		&models.GithubRepository{},
 		&models.GithubCommit{},
+		&models.GithubPullRequest{},
 	)
 	if err != nil {
 		logger.Error("Error migrating github: ", err)

--- a/plugins/github/init.go
+++ b/plugins/github/init.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/github/models"
+)
+
+func (plugin Github) Init() {
+	logger.Info("INFO >>> init GitHub plugin", true)
+	err := lakeModels.Db.AutoMigrate(
+		&models.GithubRepository{},
+		&models.GithubCommit{},
+	)
+	if err != nil {
+		logger.Error("Error migrating github: ", err)
+		panic(err)
+	}
+}

--- a/plugins/github/models/github_commit.go
+++ b/plugins/github/models/github_commit.go
@@ -6,7 +6,7 @@ import (
 
 type GithubCommit struct {
 	Sha            string `gorm:"primaryKey"`
-	Repository     string
+	RepositoryId   int    `gorm:"index"`
 	AuthorName     string
 	AuthorEmail    string
 	AuthoredDate   string

--- a/plugins/github/models/github_commit.go
+++ b/plugins/github/models/github_commit.go
@@ -1,0 +1,13 @@
+package models
+
+import (
+	"github.com/merico-dev/lake/models"
+)
+
+type GithubCommit struct {
+	GithubId     string `gorm:"primaryKey"`
+	RepositoryId int    `gorm:"index"`
+	Title        string
+
+	models.NoPKModel
+}

--- a/plugins/github/models/github_commit.go
+++ b/plugins/github/models/github_commit.go
@@ -5,9 +5,16 @@ import (
 )
 
 type GithubCommit struct {
-	GithubId     string `gorm:"primaryKey"`
-	RepositoryId int    `gorm:"index"`
-	Title        string
+	Sha            string `gorm:"primaryKey"`
+	Repository     string
+	AuthorName     string
+	AuthorEmail    string
+	AuthoredDate   string
+	CommitterName  string
+	CommitterEmail string
+	CommittedDate  string
+	Message        string
+	Url            string
 
 	models.NoPKModel
 }

--- a/plugins/github/models/github_pull_request.go
+++ b/plugins/github/models/github_pull_request.go
@@ -1,0 +1,16 @@
+package models
+
+import "github.com/merico-dev/lake/models"
+
+type GithubPullRequest struct {
+	GithubId        int `gorm:"primaryKey"`
+	RepositoryId    int `gorm:"index"`
+	State           string
+	Title           string
+	HTMLUrl         string
+	MergedAt        string
+	GithubCreatedAt string
+	ClosedAt        string
+
+	models.NoPKModel
+}

--- a/plugins/github/models/github_repository.go
+++ b/plugins/github/models/github_repository.go
@@ -1,0 +1,11 @@
+package models
+
+import "github.com/merico-dev/lake/models"
+
+type GithubRepository struct {
+	GithubId int `gorm:"primaryKey"`
+	Name     string
+	HTMLUrl  string
+
+	models.NoPKModel
+}

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -60,7 +60,7 @@ func getPaginationInfo(resourceUriFormat string) (int, int, error) {
 	var paginationInfo githubUtils.PagingInfo
 	paginationInfo, err = githubUtils.GetPagingFromLinkHeader(linkHeader)
 	if err != nil {
-		logger.Error("pagination info", err)
+		logger.Error("Pagination Info", err)
 	}
 
 	if paginationInfo.Last != "" {
@@ -79,11 +79,7 @@ func getPaginationInfo(resourceUriFormat string) (int, int, error) {
 		panic(err)
 	}
 	rateLimitResetTime := time.Unix(i, 0)
-	// rateLimitResetTime, err := http.ParseTime()
-	// if err != nil {
-	// 	logger.Error("Parse error: ", err)
-	// 	return 0, 0, err
-	// }
+
 	rateLimitInt, err := strconv.Atoi(rateRemaining)
 	if err != nil {
 		logger.Error("Convert error: ", err)
@@ -208,7 +204,7 @@ func (githubApiClient *GithubApiClient) FetchWithPagination(resourceUri string, 
 	total, _, _ := getPaginationInfo(resourceUriFormat)
 	// Loop until all pages are requested
 	fmt.Println("INFO >>> total pages", total)
-	for i := 0; (i * pageSize) < total; i++ {
+	for i := 0; i < total; i++ {
 		// we need to save the value for the request so it is not overwritten
 		currentPage := i
 		url := fmt.Sprintf(resourceUriFormat, currentPage, pageSize)

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -1,0 +1,215 @@
+package tasks
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/merico-dev/lake/config"
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/utils"
+)
+
+type GithubApiClient struct {
+	core.ApiClient
+}
+
+var githubApiClient *GithubApiClient
+
+func CreateApiClient() *GithubApiClient {
+	if githubApiClient == nil {
+		githubApiClient = &GithubApiClient{}
+		githubApiClient.Setup(
+			config.V.GetString("GITHUB_ENDPOINT"),
+			map[string]string{
+				"Authorization": fmt.Sprintf("Bearer %v", config.V.GetString("GITHUB_AUTH")),
+			},
+			10*time.Second,
+			3,
+		)
+	}
+	return githubApiClient
+}
+
+type GithubPaginationHandler func(res *http.Response) error
+
+func getTotal(resourceUriFormat string) (int, int, error) {
+	// jsut get the first page of results. The response has a head that tells the total pages
+	page := 0
+	page_size := 1
+	res, err := githubApiClient.Get(fmt.Sprintf(resourceUriFormat, page_size, page), nil, nil)
+
+	if err != nil {
+		resBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			logger.Error("UnmarshalResponse failed: ", string(resBody))
+			return 0, 0, err
+		}
+		logger.Print(string(resBody) + "\n")
+		return 0, 0, err
+	}
+
+	totalInt := -1
+	total := res.Header.Get("X-Total")
+	if total != "" {
+		totalInt, err = convertStringToInt(total)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	rateRemaining := res.Header.Get("ratelimit-remaining")
+	date, err := http.ParseTime(res.Header.Get("date"))
+	if err != nil {
+		return 0, 0, err
+	}
+	rateLimitResetTime, err := http.ParseTime(res.Header.Get("ratelimit-resettime"))
+	if err != nil {
+		return 0, 0, err
+	}
+	rateLimitInt, err := strconv.Atoi(rateRemaining)
+	if err != nil {
+		return 0, 0, err
+	}
+	rateLimitPerSecond := rateLimitInt / int(rateLimitResetTime.Unix()-date.Unix()) * 9 / 10
+	return totalInt, rateLimitPerSecond, nil
+}
+
+func convertStringToInt(input string) (int, error) {
+	return strconv.Atoi(input)
+}
+
+// run all requests in an Ants worker pool
+func (githubApiClient *GithubApiClient) FetchWithPaginationAnts(resourceUri string, pageSize int, handler GithubPaginationHandler) error {
+
+	var resourceUriFormat string
+	if strings.ContainsAny(resourceUri, "?") {
+		resourceUriFormat = resourceUri + "&per_page=%v&page=%v"
+	} else {
+		resourceUriFormat = resourceUri + "?per_page=%v&page=%v"
+	}
+	// We need to get the total pages first so we can loop through all requests concurrently
+	total, rateLimitPerSecond, err := getTotal(resourceUriFormat)
+	if err != nil {
+		return err
+	}
+
+	workerNum := 50
+	// set up the worker pool
+	scheduler, err := utils.NewWorkerScheduler(workerNum, rateLimitPerSecond)
+	if err != nil {
+		return err
+	}
+
+	defer scheduler.Release()
+
+	// not all api return x-total header, use step concurrency
+	if total == -1 {
+		// TODO: How do we know how high we can set the conc? Is is rateLimit?
+		conc := 10
+		step := 0
+		c := make(chan bool)
+		for {
+			for i := conc; i > 0; i-- {
+				page := step*conc + i
+				err := scheduler.Submit(func() error {
+					url := fmt.Sprintf(resourceUriFormat, pageSize, page)
+					res, err := githubApiClient.Get(url, nil, nil)
+					if err != nil {
+						return err
+					}
+					handlerErr := handler(res)
+					if handlerErr != nil {
+						return handlerErr
+					}
+					_, err = strconv.ParseInt(res.Header.Get("X-Next-Page"), 10, 32)
+					// only send message to channel if I'm the last page
+					if page%conc == 0 {
+						if err != nil {
+							fmt.Println(page, "has no next page")
+							c <- false
+						} else {
+							fmt.Printf("page: %v send true\n", page)
+							c <- true
+						}
+					}
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+			}
+			cont := <-c
+			if !cont {
+				break
+			}
+			step += 1
+		}
+	} else {
+		// Loop until all pages are requested
+		for i := 1; (i * pageSize) <= (total + pageSize); i++ {
+			// we need to save the value for the request so it is not overwritten
+			currentPage := i
+			err1 := scheduler.Submit(func() error {
+				url := fmt.Sprintf(resourceUriFormat, pageSize, currentPage)
+
+				res, err := githubApiClient.Get(url, nil, nil)
+
+				if err != nil {
+					return err
+				}
+
+				handlerErr := handler(res)
+				if handlerErr != nil {
+					return handlerErr
+				}
+				return nil
+			})
+
+			if err1 != nil {
+				return err
+			}
+		}
+	}
+
+	scheduler.WaitUntilFinish()
+	return nil
+}
+
+// fetch paginated without ANTS worker pool
+func (githubApiClient *GithubApiClient) FetchWithPagination(resourceUri string, pageSize int, handler GithubPaginationHandler) error {
+
+	var resourceUriFormat string
+	if strings.ContainsAny(resourceUri, "?") {
+		resourceUriFormat = resourceUri + "&per_page=%v&page=%v"
+	} else {
+		resourceUriFormat = resourceUri + "?per_page=%v&page=%v"
+	}
+
+	// We need to get the total pages first so we can loop through all requests concurrently
+	total, _, _ := getTotal(resourceUriFormat)
+
+	// Loop until all pages are requested
+	for i := 0; (i * pageSize) < total; i++ {
+		// we need to save the value for the request so it is not overwritten
+		currentPage := i
+		url := fmt.Sprintf(resourceUriFormat, pageSize, currentPage)
+
+		res, err := githubApiClient.Get(url, nil, nil)
+
+		if err != nil {
+			return err
+		}
+
+		handlerErr := handler(res)
+		if handlerErr != nil {
+			return handlerErr
+		}
+	}
+
+	return nil
+}

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -32,7 +32,7 @@ type Commit struct {
 	Message string
 }
 
-func CollectCommits(owner string, repositoryName string) error {
+func CollectCommits(owner string, repositoryName string, repositoryId int) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
 	return githubApiClient.FetchWithPagination(getUrl, 100,
@@ -46,7 +46,7 @@ func CollectCommits(owner string, repositoryName string) error {
 			for _, commit := range *githubApiResponse {
 				githubCommit := &models.GithubCommit{
 					Sha:            commit.Sha,
-					Repository:     repositoryName,
+					RepositoryId:   repositoryId,
 					Message:        commit.Commit.Message,
 					AuthorName:     commit.Commit.Author.Name,
 					AuthorEmail:    commit.Commit.Author.Email,

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -35,7 +35,7 @@ type Commit struct {
 func CollectCommits(owner string, repositoryName string, repositoryId int) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
-	return githubApiClient.FetchWithPagination(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -1,0 +1,45 @@
+package tasks
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/github/models"
+	"gorm.io/gorm/clause"
+)
+
+type ApiCommitsResponse struct {
+	GithubId     string `json:"id"`
+	RepositoryId int    `json:"repository_id"`
+	Title        string
+}
+
+func CollectCommits(owner string, repositoryName string) error {
+	githubApiClient := CreateApiClient()
+	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
+	return githubApiClient.FetchWithPagination(getUrl, 100,
+		func(res *http.Response) error {
+			githubApiResponse := &ApiCommitsResponse{}
+			err := core.UnmarshalResponse(res, githubApiResponse)
+			if err != nil {
+				logger.Error("Error: ", err)
+				return err
+			}
+			githubCommits := &models.GithubCommit{
+				GithubId:     githubApiResponse.GithubId,
+				RepositoryId: githubApiResponse.RepositoryId,
+				Title:        githubApiResponse.Title,
+			}
+			err = lakeModels.Db.Clauses(clause.OnConflict{
+				UpdateAll: true,
+			}).Create(&githubCommits).Error
+			if err != nil {
+				logger.Error("Could not upsert: ", err)
+			}
+			return nil
+
+		})
+}

--- a/plugins/github/tasks/github_pull_requests_collector.go
+++ b/plugins/github/tasks/github_pull_requests_collector.go
@@ -1,0 +1,57 @@
+package tasks
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/github/models"
+	"gorm.io/gorm/clause"
+)
+
+type ApiPullsResponse []Pull
+
+type Pull struct {
+	GithubId        int `json:"id"`
+	State           string
+	Title           string
+	HTMLUrl         string `json:"html_url"`
+	MergedAt        string `json:"merged_at"`
+	GithubCreatedAt string `json:"created_at"`
+	ClosedAt        string `json:"closed_at"`
+}
+
+func CollectPullRequests(owner string, repositoryName string, repositoryId int) error {
+	githubApiClient := CreateApiClient()
+	getUrl := fmt.Sprintf("repos/%v/%v/pulls?state=all", owner, repositoryName)
+	return githubApiClient.FetchWithPagination(getUrl, 100,
+		func(res *http.Response) error {
+			githubApiResponse := &ApiPullsResponse{}
+			err := core.UnmarshalResponse(res, githubApiResponse)
+			if err != nil {
+				logger.Error("Error: ", err)
+				return err
+			}
+			for _, pull := range *githubApiResponse {
+				githubPull := &models.GithubPullRequest{
+					GithubId:        pull.GithubId,
+					RepositoryId:    repositoryId,
+					State:           pull.State,
+					Title:           pull.Title,
+					HTMLUrl:         pull.HTMLUrl,
+					MergedAt:        pull.MergedAt,
+					GithubCreatedAt: pull.GithubCreatedAt,
+					ClosedAt:        pull.ClosedAt,
+				}
+				err = lakeModels.Db.Clauses(clause.OnConflict{
+					UpdateAll: true,
+				}).Create(&githubPull).Error
+				if err != nil {
+					logger.Error("Could not upsert: ", err)
+				}
+			}
+			return nil
+		})
+}

--- a/plugins/github/tasks/github_pull_requests_collector.go
+++ b/plugins/github/tasks/github_pull_requests_collector.go
@@ -26,7 +26,7 @@ type Pull struct {
 func CollectPullRequests(owner string, repositoryName string, repositoryId int) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls?state=all", owner, repositoryName)
-	return githubApiClient.FetchWithPagination(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_repository_collector.go
+++ b/plugins/github/tasks/github_repository_collector.go
@@ -16,19 +16,19 @@ type ApiRepositoryResponse struct {
 	HTMLUrl  string `json:"html_url"`
 }
 
-func CollectRepository(owner string, repositoryName string) error {
+func CollectRepository(owner string, repositoryName string) (int, error) {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v", owner, repositoryName)
 	res, err := githubApiClient.Get(getUrl, nil, nil)
 	if err != nil {
 		logger.Error("Error: ", err)
-		return err
+		return 0, err
 	}
 	githubApiResponse := &ApiRepositoryResponse{}
 	err = core.UnmarshalResponse(res, githubApiResponse)
 	if err != nil {
 		logger.Error("Error: ", err)
-		return err
+		return 0, err
 	}
 	githubRepository := &models.GithubRepository{
 		Name:     githubApiResponse.Name,
@@ -41,5 +41,5 @@ func CollectRepository(owner string, repositoryName string) error {
 	if err != nil {
 		logger.Error("Could not upsert: ", err)
 	}
-	return nil
+	return githubRepository.GithubId, nil
 }

--- a/plugins/github/tasks/github_repository_collector.go
+++ b/plugins/github/tasks/github_repository_collector.go
@@ -1,0 +1,45 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/github/models"
+	"gorm.io/gorm/clause"
+)
+
+type ApiRepositoryResponse struct {
+	Name     string `json:"name"`
+	GithubId int    `json:"id"`
+	HTMLUrl  string `json:"html_url"`
+}
+
+func CollectRepository(owner string, repositoryName string) error {
+	githubApiClient := CreateApiClient()
+	getUrl := fmt.Sprintf("repos/%v/%v", owner, repositoryName)
+	res, err := githubApiClient.Get(getUrl, nil, nil)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return err
+	}
+	githubApiResponse := &ApiRepositoryResponse{}
+	err = core.UnmarshalResponse(res, githubApiResponse)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return err
+	}
+	githubRepository := &models.GithubRepository{
+		Name:     githubApiResponse.Name,
+		GithubId: githubApiResponse.GithubId,
+		HTMLUrl:  githubApiResponse.HTMLUrl,
+	}
+	err = lakeModels.Db.Clauses(clause.OnConflict{
+		UpdateAll: true,
+	}).Create(&githubRepository).Error
+	if err != nil {
+		logger.Error("Could not upsert: ", err)
+	}
+	return nil
+}

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -2,23 +2,62 @@ package utils
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/merico-dev/lake/logger"
 )
 
 type PagingInfo struct {
-	Next  string
-	Last  string
-	First string
-	Prev  string
+	Next  int
+	Last  int
+	First int
+	Prev  int
 }
 
+type RateLimitInfo struct {
+	Date      time.Time
+	ResetTime time.Time
+	Remaining int
+}
+
+func ConvertRateLimitInfo(date string, resetTime string, remaining string) (RateLimitInfo, error) {
+	convertedDate, err := http.ParseTime(date)
+	if err != nil {
+		fmt.Println("Convert error: ", err)
+	}
+	resetInt, err := strconv.ParseInt(resetTime, 10, 64)
+	if err != nil {
+		fmt.Println("Convert error: ", err)
+	}
+	convertedResetTime := time.Unix(resetInt, 0)
+	convertedRemaining, err := strconv.Atoi(remaining)
+	if err != nil {
+		logger.Error("Convert error: ", err)
+	}
+	return RateLimitInfo{
+		Date:      convertedDate,
+		ResetTime: convertedResetTime,
+		Remaining: convertedRemaining,
+	}, nil
+}
+
+func GetRateLimitPerSecond(info RateLimitInfo) int {
+	return info.Remaining / int(info.ResetTime.Unix()-info.Date.Unix()) * 9 / 10
+}
+func ConvertStringToInt(input string) (int, error) {
+	return strconv.Atoi(input)
+}
 func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 	result := PagingInfo{
-		Next:  "",
-		Last:  "",
-		Prev:  "",
-		First: "",
+		Next:  0,
+		Last:  0,
+		Prev:  0,
+		First: 0,
 	}
 	linksArray := strings.Split(link, ",")
 	pattern1 := regexp.MustCompile(`page=*[0-9]+`)
@@ -33,18 +72,23 @@ func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 				pageNumberString := strings.Replace(pageNumberSubstring, `page=`, ``, 1)
 				pageNameSubstring := string(content[loc2[0]:loc2[1]])
 				pageNameString := strings.Replace(pageNameSubstring, `rel="`, ``, 1)
+
+				pageNumberInt, convertErr := ConvertStringToInt(pageNumberString)
+				if convertErr != nil {
+					return result, convertErr
+				}
 				switch pageNameString {
 				case "next":
-					result.Next = pageNumberString
+					result.Next = pageNumberInt
 
 				case "first":
-					result.First = pageNumberString
+					result.First = pageNumberInt
 
 				case "last":
-					result.Last = pageNumberString
+					result.Last = pageNumberInt
 
 				case "prev":
-					result.Prev = pageNumberString
+					result.Prev = pageNumberInt
 				}
 
 			} else {
@@ -53,6 +97,6 @@ func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 		}
 		return result, nil
 	} else {
-		return result, errors.New("Length of the split array is too short.")
+		return result, errors.New("The link string provided is invalid.")
 	}
 }

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Paging struct {
+	next  string
+	last  string
+	first string
+	prev  string
+}
+
+func GetPagingFromLinkHeader(link string) (Paging, error) {
+	var result Paging
+	linksArray := strings.Split(link, ",")
+	pattern1 := regexp.MustCompile(`page=*[0-9]+`)
+	pattern2 := regexp.MustCompile(`rel="*[a-z]+`)
+	for i := 0; i < len(linksArray); i++ {
+		content := []byte(linksArray[i])
+		loc1 := pattern1.FindIndex(content)
+		loc2 := pattern2.FindIndex(content)
+		pageNumberSubstring := string(content[loc1[0]:loc1[1]])
+		pageNameSubstring := string(content[loc2[0]:loc2[1]])
+		pageNumberString := strings.Replace(pageNumberSubstring, `page=`, ``, 1)
+		pageNameString := strings.Replace(pageNameSubstring, `rel="`, ``, 1)
+		switch pageNameString {
+		case "next":
+			result.next = pageNumberString
+
+		case "first":
+			result.first = pageNumberString
+
+		case "last":
+			result.last = pageNumberString
+
+		case "prev":
+			result.prev = pageNumberString
+		}
+	}
+	return result, nil
+}

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -1,43 +1,58 @@
 package utils
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 )
 
-type Paging struct {
-	next  string
-	last  string
-	first string
-	prev  string
+type PagingInfo struct {
+	Next  string
+	Last  string
+	First string
+	Prev  string
 }
 
-func GetPagingFromLinkHeader(link string) (Paging, error) {
-	var result Paging
+func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
+	result := PagingInfo{
+		Next:  "",
+		Last:  "",
+		Prev:  "",
+		First: "",
+	}
 	linksArray := strings.Split(link, ",")
 	pattern1 := regexp.MustCompile(`page=*[0-9]+`)
 	pattern2 := regexp.MustCompile(`rel="*[a-z]+`)
-	for i := 0; i < len(linksArray); i++ {
-		content := []byte(linksArray[i])
-		loc1 := pattern1.FindIndex(content)
-		loc2 := pattern2.FindIndex(content)
-		pageNumberSubstring := string(content[loc1[0]:loc1[1]])
-		pageNameSubstring := string(content[loc2[0]:loc2[1]])
-		pageNumberString := strings.Replace(pageNumberSubstring, `page=`, ``, 1)
-		pageNameString := strings.Replace(pageNameSubstring, `rel="`, ``, 1)
-		switch pageNameString {
-		case "next":
-			result.next = pageNumberString
+	if len(linksArray) >= 2 {
+		for i := 0; i < len(linksArray); i++ {
+			content := []byte(linksArray[i])
+			loc1 := pattern1.FindIndex(content)
+			loc2 := pattern2.FindIndex(content)
+			if len(loc1) >= 2 && len(loc2) >= 2 {
+				pageNumberSubstring := string(content[loc1[0]:loc1[1]])
+				pageNumberString := strings.Replace(pageNumberSubstring, `page=`, ``, 1)
+				pageNameSubstring := string(content[loc2[0]:loc2[1]])
+				pageNameString := strings.Replace(pageNameSubstring, `rel="`, ``, 1)
+				switch pageNameString {
+				case "next":
+					result.Next = pageNumberString
 
-		case "first":
-			result.first = pageNumberString
+				case "first":
+					result.First = pageNumberString
 
-		case "last":
-			result.last = pageNumberString
+				case "last":
+					result.Last = pageNumberString
 
-		case "prev":
-			result.prev = pageNumberString
+				case "prev":
+					result.Prev = pageNumberString
+				}
+
+			} else {
+				return result, errors.New("Parsed string values aren't long enough.")
+			}
 		}
+		return result, nil
+	} else {
+		return result, errors.New("Length of the split array is too short.")
 	}
-	return result, nil
 }

--- a/plugins/github/utils/utils_test.go
+++ b/plugins/github/utils/utils_test.go
@@ -12,13 +12,14 @@ import (
 // TestParseLinkHeader calls utils.TestParseLinkHeader with a Link header string, checking
 // for a valid return value.
 func TestParseLinkHeader(t *testing.T) {
-	var pagingExpected Paging
+	fmt.Println("INFO >>> Handles good link string")
+	var pagingExpected PagingInfo
 
-	pagingExpected = Paging{
-		next:  "15",
-		last:  "34",
-		first: "1",
-		prev:  "13",
+	pagingExpected = PagingInfo{
+		Next:  "15",
+		Last:  "34",
+		First: "1",
+		Prev:  "13",
 	}
 	linkHeaderFull := `<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="next",
   <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last",
@@ -29,5 +30,20 @@ func TestParseLinkHeader(t *testing.T) {
 		fmt.Println("ERROR: could not get paging from link header", err)
 
 	}
+	assert.Equal(t, result, pagingExpected)
+}
+func TestParseLinkHeaderEmptyString(t *testing.T) {
+	fmt.Println("INFO >>> Handles empty link string")
+	var pagingExpected PagingInfo
+
+	pagingExpected = PagingInfo{
+		Next:  "",
+		Last:  "",
+		First: "",
+		Prev:  "",
+	}
+	linkHeaderFull := ``
+	result, _ := GetPagingFromLinkHeader(linkHeaderFull)
+
 	assert.Equal(t, result, pagingExpected)
 }

--- a/plugins/github/utils/utils_test.go
+++ b/plugins/github/utils/utils_test.go
@@ -13,9 +13,7 @@ import (
 // for a valid return value.
 func TestParseLinkHeader(t *testing.T) {
 	fmt.Println("INFO >>> Handles good link string")
-	var pagingExpected PagingInfo
-
-	pagingExpected = PagingInfo{
+	var pagingExpected = PagingInfo{
 		Next:  "15",
 		Last:  "34",
 		First: "1",
@@ -34,9 +32,7 @@ func TestParseLinkHeader(t *testing.T) {
 }
 func TestParseLinkHeaderEmptyString(t *testing.T) {
 	fmt.Println("INFO >>> Handles empty link string")
-	var pagingExpected PagingInfo
-
-	pagingExpected = PagingInfo{
+	var pagingExpected = PagingInfo{
 		Next:  "",
 		Last:  "",
 		First: "",

--- a/plugins/github/utils/utils_test.go
+++ b/plugins/github/utils/utils_test.go
@@ -14,10 +14,10 @@ import (
 func TestParseLinkHeader(t *testing.T) {
 	fmt.Println("INFO >>> Handles good link string")
 	var pagingExpected = PagingInfo{
-		Next:  "15",
-		Last:  "34",
-		First: "1",
-		Prev:  "13",
+		Next:  15,
+		Last:  34,
+		First: 1,
+		Prev:  13,
 	}
 	linkHeaderFull := `<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="next",
   <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last",
@@ -33,13 +33,28 @@ func TestParseLinkHeader(t *testing.T) {
 func TestParseLinkHeaderEmptyString(t *testing.T) {
 	fmt.Println("INFO >>> Handles empty link string")
 	var pagingExpected = PagingInfo{
-		Next:  "",
-		Last:  "",
-		First: "",
-		Prev:  "",
+		Next:  0,
+		Last:  0,
+		First: 0,
+		Prev:  0,
 	}
 	linkHeaderFull := ``
 	result, _ := GetPagingFromLinkHeader(linkHeaderFull)
 
 	assert.Equal(t, result, pagingExpected)
+}
+func TestGetRateLimitPerSecond(t *testing.T) {
+	fmt.Println("KEVIN >>> hello")
+	date := "Fri, 17 Sep 2021 16:40:23 GMT"
+	resetTime := "1631899671"
+	remaining := "4970"
+
+	rateLimitInfo, err := ConvertRateLimitInfo(date, resetTime, remaining)
+	if err != nil {
+		fmt.Println("KEVIN >>> err", err)
+	}
+	fmt.Println("KEVIN >>> rateLimitInfo", rateLimitInfo)
+	rateLimitPerSecond := GetRateLimitPerSecond(rateLimitInfo)
+
+	fmt.Println("KEVIN >>> rateLimitPerSecond", rateLimitPerSecond)
 }

--- a/plugins/github/utils/utils_test.go
+++ b/plugins/github/utils/utils_test.go
@@ -1,0 +1,33 @@
+// https://golang.org/doc/tutorial/add-a-test
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+)
+
+// TestParseLinkHeader calls utils.TestParseLinkHeader with a Link header string, checking
+// for a valid return value.
+func TestParseLinkHeader(t *testing.T) {
+	var pagingExpected Paging
+
+	pagingExpected = Paging{
+		next:  "15",
+		last:  "34",
+		first: "1",
+		prev:  "13",
+	}
+	linkHeaderFull := `<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="next",
+  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last",
+  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=1>; rel="first",
+  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=13>; rel="prev"`
+	result, err := GetPagingFromLinkHeader(linkHeaderFull)
+	if err != nil {
+		fmt.Println("ERROR: could not get paging from link header", err)
+
+	}
+	assert.Equal(t, result, pagingExpected)
+}


### PR DESCRIPTION
### Description

This PR introduces a new plugin - The GitHub Plugin. 

### Does this close any open issues?
No. It achieves part of issue #407 

### Current Behavior
No GitHub plugin.

### New Behavior
Collects and saves the following data from GitHub:
- Single Repository
- Commits (for the repository)
- Pull Requests (for the repository)

### Screenshots
![image](https://user-images.githubusercontent.com/27032263/133825494-2d759016-fa42-4b8f-83df-a1a9dadc0e8d.png)

### Other Information

It uses pagination without the ants package. Ants can be incorporated in future work.
