### PR TITLE
feat: domain layer plugin

### DIFF
--- a/plugins/domainlayer/README.md
+++ b/plugins/domainlayer/README.md
@@ -1,0 +1,57 @@
+# Why
+
+We have Jira/TAPD for **Project Management**, we have Github/Gitlab/BitBucket for **Code Hosting**, that is, we have
+multiple _Platforms_ for a certain type of problem. So, how can we calculate metrics across different _Platforms_?
+
+For example, some users may use Jira as their **Project Management** platform, the others might opt for TAPD, if we
+were to implement a Requirement Count metrics for all users, should we implement 2 charts for Jira and TAPD
+independently? It's too impractical to begin with.
+
+
+# How
+
+Domain Layer is designed to solve the problem by offering a set of Platform Independent Entities, Devlake divides all
+platforms into three categories: Project Management / Code Hosting / Devops, by abstracting common properties from
+different platforms, we can define a set of Domain Entities for each category.
+
+The following rules make sure Domain Layer Entities serve its purpose
+
+1. Every platform specific entity can be mapped (or split) to one (or more) Domain Layer Entity
+2. Every Domain Layer Entity contains enough information for metrics calculation
+3. Domain Layer Entity should contains some sort of pointer to its origin record, and all entities should use the same
+   pointer schema
+
+# What
+
+## Domain Layer Entity
+
+- Each entity has a incremental primary key named `ID` which is platform independent
+- Each entity has a `OriginKey` describe its origin record in format `<Plugin>:<Entity>:<PK0>:<PK1>`
+- All fields needed for metric calculation
+
+PS: `many-to-many` Entities are not considered as Domain Layer Entity, but part of the system, so they are freed from
+these rules.
+
+
+## Conversion Plugin
+
+- Read data from platform specific table, convert and store record into one or multiple domain table(s)
+- Set `OriginKey`
+- Fields conversion
+
+Sample code:
+
+```go
+
+type Issue struct {
+    ID              uint64
+    OriginKey       string
+    ...
+}
+
+issue := Issue {
+    OriginKey: "jira:jira_issues:10"
+    ...
+}
+
+```

--- a/plugins/domainlayer/domainlayer.go
+++ b/plugins/domainlayer/domainlayer.go
@@ -1,0 +1,32 @@
+package main // must be main for plugin entry point
+
+import (
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/domainlayer/models/code"
+)
+
+// plugin interface
+type DomainLayer string
+
+func (plugin DomainLayer) Init() {
+	err := lakeModels.Db.AutoMigrate(
+		&code.Repo{},
+		&code.Commit{},
+		&code.Pr{},
+		&code.Note{},
+	)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (plugin DomainLayer) Description() string {
+	return "Domain Layer"
+}
+
+func (plugin DomainLayer) Execute(options map[string]interface{}, progress chan<- float32) {
+	progress <- 1
+}
+
+// Export a variable named PluginEntry for Framework to search and load
+var PluginEntry DomainLayer //nolint

--- a/plugins/domainlayer/models/base/base.go
+++ b/plugins/domainlayer/models/base/base.go
@@ -1,0 +1,8 @@
+package base
+
+import "gorm.io/gorm"
+
+type DomainEntity struct {
+	gorm.Model
+	OriginKey string `json:"originKey" gorm:"type:varchar(255);uniqueIndex"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+}

--- a/plugins/domainlayer/models/code/commit.go
+++ b/plugins/domainlayer/models/code/commit.go
@@ -1,0 +1,20 @@
+package code
+
+import (
+	"time"
+
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Commit struct {
+	base.DomainEntity
+	RepoId         uint64 `gorm:"index"`
+	Sha            string
+	Message        string
+	AuthorName     string
+	AuthorEmail    string
+	AuthoredDate   time.Time
+	CommitterName  string
+	CommitterEmail string
+	CommittedDate  time.Time
+}

--- a/plugins/domainlayer/models/code/note.go
+++ b/plugins/domainlayer/models/code/note.go
@@ -1,0 +1,18 @@
+package code
+
+import (
+	"time"
+
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Note struct {
+	base.DomainEntity
+	PrId        uint64 `gorm:"index"`
+	Type        string
+	Author      string
+	Body        string
+	Resolvable  bool // Resolvable means a comment is a code review comment
+	System      bool // System means the comment is generated automatically
+	CreatedDate time.Time
+}

--- a/plugins/domainlayer/models/code/pr.go
+++ b/plugins/domainlayer/models/code/pr.go
@@ -1,0 +1,19 @@
+package code
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Pr struct {
+	base.DomainEntity
+	RepoId      uint64 `gorm:"index"`
+	State       string
+	Title       string
+	Url         string
+	CreatedDate time.Time
+	MergedDate  sql.NullTime
+	ClosedAt    sql.NullTime
+}

--- a/plugins/domainlayer/models/code/repo.go
+++ b/plugins/domainlayer/models/code/repo.go
@@ -1,0 +1,11 @@
+package code
+
+import (
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Repo struct {
+	base.DomainEntity
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}

--- a/plugins/domainlayer/models/devops/pipeline.go
+++ b/plugins/domainlayer/models/devops/pipeline.go
@@ -1,0 +1,18 @@
+package devops
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Pipeline struct {
+	base.DomainEntity
+	RepoId       uint64
+	CommitId     uint64
+	Status       string
+	Duration     int
+	StartedDate  time.Time
+	FinishedDate sql.NullTime
+}

--- a/plugins/domainlayer/models/ticket/board.go
+++ b/plugins/domainlayer/models/ticket/board.go
@@ -1,0 +1,11 @@
+package ticket
+
+import (
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Board struct {
+	base.DomainEntity
+	Name string
+	Url  string
+}

--- a/plugins/domainlayer/models/ticket/issue.go
+++ b/plugins/domainlayer/models/ticket/issue.go
@@ -1,0 +1,26 @@
+package ticket
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
+)
+
+type Issue struct {
+	base.DomainEntity
+
+	// collected fields
+	BoardId        uint64
+	Url            string
+	Key            string
+	Summary        string
+	EpicKey        string
+	Type           string
+	Status         string
+	StoryPoint     uint
+	ResolutionDate sql.NullTime
+	CreatedDate    time.Time
+	UpdatedDate    time.Time
+	LeadTime       uint
+}


### PR DESCRIPTION
# Summary

Domain Entity Plugin

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
All entities are divided into 3 categories:

- `code`: code hosting platforms like github/gitlab
- `devops`: CI/CD platforms like Jenkins/Gitlab pipeline
- `ticket`: project management system like jira/TAPD

This plugin will create all Domain Layer Entities on initialization, and that's all.
Conversion plugins will be implemented separately.

### Does this close any open issues?
Closes #414

### Other Information
@joncodo @kevin-kline  you may merge it if you thought the overall design is ok and continue your work on this plugin.
