### PR TITLE
feat: set OriginKey as primary to support indate

### DIFF
--- a/plugins/domainlayer/models/base/base.go
+++ b/plugins/domainlayer/models/base/base.go
@@ -1,8 +1,8 @@
 package base
 
-import "gorm.io/gorm"
+import "github.com/merico-dev/lake/models"
 
 type DomainEntity struct {
-	gorm.Model
-	OriginKey string `json:"originKey" gorm:"type:varchar(255);uniqueIndex"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	OriginKey string `json:"originKey" gorm:"primaryKey;type:varchar(255)"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	models.NoPKModel
 }


### PR DESCRIPTION
# Summary

@joncodo @kevin-kline 
I'was working on `jira-domain` plugin, had this `indate` operation problem,  maybe we could set `OriginKey` as PrimaryKey so we could do sth like:

```golang
err = lakeModels.Db.Clauses(clause.OnConflict{
	UpdateAll: true,
}).Create(jiraIssue).Error
```

any thought?


### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated
