### PR TITLE
feat: github performance

### DIFF
--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -3,6 +3,7 @@ package main // must be main for plugin entry point
 import (
 	"github.com/merico-dev/lake/logger" // A pseudo type for Plugin Interface implementation
 	"github.com/merico-dev/lake/plugins/github/tasks"
+	"github.com/merico-dev/lake/utils"
 )
 
 type Github string
@@ -12,6 +13,14 @@ func (plugin Github) Description() string {
 }
 
 func (plugin Github) Execute(options map[string]interface{}, progress chan<- float32) {
+	// We need this rate limit set to 1 since there are only 5000 requests per hour allowed for the github api
+	scheduler, err := utils.NewWorkerScheduler(50, 1)
+	if err != nil {
+		logger.Error("could not create scheduler", false)
+	}
+
+	defer scheduler.Release()
+
 	logger.Print("start github plugin execution")
 
 	owner, ok := options["owner"]
@@ -34,20 +43,20 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		return
 	}
 
-	collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId)
+	collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId, scheduler)
 	if collectCommitsErr != nil {
 		logger.Error("Could not collect commits: ", collectCommitsErr)
 		return
 	}
-	tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId)
+	tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId, scheduler)
 
-	collectIssuesErr := tasks.CollectIssues(ownerString, repositoryNameString, repoId)
+	collectIssuesErr := tasks.CollectIssues(ownerString, repositoryNameString, repoId, scheduler)
 	if collectIssuesErr != nil {
 		logger.Error("Could not collect issues: ", collectIssuesErr)
 		return
 	}
 
-	tasks.CollectChildrenOnPullRequests(ownerString, repositoryNameString, repoId)
+	tasks.CollectChildrenOnPullRequests(ownerString, repositoryNameString, repoId, scheduler)
 
 	progress <- 1
 

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -38,181 +37,81 @@ func CreateApiClient() *GithubApiClient {
 
 type GithubPaginationHandler func(res *http.Response) error
 
-func getPaginationInfoFromGitHub(resourceUriFormat string) (githubUtils.PagingInfo, int, error) {
-	// just get the first page of results. The response has a head that tells the total pages
-	paginationInfo := githubUtils.PagingInfo{
-		First: 1,
-		Last:  1,
-		Next:  1,
-		Prev:  1,
-	}
-
-	page := 1
-	page_size := 100 // This is the maximum
-	res, err := githubApiClient.Get(fmt.Sprintf(resourceUriFormat, page, page_size), nil, nil)
-	fmt.Println("INFO >>> res.Status get page info", res.Status)
+// run all requests in an Ants worker pool
+// conc - number of concurent requests you want to run
+func (githubApiClient *GithubApiClient) FetchWithPaginationAnts(resourceUri string, pageSize int, conc int, scheduler *utils.WorkerScheduler, handler GithubPaginationHandler) error {
+	url := AddPagingQueryToUrl(resourceUri)
+	err := RunConcurrently(url, pageSize, conc, scheduler, handler)
 	if err != nil {
-		resBody, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			logger.Error("UnmarshalResponse failed: ", string(resBody))
-			return paginationInfo, 0, err
-		}
-		logger.Print(string(resBody) + "\n")
-		return paginationInfo, 0, err
+		logger.Error("runConcurrently() failed", true)
 	}
-
-	linkHeader := res.Header.Get("Link")
-	// PagingInfo object contains Next, First, Last, and Prev page number
-
-	paginationInfo, err = githubUtils.GetPagingFromLinkHeader(linkHeader)
-	if err != nil {
-		logger.Info("", err)
-	}
-	// These are all strings
-	date := res.Header.Get("Date")
-	reset := res.Header.Get("X-RateLimit-Reset")
-	remaining := res.Header.Get("X-RateLimit-Remaining")
-	rateLimitInfo, rateLimitInfoErr := githubUtils.ConvertRateLimitInfo(date, reset, remaining)
-	if rateLimitInfoErr != nil {
-		fmt.Println("ERROR >>> Rate Limit Info Err: ", rateLimitInfoErr)
-	}
-	rateLimitPerSecond := githubUtils.GetRateLimitPerSecond(rateLimitInfo)
-
-	return paginationInfo, rateLimitPerSecond, nil
+	return nil
 }
 
-// run all requests in an Ants worker pool
-func (githubApiClient *GithubApiClient) FetchWithPaginationAnts(resourceUri string, pageSize int, handler GithubPaginationHandler) error {
-
-	var resourceUriFormat string
-	if strings.ContainsAny(resourceUri, "?") {
-		resourceUriFormat = resourceUri + "&page=%v&per_page=%v"
+func AddPagingQueryToUrl(url string) string {
+	var urlWithPagingQuery string
+	if strings.ContainsAny(url, "?") {
+		urlWithPagingQuery = url + "&page=%v&per_page=%v"
 	} else {
-		resourceUriFormat = resourceUri + "?page=%v&per_page=%v"
+		urlWithPagingQuery = url + "?page=%v&per_page=%v"
+	}
+	return urlWithPagingQuery
+}
+
+// This method exists in the case where we do not know how many pages of data we have to fetch
+// This loops through the data in chunks of `conc` and if there is any request in there with no data returned, we assume we are at the end of the data required to fetch
+// This is needed since we do not want to make a request to get the paging details first since the rate limit for github is so low
+func RunConcurrently(resourceUriFormat string, pageSize int, conc int, scheduler *utils.WorkerScheduler, handler GithubPaginationHandler) error {
+
+	if conc == 0 {
+		logger.Error("you must send a conc count to RunConcurrently()", true)
 	}
 
-	// We need to get the total pages first so we can loop through all requests concurrently
-	paginationInfo, rateLimitPerSecond, err := getPaginationInfoFromGitHub(resourceUriFormat)
-	if err != nil {
-		return err
-	}
-	workerNum := 50
-	// set up the worker pool
-	scheduler, err := utils.NewWorkerScheduler(workerNum, rateLimitPerSecond)
-	if err != nil {
-		return err
-	}
-
-	defer scheduler.Release()
-
-	// if we don't get a "last" result, try going step by step using the "next" property
-	if paginationInfo.Last == 0 {
-		fmt.Println("INFO >>> No last page. Using step concurrency...")
-		// TODO: How do we know how high we can set the conc? Is is rateLimit?
-		conc := 10
-		step := 0
-		c := make(chan bool)
-		for {
-			for i := conc; i > 0; i-- {
-				page := step*conc + i
-				err := scheduler.Submit(func() error {
-					url := fmt.Sprintf(resourceUriFormat, page, pageSize)
-
-					res, err := githubApiClient.Get(url, nil, nil)
-					if err != nil {
-						return err
-					}
-					linkHeader := res.Header.Get("Link")
-					paginationInfo2, getPagingErr := githubUtils.GetPagingFromLinkHeader(linkHeader)
-					if getPagingErr != nil {
-						logger.Info("GetPagingFromLinkHeader err: ", getPagingErr)
-					}
-					handlerErr := handler(res)
-					if handlerErr != nil {
-						return handlerErr
-					}
-					// only send message to channel if I'm the last page
-					if page%conc == 0 {
-						if paginationInfo2.Next == 0 {
-							fmt.Println(page, "has no next page")
-							c <- false
-						} else {
-							fmt.Printf("page: %v send true\n", page)
-							c <- true
-						}
-					}
-					return nil
-				})
-				if err != nil {
-					return err
-				}
-			}
-			cont := <-c
-			if !cont {
-				break
-			}
-			step += 1
-		}
-	} else {
-		fmt.Println("INFO >>> Last page found. Looping through: ", paginationInfo.Last)
-		// Loop until all pages are requested
-		for i := 1; i <= paginationInfo.Last; i++ {
-			// we need to save the value for the request so it is not overwritten
-			currentPage := i
-			err1 := scheduler.Submit(func() error {
-				url := fmt.Sprintf(resourceUriFormat, currentPage, pageSize)
+	// How many requests would you like to send at once in chunks
+	step := 0
+	c := make(chan bool)
+	for {
+		for i := conc; i > 0; i-- {
+			page := step*conc + i
+			err := scheduler.Submit(func() error {
+				url := fmt.Sprintf(resourceUriFormat, page, pageSize)
 				res, err := githubApiClient.Get(url, nil, nil)
-
 				if err != nil {
 					return err
 				}
-
+				linkHeader := res.Header.Get("Link")
+				paginationInfo2, getPagingErr := githubUtils.GetPagingFromLinkHeader(linkHeader)
+				if getPagingErr != nil {
+					logger.Info("GetPagingFromLinkHeader err: ", getPagingErr)
+				}
 				handlerErr := handler(res)
 				if handlerErr != nil {
 					return handlerErr
 				}
+
+				// only send message to channel if I'm the last page
+				if page%conc == 0 {
+					if paginationInfo2.Next == 1 {
+						fmt.Println(page, "has no next page")
+						c <- false
+					} else {
+						fmt.Printf("page: %v send true\n", page)
+						c <- true
+					}
+				}
 				return nil
 			})
-
-			if err1 != nil {
+			if err != nil {
 				return err
 			}
 		}
+		cont := <-c
+		if !cont {
+			break
+		}
+		step += 1
 	}
 
 	scheduler.WaitUntilFinish()
-	return nil
-}
-
-// fetch paginated without ANTS worker pool
-func (githubApiClient *GithubApiClient) FetchWithPagination(resourceUri string, pageSize int, handler GithubPaginationHandler) error {
-
-	var resourceUriFormat string
-	if strings.ContainsAny(resourceUri, "?") {
-		resourceUriFormat = resourceUri + "&page=%v&per_page=%v"
-	} else {
-		resourceUriFormat = resourceUri + "?page=%v&per_page=%v"
-	}
-
-	// We need to get the total pages first so we can loop through all requests concurrently
-	paginationInfo, _, _ := getPaginationInfoFromGitHub(resourceUriFormat)
-	// Loop until all pages are requested
-	// PLEASE NOTE: Pages start at 1. Page 1 and page 0 are the same.
-	logger.Info("INFO >>> Last Page: ", paginationInfo.Last)
-	for i := 1; i <= paginationInfo.Last; i++ {
-		// we need to save the value for the request so it is not overwritten
-		currentPage := i
-		url := fmt.Sprintf(resourceUriFormat, currentPage, pageSize)
-		res, err := githubApiClient.Get(url, nil, nil)
-		if err != nil {
-			return err
-		}
-
-		handlerErr := handler(res)
-		if handlerErr != nil {
-			return handlerErr
-		}
-	}
-
 	return nil
 }

--- a/plugins/github/tasks/github_commits_children_collector.go
+++ b/plugins/github/tasks/github_commits_children_collector.go
@@ -7,15 +7,9 @@ import (
 	"github.com/merico-dev/lake/utils"
 )
 
-func CollectChildrenOnCommits(owner string, repositoryName string, repositoryId int) {
+func CollectChildrenOnCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) {
 	var commits []models.GithubCommit
 	lakeModels.Db.Find(&commits)
-
-	maxWorkersPerSecond := 5 // Needs work - this is a temporary value
-	scheduler, err := utils.NewWorkerScheduler(50, maxWorkersPerSecond)
-	if err != nil {
-		logger.Error("Could not create work scheduler for GitHub Pull Requests", err)
-	}
 
 	for i := 0; i < len(commits); i++ {
 		commit := (commits)[i]

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -8,6 +8,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
+	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -32,10 +33,10 @@ type Commit struct {
 	Message string
 }
 
-func CollectCommits(owner string, repositoryName string, repositoryId int) error {
+func CollectCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_issues_collector.go
+++ b/plugins/github/tasks/github_issues_collector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
 	"github.com/merico-dev/lake/plugins/github/utils"
+	lakeUtils "github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -41,10 +42,10 @@ type Pull struct {
 	ClosedAt        string `json:"closed_at"`
 }
 
-func CollectIssues(owner string, repositoryName string, repositoryId int) error {
+func CollectIssues(owner string, repositoryName string, repositoryId int, scheduler *lakeUtils.WorkerScheduler) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/issues?state=all", owner, repositoryName)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssuesResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_pull_request_children_collector.go
+++ b/plugins/github/tasks/github_pull_request_children_collector.go
@@ -7,35 +7,29 @@ import (
 	"github.com/merico-dev/lake/utils"
 )
 
-func CollectChildrenOnPullRequests(owner string, repositoryName string, repositoryId int) {
+func CollectChildrenOnPullRequests(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) {
 	var prs []models.GithubPullRequest
 	lakeModels.Db.Find(&prs)
-
-	maxWorkersPerSecond := 5 // Needs work - this is a temporary value
-	scheduler, err := utils.NewWorkerScheduler(50, maxWorkersPerSecond)
-	if err != nil {
-		logger.Error("Could not create work scheduler for GitHub Pull Requests", err)
-	}
 
 	for i := 0; i < len(prs); i++ {
 		pr := (prs)[i]
 		err := scheduler.Submit(func() error {
-			reviewErr := CollectPullRequestReviews(owner, repositoryName, repositoryId, &pr)
+			reviewErr := CollectPullRequestReviews(owner, repositoryName, repositoryId, &pr, scheduler)
 			if reviewErr != nil {
 				logger.Error("Could not collect PR reviews", reviewErr)
 				return reviewErr
 			}
-			commentsErr := CollectPullRequestComments(owner, repositoryName, &pr)
+			commentsErr := CollectPullRequestComments(owner, repositoryName, &pr, scheduler)
 			if commentsErr != nil {
 				logger.Error("Could not collect PR Comments", commentsErr)
 				return commentsErr
 			}
-			commitsErr := CollectPullRequestCommits(owner, repositoryName, &pr)
+			commitsErr := CollectPullRequestCommits(owner, repositoryName, &pr, scheduler)
 			if commitsErr != nil {
 				logger.Error("Could not collect PR Comments", commitsErr)
 				return commitsErr
 			}
-			
+
 			// This call is to update the details of the individual pull request with additions / deletions / etc.
 			// prErr := CollectPullRequest(owner, repositoryName, repositoryId, &pr)
 			// if prErr != nil {

--- a/plugins/github/tasks/github_pull_request_comments_collector.go
+++ b/plugins/github/tasks/github_pull_request_comments_collector.go
@@ -8,6 +8,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
+	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -21,10 +22,10 @@ type Comment struct {
 	}
 }
 
-func CollectPullRequestComments(owner string, repositoryName string, pull *models.GithubPullRequest) error {
+func CollectPullRequestComments(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommentResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_commits_collector.go
+++ b/plugins/github/tasks/github_pull_request_commits_collector.go
@@ -8,6 +8,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
+	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -32,10 +33,10 @@ type PrCommit struct {
 	Message string
 }
 
-func CollectPullRequestCommits(owner string, repositoryName string, pull *models.GithubPullRequest) error {
+func CollectPullRequestCommits(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/commits", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommitResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_reviewer_collector.go
+++ b/plugins/github/tasks/github_pull_request_reviewer_collector.go
@@ -8,6 +8,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
+	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -24,10 +25,10 @@ type PullRequestReview struct {
 	SubmittedAt string `json:"submitted_at"`
 }
 
-func CollectPullRequestReviews(owner string, repositoryName string, repositoryId int, pull *models.GithubPullRequest) error {
+func CollectPullRequestReviews(owner string, repositoryName string, repositoryId int, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
 	githubApiClient := CreateApiClient()
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestReviewResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -31,7 +31,7 @@ func ConvertRateLimitInfo(date string, resetTime string, remaining string) (Rate
 			return rateLimitInfo, err
 		}
 	} else {
-		return rateLimitInfo, errors.New("Rate limit date was an empty string")
+		return rateLimitInfo, errors.New("rate limit date was an empty string")
 	}
 	if resetTime != "" {
 		resetInt, err := strconv.ParseInt(resetTime, 10, 64)
@@ -40,7 +40,7 @@ func ConvertRateLimitInfo(date string, resetTime string, remaining string) (Rate
 		}
 		rateLimitInfo.ResetTime = time.Unix(resetInt, 0)
 	} else {
-		return rateLimitInfo, errors.New("Rate limit reset time was an empty string")
+		return rateLimitInfo, errors.New("rate limit reset time was an empty string")
 	}
 	if remaining != "" {
 		rateLimitInfo.Remaining, err = strconv.Atoi(remaining)
@@ -48,7 +48,7 @@ func ConvertRateLimitInfo(date string, resetTime string, remaining string) (Rate
 			return rateLimitInfo, err
 		}
 	} else {
-		return rateLimitInfo, errors.New("Rate remaining was an empty string")
+		return rateLimitInfo, errors.New("rate remaining was an empty string")
 	}
 	return rateLimitInfo, nil
 }
@@ -105,11 +105,11 @@ func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 				}
 
 			} else {
-				return result, errors.New("Parsed string values aren't long enough.")
+				return result, errors.New("parsed string values aren't long enough")
 			}
 		}
 		return result, nil
 	} else {
-		return result, errors.New("The link string provided is invalid.")
+		return result, errors.New("the link string provided is invalid")
 	}
 }


### PR DESCRIPTION
# Summary

This work allows us to do a few things differently when it comes to github. The main problem is that their api only allows us 5000 requests/minute.

Because of this, we need to be really careful how many requests we make and how quickly we make them.

## Tasks covered

- DONE - @Jon Performance - Remove the get total requests and use sequential for next page header
- DONE - @Jon Performance - **Refactor the one network scheduler
- DONE - @Jon Performance set the rate ants rate to (number of tokens*1 = 3600 REQUESTS PER HOUR 
- Remove the non ants requests

