### PR TITLE
fix: add missing README for jiradomain/jenkinsdomain

### DIFF
--- a/plugins/jenkinsdomain/README.md
+++ b/plugins/jenkinsdomain/README.md
@@ -1,0 +1,17 @@
+# Jenkins Domain
+
+## Summary
+
+This plugin converts Jenkins data to [Domain Layer](../domainlayer/README.md) data
+
+
+## How to trigger the conversion task
+```
+curl -XPOST 'localhost:8080/task' \
+-H 'Content-Type: application/json' \
+-d '[{
+    "plugin": "jenkinsdomain",
+    "options": {
+    }
+}]'
+```

--- a/plugins/jiradomain/README.md
+++ b/plugins/jiradomain/README.md
@@ -1,0 +1,17 @@
+# Jira Domain
+
+## Summary
+
+This plugin converts Jira data to [Domain Layer](../domainlayer/README.md) data
+
+
+## How to trigger the conversion task
+```
+curl -XPOST 'localhost:8080/task' \
+-H 'Content-Type: application/json' \
+-d '[{
+    "plugin": "jiradomain",
+    "options": {
+    }
+}]'
+```


### PR DESCRIPTION
# Summary

Add missing README.md for jiradomain and jenkinsdomain plugins.

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated
