### PR TITLE
feat: add jest and testing-library support to config-ui

### DIFF
--- a/config-ui/.eslintrc.json
+++ b/config-ui/.eslintrc.json
@@ -1,3 +1,15 @@
 {
-  "extends": ["next/babel"]
+  "root": true,
+  "extends": ["next/babel", "next/core-web-vitals"],
+  "plugins": ["testing-library"],
+  "overrides": [
+    // Only uses Testing Library lint rules in test files
+    {
+      "files": [
+        "**/__tests__/**/*.[jt]s?(x)",
+        "**/?(*.)+(spec|test).[jt]s?(x)"
+      ],
+      "extends": ["plugin:testing-library/react"]
+    }
+  ]
 }

--- a/config-ui/components/Sidebar.jsx
+++ b/config-ui/components/Sidebar.jsx
@@ -4,7 +4,7 @@ import { Button, Card, Elevation, Icon, Tree, Classes } from '@blueprintjs/core'
 import styles from '../styles/Sidebar.module.css'
 
 const Sidebar = () => {
-  const { asPath } = useRouter()
+  const { asPath } = useRouter() || {asPath: { text: '' }}
 
   const [isOpen, setIsOpen] = useState(true)
   const [pluginData, setPluginData] = useState()

--- a/config-ui/jest.config.js
+++ b/config-ui/jest.config.js
@@ -1,0 +1,33 @@
+module.exports = {
+  collectCoverageFrom: [
+    '**/*.{js,jsx,ts,tsx}',
+    '!**/*.d.ts',
+    '!**/node_modules/**',
+  ],
+  moduleNameMapper: {
+    // Handle CSS imports (with CSS modules)
+    // https://jestjs.io/docs/webpack#mocking-css-modules
+    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+
+    // Handle CSS imports (without CSS modules)
+    '^.+\\.(css|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
+
+    // Handle image imports
+    // https://jestjs.io/docs/webpack#handling-static-assets
+    '^.+\\.(jpg|jpeg|png|gif|webp|svg)$': `<rootDir>/__mocks__/fileMock.js`,
+
+    // Handle module aliases
+    '^@/components/(.*)$': '<rootDir>/components/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
+  transform: {
+    // Use babel-jest to transpile tests with the next/babel preset
+    // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
+    '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
+  },
+  transformIgnorePatterns: [
+    '/node_modules/',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ],
+}

--- a/config-ui/jest.setup.js
+++ b/config-ui/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev -p 4000",
     "build": "next build",
     "start": "next start -p 4000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --ci"
   },
   "dependencies": {
     "@blueprintjs/core": "^3.49.1",
@@ -18,7 +21,15 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^12.1.1",
+    "@testing-library/user-event": "^13.2.1",
+    "babel-jest": "^27.2.3",
     "eslint": "7.32.0",
-    "eslint-config-next": "11.1.2"
+    "eslint-config-next": "11.1.2",
+    "eslint-plugin-testing-library": "^4.12.4",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^27.2.3",
+    "react-test-renderer": "^17.0.2"
   }
 }

--- a/config-ui/pages/plugins/jira/index.test.js
+++ b/config-ui/pages/plugins/jira/index.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Home from './index'
+
+describe('Check the correct heading', () => {
+  it('renders a heading with proper text', () => {
+    render(<Home env={{
+      JIRA_ENDPOINT: "test-endpoint"
+    }} />)
+
+    const heading = screen.getByRole('heading', {
+      name: 'Jira Plugin'
+    })
+
+    expect(heading).toBeInTheDocument()
+  })
+})

--- a/config-ui/utils/findStrBetween.js
+++ b/config-ui/utils/findStrBetween.js
@@ -1,4 +1,7 @@
 export const findStrBetween = (str, first, last) => {
   const r = new RegExp(first + '(.*?)' + last, 'gm')
-  return str.match(r)
+
+  if (str) {
+    return str.match(r)
+  }
 }


### PR DESCRIPTION
# Summary

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Add jest and testing-library setup to config-ui

### Does this close any open issues?
No

### Current Behavior
No testing setup for components/functions

### New Behavior
Now can use this setup to test stuff. Will be useful especially for some of the form parsing functions, which we can do in other PRs

