### PR TITLE
Next optimize docker prod

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -1,12 +1,15 @@
 FROM node:14-alpine
 
 ARG REGISTRY=https://registry.npmjs.org/
-COPY package.json /src/package.json
+COPY ./server/package.json /src/package.json
+
 WORKDIR /src
+
 RUN npm i --registry=${REGISTRY}
 
-COPY . /src
+COPY out .
+COPY ./server/server.js .
 
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "server"]
 
 EXPOSE 4000

--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 4000",
-    "build": "next build",
+    "build": "next build && next export",
     "start": "next start -p 4000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "server": "node server.js"
   },
   "dependencies": {
     "@blueprintjs/core": "^3.49.1",

--- a/config-ui/server/package.json
+++ b/config-ui/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "server": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/config-ui/server/server.js
+++ b/config-ui/server/server.js
@@ -1,4 +1,6 @@
 const express = require('express')
+const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const app = express()
 
@@ -26,6 +28,31 @@ app.get('/plugins/gitlab', (req, res) => {
 
 app.get('/plugins/jenkins', (req, res) => {
   res.sendFile(path.join(__dirname, 'plugins/jenkins.html'))
+})
+
+// Api
+
+app.get('/api/setenv/:key/:value', (req, res) => {
+
+  const key = req.params.key
+  const value = req.params.value
+
+  const envFilePath = process.env.ENV_FILEPATH || path.join(process.cwd(), 'data', '../../.env')
+  const readEnvVars = () => fs.readFileSync(envFilePath, "utf-8").split(os.EOL)
+
+  const envVars = readEnvVars()
+  const targetLine = envVars.find((line) => line.split("=")[0] === key)
+
+  if (targetLine !== undefined) {
+    const targetLineIndex = envVars.indexOf(targetLine)
+    envVars.splice(targetLineIndex, 1, `${key}=${value}`)
+  }
+  else {
+    envVars.push(`${key}=${value}`)
+  }
+
+  fs.writeFileSync(envFilePath, envVars.join(os.EOL))
+  res.status(200).json({ key: value, status: 'updated' })
 })
 
 app.listen(4000, () => console.log(`Live on port 4000`))

--- a/config-ui/server/server.js
+++ b/config-ui/server/server.js
@@ -1,0 +1,31 @@
+const express = require('express')
+const path = require('path')
+const app = express()
+
+app.use(express.static(__dirname))
+
+// Main pages
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'))
+})
+
+app.get('/triggers', (req, res) => {
+  res.sendFile(path.join(__dirname, 'triggers.html'))
+})
+
+// Plugins
+
+app.get('/plugins/jira', (req, res) => {
+  res.sendFile(path.join(__dirname, 'plugins/jira.html'))
+})
+
+app.get('/plugins/gitlab', (req, res) => {
+  res.sendFile(path.join(__dirname, 'plugins/gitlab.html'))
+})
+
+app.get('/plugins/jenkins', (req, res) => {
+  res.sendFile(path.join(__dirname, 'plugins/jenkins.html'))
+})
+
+app.listen(4000, () => console.log(`Live on port 4000`))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     depends_on:
       - grafana
   config-ui:
-    image: mericodev/config-ui:latest
+    image: mericodev/config-ui:2
     ports:
       - 127.0.0.1:4000:4000
     environment:


### PR DESCRIPTION
# Summary

### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated

### Description
- Stops using dev mode in config ui (in docker). This will make it a lot faster
- Updated docker image to only use statically built files + a small express server
- Lowered file size of docker image build for config ui

uncompressed ([down from 797MB](https://github.com/merico-dev/lake/issues/458#issue-1009472484))
```
REPOSITORY            TAG       IMAGE ID       CREATED             SIZE
mericodev/config-ui   2         680fea42616c   About an hour ago   122MB
```

compressed is ~250mb to ~50mb

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/458
https://github.com/merico-dev/lake/issues/456

### Current Behavior
config-ui was slow because running in dev mode. Also docker image was very large.

### New Behavior
config-ui is fast because running in prod mode. Also docker image is much smaller.

### Screenshots
Old size compressed
![Screen Shot 2021-09-29 at 5 49 39 PM](https://user-images.githubusercontent.com/3789273/135353859-eae05388-911c-45e1-9cdb-7d85bc84294c.png)
New size compressed
![Screen Shot 2021-09-29 at 5 49 08 PM](https://user-images.githubusercontent.com/3789273/135353863-4d9d383b-f671-4218-a992-4e7d19ecd5b0.png)

### Other Information
I didn't want to touch the `mericodev/configui:latest` docker hub image during this setup, since its a big change to the setup. So please test using `mericodev/configui:2`, or just locally. 

Once we merge it in, we'll need to update the `docker-compose.yml` file to point to `latest` (and push to it), and not tag `2`
