### PR TITLE
Github Domain layer only

### DIFF
--- a/grafana/dashboards/GithubDomainLayerOnly.json
+++ b/grafana/dashboards/GithubDomainLayerOnly.json
@@ -1,0 +1,622 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 10,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  sum(additions)\nFROM commits\nWHERE\n  $__timeFilter(created_at)\n  AND message not like '%Merge branch%'",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Added LOC",
+      "type": "stat"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  sum(deletions)\nFROM commits\nWHERE\n  $__timeFilter(created_at) \n  AND message not like '%Merge branch%'\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Deleted Loc",
+      "type": "stat"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 8,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "with loc as(\n  SELECT\n    DATE_ADD(date(authored_date), INTERVAL 1 DAY) as time,\n    sum(additions) as added_LOC,\n    sum(deletions) as deleted_LOC\n  FROM commits\n  WHERE\n    message not like '%Merge branch%'\n    and $__timeFilter(authored_date)\n  group by 1\n)\n\nSELECT \n  timestamp(time) as time,\n  added_LOC as \"Added LOC\",\n  deleted_LOC as \"Deleted LOC\"\nFROM loc\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Added and Deleted LOC Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  count(distinct author_email) as developer_count\nFROM commits",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Total Developers By Email",
+      "type": "stat"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  now() AS \"time\",\n  count(*) as value\nFROM \n  prs\nWHERE\n $__timeFilter(created_at) AND state = 'open'\ngroup by 1\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Open Pull Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 13
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  now() AS \"time\",\n  count(*) as value\nFROM \n  prs\nWHERE\n $__timeFilter(created_at)\ngroup by 1\nORDER BY 1",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Total Pull Request Count",
+      "type": "stat"
+    },
+    {
+      "datasource": "mysql",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 13
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  count(sha)\n  \nFROM commits\nWHERE\n  $__timeFilter(created_at)\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "duration_sec"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "builds",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "title": "Total Commits",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2021-01-30T18:24:57.517Z",
+    "to": "2022-02-02T18:24:57.519Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Github Domain Layer Only",
+  "uid": "ilRLEaFnz",
+  "version": 5
+}

--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -141,7 +141,8 @@ func (apiClient *ApiClient) Do(
 	// assume setting the Authorization header using Bearer will work. However, this
 	// may not be the case for other APIs, and we will need to pass in "authType" or some
 	// other field to specify how authorization should be handled.
-	if len(apiClient.tokens) > 0 {
+	if len(apiClient.tokens) > 0 && apiClient.tokens[0] != "" {
+		// override the current auth with a new auth
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", apiClient.tokens[tokenIndex]))
 		tokenIndex = (tokenIndex + 1) % len(apiClient.tokens)
 	}

--- a/plugins/domainlayer/models/code/commit.go
+++ b/plugins/domainlayer/models/code/commit.go
@@ -10,6 +10,8 @@ type Commit struct {
 	base.DomainEntity
 	RepoId         uint64 `gorm:"index"`
 	Sha            string
+	Additions      int
+	Deletions      int
 	Message        string
 	AuthorName     string
 	AuthorEmail    string

--- a/plugins/github-domain/tasks/commit_converter.go
+++ b/plugins/github-domain/tasks/commit_converter.go
@@ -32,6 +32,8 @@ func convertToCommitModel(commit *githubModels.GithubCommit) *code.Commit {
 		Sha:            commit.Sha,
 		RepoId:         uint64(commit.RepositoryId),
 		Message:        commit.Message,
+		Additions:      commit.Additions,
+		Deletions:      commit.Deletions,
 		AuthorName:     commit.AuthorName,
 		AuthorEmail:    commit.AuthorEmail,
 		AuthoredDate:   commit.AuthoredDate,

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,0 +1,25 @@
+# Github Pond
+
+## Metrics
+
+Currently the data is only fetched and stored in the DB. Soon we will have charts in Grafana to support this data.
+
+## Github rate limits
+
+"For API requests using Basic Authentication or OAuth, you can make up to 5,000 requests per hour."
+
+- https://docs.github.com/en/rest/overview/resources-in-the-rest-api
+
+If you have a need for more api rate limits, you can set many tokens in the config file and we will use all of your tokens.
+
+NOTE: You can get 15000 requests/hour/token if you pay for github enterprise.
+
+## Configuration
+
+In your .env file, you will need to set up
+
+```
+GITHUB_AUTH_TOKENS=XXX,YYY,ZZZ // where each token is a different user's token (optional)
+GITHUB_AUTH=XXX
+```
+

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -19,7 +19,24 @@ NOTE: You can get 15000 requests/hour/token if you pay for github enterprise.
 In your .env file, you will need to set up
 
 ```
-GITHUB_AUTH_TOKENS=XXX,YYY,ZZZ // where each token is a different user's token (optional)
+
 GITHUB_AUTH=XXX
+
+or...
+
+GITHUB_AUTH=XXX,YYY,ZZZ // where each token is a different user's token (optional)
 ```
 
+## Sample Request
+
+```
+curl --location --request POST 'localhost:8080/task' \
+--header 'Content-Type: application/json' \
+--data-raw '[[{
+    "Plugin": "github",
+    "Options": {
+        "repositoryName": "lake",
+        "owner": "merico-dev"
+    }
+}]]'
+```

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -74,7 +74,9 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	if err != nil {
 		return fmt.Errorf("Could not collect repo Issue Labels: %v", err)
 	}
+
 	progress <- 0.2
+
 	if tasksToRun["collectCommits"] {
 		fmt.Println("INFO >>> starting commits collection")
 		collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
@@ -83,7 +85,9 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		}
 		tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 	}
+
 	progress <- 0.4
+
 	if tasksToRun["collectIssues"] {
 		fmt.Println("INFO >>> starting issues / PRs collection")
 		collectIssuesErr := tasks.CollectIssues(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
@@ -91,18 +95,22 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			return fmt.Errorf("Could not collect issues: %v", collectIssuesErr)
 		}
 		progress <- 0.6
+
 		fmt.Println("INFO >>> starting children on issues collection")
 		collectIssueChildrenErr := tasks.CollectChildrenOnIssues(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectIssueChildrenErr != nil {
 			return fmt.Errorf("Could not collect Issue children: %v", collectIssueChildrenErr)
 		}
+
 		progress <- 0.8
+
 		fmt.Println("INFO >>> collecting PR children collection")
 		collectPrChildrenErr := tasks.CollectChildrenOnPullRequests(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectPrChildrenErr != nil {
 			return fmt.Errorf("Could not collect PR children: %v", collectPrChildrenErr)
 		}
 	}
+
 	progress <- 1
 
 	close(progress)

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -21,8 +21,16 @@ func (plugin Github) Description() string {
 }
 
 func (plugin Github) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	// We need this rate limit set to 1 since there are only 5000 requests per hour allowed for the github api
-	scheduler, err := utils.NewWorkerScheduler(50, 1, ctx)
+	githubApiClient := tasks.CreateApiClient()
+	// GitHub API has very low rate limits, so we cycle through multiple tokens to increase rate limits.
+	// Then we set the ants max worker per second according to the number of tokens we have to maximize speed.
+	tokenCount := len(githubApiClient.GetTokens())
+	// We need this rate limit set to 1 by default since there are only 5000 requests per hour allowed for the github api
+	maxWorkerPerSecond := 1
+	if tokenCount > 0 {
+		maxWorkerPerSecond = tokenCount
+	}
+	scheduler, err := utils.NewWorkerScheduler(50, maxWorkerPerSecond, ctx)
 	if err != nil {
 		logger.Error("could not create scheduler", false)
 	}
@@ -58,39 +66,39 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			"collectIssues":  true,
 		}
 	}
-	repoId, collectRepoErr := tasks.CollectRepository(ownerString, repositoryNameString)
+	repoId, collectRepoErr := tasks.CollectRepository(ownerString, repositoryNameString, githubApiClient)
 	if collectRepoErr != nil {
 		return fmt.Errorf("Could not collect repositories: %v", collectRepoErr)
 	}
-	err = tasks.CollectRepositoryIssueLabels(ownerString, repositoryNameString, scheduler)
+	err = tasks.CollectRepositoryIssueLabels(ownerString, repositoryNameString, scheduler, githubApiClient)
 	if err != nil {
 		return fmt.Errorf("Could not collect repo Issue Labels: %v", err)
 	}
 	progress <- 0.2
 	if tasksToRun["collectCommits"] {
 		fmt.Println("INFO >>> starting commits collection")
-		collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId, scheduler)
+		collectCommitsErr := tasks.CollectCommits(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectCommitsErr != nil {
 			return fmt.Errorf("Could not collect commits: %v", collectCommitsErr)
 		}
-		tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId, scheduler)
+		tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 	}
 	progress <- 0.4
 	if tasksToRun["collectIssues"] {
 		fmt.Println("INFO >>> starting issues / PRs collection")
-		collectIssuesErr := tasks.CollectIssues(ownerString, repositoryNameString, repoId, scheduler)
+		collectIssuesErr := tasks.CollectIssues(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectIssuesErr != nil {
 			return fmt.Errorf("Could not collect issues: %v", collectIssuesErr)
 		}
 		progress <- 0.6
 		fmt.Println("INFO >>> starting children on issues collection")
-		collectIssueChildrenErr := tasks.CollectChildrenOnIssues(ownerString, repositoryNameString, repoId, scheduler)
+		collectIssueChildrenErr := tasks.CollectChildrenOnIssues(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectIssueChildrenErr != nil {
 			return fmt.Errorf("Could not collect Issue children: %v", collectIssueChildrenErr)
 		}
 		progress <- 0.8
 		fmt.Println("INFO >>> collecting PR children collection")
-		collectPrChildrenErr := tasks.CollectChildrenOnPullRequests(ownerString, repositoryNameString, repoId, scheduler)
+		collectPrChildrenErr := tasks.CollectChildrenOnPullRequests(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 		if collectPrChildrenErr != nil {
 			return fmt.Errorf("Could not collect PR children: %v", collectPrChildrenErr)
 		}

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -23,6 +23,9 @@ func CreateApiClient() *GithubApiClient {
 	if githubApiClient == nil {
 		githubApiClient = &GithubApiClient{}
 		auth := fmt.Sprintf("Bearer %v", config.V.GetString("GITHUB_AUTH"))
+		tokensString := config.V.GetString("GITHUB_AUTH_TOKENS")
+		// convert comma seperated value to array of strings
+		tokensArray := strings.Split(tokensString, ",")
 		githubApiClient.Setup(
 			config.V.GetString("GITHUB_ENDPOINT"),
 			map[string]string{
@@ -30,6 +33,7 @@ func CreateApiClient() *GithubApiClient {
 			},
 			10*time.Second,
 			3,
+			tokensArray,
 		)
 	}
 	return githubApiClient

--- a/plugins/github/tasks/github_commits_children_collector.go
+++ b/plugins/github/tasks/github_commits_children_collector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/merico-dev/lake/utils"
 )
 
-func CollectChildrenOnCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) {
+func CollectChildrenOnCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) {
 	var commits []models.GithubCommit
 	lakeModels.Db.Find(&commits)
 
@@ -16,7 +16,7 @@ func CollectChildrenOnCommits(owner string, repositoryName string, repositoryId 
 		err := scheduler.Submit(func() error {
 
 			// This call is to update the details of the individual pull request with additions / deletions / etc.
-			commitErr := CollectCommit(owner, repositoryName, repositoryId, &commit)
+			commitErr := CollectCommit(owner, repositoryName, repositoryId, &commit, githubApiClient)
 			if commitErr != nil {
 				logger.Error("Could not collect Commits to update details", commitErr)
 				return commitErr

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -39,7 +39,7 @@ func CollectCommits(owner string, repositoryName string, repositoryId int, sched
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)
-			if err != nil {
+			if err != nil || res.StatusCode == 401 {
 				logger.Error("Error: ", err)
 				return err
 			}

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -33,8 +33,7 @@ type Commit struct {
 	Message string
 }
 
-func CollectCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_issue_children_collector.go
+++ b/plugins/github/tasks/github_issue_children_collector.go
@@ -7,22 +7,22 @@ import (
 	"github.com/merico-dev/lake/utils"
 )
 
-func CollectChildrenOnIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) error {
+func CollectChildrenOnIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	var issues []models.GithubIssue
 	lakeModels.Db.Find(&issues)
 	for i := 0; i < len(issues); i++ {
 		issue := (issues)[i]
-		eventsErr := CollectIssueEvents(owner, repositoryName, &issue, scheduler)
+		eventsErr := CollectIssueEvents(owner, repositoryName, &issue, scheduler, githubApiClient)
 		if eventsErr != nil {
 			logger.Error("Could not collect issue events", eventsErr)
 			return eventsErr
 		}
-		commentsErr := CollectIssueComments(owner, repositoryName, &issue, scheduler)
+		commentsErr := CollectIssueComments(owner, repositoryName, &issue, scheduler, githubApiClient)
 		if commentsErr != nil {
 			logger.Error("Could not collect issue Comments", commentsErr)
 			return commentsErr
 		}
-		labelsErr := CollectIssueLabelsForSingleIssue(owner, repositoryName, &issue, scheduler)
+		labelsErr := CollectIssueLabelsForSingleIssue(owner, repositoryName, &issue, scheduler, githubApiClient)
 		if labelsErr != nil {
 			logger.Error("Could not collect issue labels", labelsErr)
 			return labelsErr

--- a/plugins/github/tasks/github_issue_comments_collector.go
+++ b/plugins/github/tasks/github_issue_comments_collector.go
@@ -23,8 +23,7 @@ type IssueComment struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectIssueComments(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectIssueComments(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repositoryName, issue.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_issue_events_collector.go
+++ b/plugins/github/tasks/github_issue_events_collector.go
@@ -23,8 +23,7 @@ type IssueEvent struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectIssueEvents(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectIssueEvents(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {	
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/events", owner, repositoryName, issue.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_issue_labels_collector.go
+++ b/plugins/github/tasks/github_issue_labels_collector.go
@@ -21,8 +21,7 @@ type IssueLabel struct {
 	Color       string
 }
 
-func CollectIssueLabelsForSinglePullRequest(owner string, repositoryName string, pr *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectIssueLabelsForSinglePullRequest(owner string, repositoryName string, pr *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repositoryName, pr.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {
@@ -51,8 +50,7 @@ func CollectIssueLabelsForSinglePullRequest(owner string, repositoryName string,
 			return nil
 		})
 }
-func CollectIssueLabelsForSingleIssue(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectIssueLabelsForSingleIssue(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repositoryName, issue.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {
@@ -81,8 +79,7 @@ func CollectIssueLabelsForSingleIssue(owner string, repositoryName string, issue
 			return nil
 		})
 }
-func CollectRepositoryIssueLabels(owner string, repositoryName string, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectRepositoryIssueLabels(owner string, repositoryName string, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/labels", owner, repositoryName)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_issues_collector.go
+++ b/plugins/github/tasks/github_issues_collector.go
@@ -28,8 +28,7 @@ type IssuesResponse struct {
 	GithubUpdatedAt core.Iso8601Time `json:"updated_at"`
 }
 
-func CollectIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues?state=all", owner, repositoryName)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_pull_request_children_collector.go
+++ b/plugins/github/tasks/github_pull_request_children_collector.go
@@ -7,28 +7,28 @@ import (
 	"github.com/merico-dev/lake/utils"
 )
 
-func CollectChildrenOnPullRequests(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler) error {
+func CollectChildrenOnPullRequests(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	var prs []models.GithubPullRequest
 	lakeModels.Db.Find(&prs)
 	for i := 0; i < len(prs); i++ {
 		pr := (prs)[i]
-		reviewErr := CollectPullRequestReviews(owner, repositoryName, repositoryId, &pr, scheduler)
+		reviewErr := CollectPullRequestReviews(owner, repositoryName, repositoryId, &pr, scheduler, githubApiClient)
 		if reviewErr != nil {
 			logger.Error("Could not collect PR Reviews", reviewErr)
 			return reviewErr
 		}
-		commentsErr := CollectPullRequestComments(owner, repositoryName, &pr, scheduler)
+		commentsErr := CollectPullRequestComments(owner, repositoryName, &pr, scheduler, githubApiClient)
 		if commentsErr != nil {
 			logger.Error("Could not collect PR Comments", commentsErr)
 			return commentsErr
 		}
-		commitsErr := CollectPullRequestCommits(owner, repositoryName, &pr, scheduler)
+		commitsErr := CollectPullRequestCommits(owner, repositoryName, &pr, scheduler, githubApiClient)
 		if commitsErr != nil {
 			logger.Error("Could not collect PR Commits", commitsErr)
 			return commitsErr
 		}
 		// Please Note: There is no difference between Issue Labels and Pull Request Labels - they are the same.
-		labelsErr := CollectIssueLabelsForSinglePullRequest(owner, repositoryName, &pr, scheduler)
+		labelsErr := CollectIssueLabelsForSinglePullRequest(owner, repositoryName, &pr, scheduler, githubApiClient)
 		if labelsErr != nil {
 			logger.Error("Could not collect PR Labels", labelsErr)
 			return labelsErr

--- a/plugins/github/tasks/github_pull_request_comments_collector.go
+++ b/plugins/github/tasks/github_pull_request_comments_collector.go
@@ -23,8 +23,7 @@ type PullRequestComment struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectPullRequestComments(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectPullRequestComments(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repositoryName, pull.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_pull_request_commits_collector.go
+++ b/plugins/github/tasks/github_pull_request_commits_collector.go
@@ -33,8 +33,7 @@ type PrCommit struct {
 	Message string
 }
 
-func CollectPullRequestCommits(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectPullRequestCommits(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/commits", owner, repositoryName, pull.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_pull_request_reviewer_collector.go
+++ b/plugins/github/tasks/github_pull_request_reviewer_collector.go
@@ -25,8 +25,7 @@ type PullRequestReview struct {
 	SubmittedAt core.Iso8601Time `json:"submitted_at"`
 }
 
-func CollectPullRequestReviews(owner string, repositoryName string, repositoryId int, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler) error {
-	githubApiClient := CreateApiClient()
+func CollectPullRequestReviews(owner string, repositoryName string, repositoryId int, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews", owner, repositoryName, pull.Number)
 	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
 		func(res *http.Response) error {

--- a/plugins/github/tasks/github_repository_collector.go
+++ b/plugins/github/tasks/github_repository_collector.go
@@ -16,8 +16,7 @@ type ApiRepositoryResponse struct {
 	HTMLUrl  string `json:"html_url"`
 }
 
-func CollectRepository(owner string, repositoryName string) (int, error) {
-	githubApiClient := CreateApiClient()
+func CollectRepository(owner string, repositoryName string, githubApiClient *GithubApiClient) (int, error) {
 	getUrl := fmt.Sprintf("repos/%v/%v", owner, repositoryName)
 	res, err := githubApiClient.Get(getUrl, nil, nil)
 	if err != nil {

--- a/plugins/github/tasks/github_single_commit_collector.go
+++ b/plugins/github/tasks/github_single_commit_collector.go
@@ -16,8 +16,7 @@ type ApiSingleCommitResponse struct {
 	}
 }
 
-func CollectCommit(owner string, repositoryName string, repositoryId int, commit *models.GithubCommit) error {
-	githubApiClient := CreateApiClient()
+func CollectCommit(owner string, repositoryName string, repositoryId int, commit *models.GithubCommit, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repositoryName, commit.Sha)
 	res, getErr := githubApiClient.Get(getUrl, nil, nil)
 	if getErr != nil {

--- a/plugins/github/tasks/github_single_pull_request_collector.go
+++ b/plugins/github/tasks/github_single_pull_request_collector.go
@@ -19,8 +19,7 @@ type ApiSinglePullResponse struct {
 	MergedAt       core.Iso8601Time `json:"merged_at"`
 }
 
-func CollectPullRequest(owner string, repositoryName string, repositoryId int, pr *models.GithubPullRequest) error {
-	githubApiClient := CreateApiClient()
+func CollectPullRequest(owner string, repositoryName string, repositoryId int, pr *models.GithubPullRequest, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v?state=all", owner, repositoryName, pr.Number)
 	res, getErr := githubApiClient.Get(getUrl, nil, nil)
 	if getErr != nil {

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -110,6 +110,6 @@ func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 		}
 		return result, nil
 	} else {
-		return result, errors.New("the link string provided is invalid")
+		return result, errors.New("the link string provided is invalid. There is likely no next page of data to fetch")
 	}
 }

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -30,6 +30,7 @@ func CreateApiClient() *GitlabApiClient {
 			},
 			10*time.Second,
 			3,
+			nil,
 		)
 	}
 	return gitlabApiClient

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -30,7 +30,6 @@ func CreateApiClient() *GitlabApiClient {
 			},
 			10*time.Second,
 			3,
-			nil,
 		)
 	}
 	return gitlabApiClient

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -28,7 +28,6 @@ func NewJiraApiClient(endpoint string, auth string) *JiraApiClient {
 		},
 		10*time.Second,
 		3,
-		nil,
 	)
 	return jiraApiClient
 }

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -28,6 +28,7 @@ func NewJiraApiClient(endpoint string, auth string) *JiraApiClient {
 		},
 		10*time.Second,
 		3,
+		nil,
 	)
 	return jiraApiClient
 }


### PR DESCRIPTION
## Related Docs
https://merico.feishu.cn/docs/doccn6ZyxRzUgKMFXzWTwzcWH7f#

## Related Tickets:
https://github.com/merico-dev/lake/issues/432
https://github.com/merico-dev/lake/issues/501
https://github.com/merico-dev/lake/issues/470
https://github.com/merico-dev/lake/issues/437

## Description

NOTE: continuation of PR: #585 

So this allows us to pull all of the pieces together for github and the domain layer.

I made a new dashboard that shows this data:
![Screen Shot 2021-11-02 at 4 09 06 PM](https://user-images.githubusercontent.com/3011407/139929361-d772a125-cf7b-4acf-a696-07929c8fb745.png)

This is for our lake repo.

In each of the queries, we are using domain layer models and not the github models.

## TODO

- [ ] make a doc for all fields and how they convert to domain layer for each entity and each property
- [ ] make sure all the domain layer plugins gather this data
- [ ] test all domain layer plugins for data collection
- [ ] Change all graphs possible to domain layer
- [ ] upload this to the server: http://52.89.41.35:44002/?orgId=1