### PR TITLE
Config UI Refactor - Connection Limiting & Integration Bugfixes

### DIFF
--- a/config-ui/src/data/NullConnection.js
+++ b/config-ui/src/data/NullConnection.js
@@ -1,0 +1,23 @@
+const NullConnection = {
+  // id: null,
+  ID: null,
+  name: null,
+  endpoint: null,
+  token: null,
+  username: null,
+  password: null,
+  basicAuthEncoded: null, // NOTE: we probably want to exclude/null this when exposing this object
+  JIRA_ISSUE_TYPE_MAPPING: null,
+  JIRA_ISSUE_EPIC_KEY_FIELD: null,
+  JIRA_ISSUE_STORYPOINT_COEFFICIENT: null,
+  JIRA_ISSUE_STORYPOINT_FIELD: null,
+  JIRA_BOARD_GITLAB_PROJECTS: null,
+  JIRA_ISSUE_INCIDENT_STATUS_MAPPING: null,
+  JIRA_ISSUE_STORY_STATUS_MAPPING: null,
+  createdAt: null,
+  updatedAt: null,
+}
+
+export {
+  NullConnection
+}

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -38,7 +38,7 @@ function useSettingsManager ({
       try {
         setShowError(false)
         ToastNotification.clear()
-        const s = await request.put(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${activeConnection.id}`, settingsPayload)
+        const s = await request.put(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${activeConnection.ID}`, settingsPayload)
         console.log('>> SETTINGS SAVED SUCCESSFULLY', settingsPayload, s)
         saveResponse = {
           ...saveResponse,

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -41,11 +41,13 @@ export default function AddConnection () {
 
   const {
     testConnection, saveConnection,
-    errors, // showErrors,
-    isSaving, // setIsSaving,
-    isTesting, // setIsTesting,
-    showError, // setShowError,
-    testStatus, // setTestStatus
+    errors,
+    isSaving,
+    isTesting,
+    showError,
+    testStatus,
+    fetchAllConnections,
+    connectionLimitReached,
   } = useConnectionManager({
     activeProvider,
     name,
@@ -70,6 +72,9 @@ export default function AddConnection () {
   useEffect(() => {
     // Selected Provider
     console.log(activeProvider)
+    if (activeProvider && activeProvider.id) {
+      fetchAllConnections()
+    }
   }, [activeProvider])
 
   useEffect(() => {
@@ -116,6 +121,8 @@ export default function AddConnection () {
               </div>
               <div className='addConnection' style={{ display: 'flex' }}>
                 <ConnectionForm
+                  isLocked={connectionLimitReached}
+                  activeProvider={activeProvider}
                   name={name}
                   endpointUrl={endpointUrl}
                   token={token}

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -24,6 +24,7 @@ import GitlabSettings from '@/pages/configure/settings/gitlab'
 import JenkinsSettings from '@/pages/configure/settings/jenkins'
 
 import { integrationsData } from '@/pages/configure/mock-data/integrations'
+import { NullConnection } from '@/data/NullConnection'
 // import { connectionsData } from '@/pages/configure/mock-data/connections'
 
 import '@/styles/integration.scss'
@@ -41,15 +42,8 @@ export default function ConfigureConnection () {
   // const [showError, setShowError] = useState(false)
 
   const [integrations, setIntegrations] = useState(integrationsData)
-  const [activeProvider, setActiveProvider] = useState(integrations[0])
-  const [activeConnection, setActiveConnection] = useState({
-    id: null,
-    name: null,
-    endpoint: null,
-    token: null,
-    username: null,
-    password: null,
-  })
+  const [activeProvider, setActiveProvider] = useState(integrations.find(p => p.id === providerId))
+  const [activeConnection, setActiveConnection] = useState(NullConnection)
   const [connections, setConnections] = useState([])
 
   const [settings, setSettings] = useState({
@@ -163,7 +157,7 @@ export default function ConfigureConnection () {
                 { href: '/integrations', icon: false, text: 'Integrations' },
                 { href: `/integrations/${activeProvider.id}`, icon: false, text: `${activeProvider.name}` },
                 {
-                  href: `/connections/configure/${activeProvider.id}/${activeConnection && activeConnection.id}`,
+                  href: `/connections/configure/${activeProvider.id}/${activeConnection && activeConnection.ID}`,
                   icon: false,
                   text: `${activeConnection ? activeConnection.name : 'Configure'} Settings`,
                   current: true

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState } from 'react'
 import {
   Button, Colors,
   FormGroup, InputGroup, Label,
+  Card,
   Icon,
+  Tag,
+  Elevation,
+  Intent
 } from '@blueprintjs/core'
 
 import '@/styles/integration.scss'
@@ -11,6 +15,8 @@ import '@blueprintjs/popover2/lib/css/blueprint-popover2.css'
 
 export default function ConnectionForm (props) {
   const {
+    isLocked = false,
+    activeProvider,
     name,
     endpointUrl,
     token,
@@ -29,7 +35,8 @@ export default function ConnectionForm (props) {
     onTokenChange = () => {},
     onUsernameChange = () => {},
     onPasswordChange = () => {},
-    authType = 'token'
+    authType = 'token',
+    sourceLimits = { jenkins: 1, gitlab: 1 }
   } = props
 
   const [allowedAuthTypes, setAllowedAuthTypes] = useState(['token', 'plain'])
@@ -61,12 +68,28 @@ export default function ConnectionForm (props) {
     setAllowedAuthTypes(['token', 'plain'])
   }, [])
 
+  useEffect(() => {
+    if (activeProvider && activeProvider.id) {
+      console.log('>>> SOURCE LIMITS = ', sourceLimits[activeProvider.id])
+    }
+  }, [])
+
   return (
     <>
       <form className='form form-add-connection'>
         <div className='headlineContainer'>
-          <h2 className='headline'>Configure Instance</h2>
+          <h2 className='headline' style={{ textDecoration: isLocked ? 'line-through' : 'none' }}>Configure Instance</h2>
           <p className='description'>Account & Authentication settings</p>
+          {activeProvider && activeProvider.id && sourceLimits[activeProvider.id] && (
+            <Card interactive={false} elevation={Elevation.TWO} style={{ width: '50%', marginBottom: '20px', backgroundColor: '#f0f0f0' }}>
+              <p className='warning-message' intent={Intent.WARNING}>
+                <Icon icon='warning-sign' size='16' color={Colors.GRAY1} style={{ marginRight: '5px' }} />
+                <strong>CONNECTION SOURCES LIMITED</strong><br />
+                You may only add <Tag intent={Intent.PRIMARY}>{sourceLimits[activeProvider.id]}</Tag> instance(s) at this time,
+                multiple sources will be supported in a future release.
+              </p>
+            </Card>
+          )}
         </div>
 
         {showError && (
@@ -83,7 +106,7 @@ export default function ConnectionForm (props) {
 
         <div className='formContainer'>
           <FormGroup
-            disabled={isTesting || isSaving}
+            disabled={isTesting || isSaving || isLocked}
             label=''
             inline={true}
             labelFor='connection-name'
@@ -96,7 +119,7 @@ export default function ConnectionForm (props) {
             </Label>
             <InputGroup
               id='connection-name'
-              disabled={isTesting || isSaving}
+              disabled={isTesting || isSaving || isLocked}
               placeholder='Enter Instance Name eg. ISSUES-AWS-US-EAST'
               defaultValue={name}
               onChange={(e) => onNameChange(e.target.value)}
@@ -108,7 +131,7 @@ export default function ConnectionForm (props) {
 
         <div className='formContainer'>
           <FormGroup
-            disabled={isTesting || isSaving}
+            disabled={isTesting || isSaving || isLocked}
             label=''
             inline={true}
             labelFor='connection-endpoint'
@@ -121,7 +144,7 @@ export default function ConnectionForm (props) {
             </Label>
             <InputGroup
               id='connection-endpoint'
-              disabled={isTesting || isSaving}
+              disabled={isTesting || isSaving || isLocked}
               placeholder='Enter Endpoint URL eg. https://merico.atlassian.net/rest'
               defaultValue={endpointUrl}
               onChange={(e) => onEndpointChange(e.target.value)}
@@ -135,7 +158,7 @@ export default function ConnectionForm (props) {
         {authType === 'token' && (
           <div className='formContainer'>
             <FormGroup
-              disabled={isTesting || isSaving}
+              disabled={isTesting || isSaving || isLocked}
               label=''
               inline={true}
               labelFor='connection-token'
@@ -148,7 +171,7 @@ export default function ConnectionForm (props) {
               </Label>
               <InputGroup
                 id='connection-token'
-                disabled={isTesting || isSaving}
+                disabled={isTesting || isSaving || isLocked}
                 placeholder='Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'
                 defaultValue={token}
                 onChange={(e) => onTokenChange(e.target.value)}
@@ -171,7 +194,7 @@ export default function ConnectionForm (props) {
             <div className='formContainer'>
               <FormGroup
                 label=''
-                disabled={isTesting || isSaving}
+                disabled={isTesting || isSaving || isLocked}
                 inline={true}
                 labelFor='connection-username'
                 helperText='USERNAME'
@@ -183,7 +206,7 @@ export default function ConnectionForm (props) {
                 </Label>
                 <InputGroup
                   id='connection-username'
-                  disabled={isTesting || isSaving}
+                  disabled={isTesting || isSaving || isLocked}
                   placeholder='Enter Username'
                   defaultValue={username}
                   onChange={(e) => onUsernameChange(e.target.value)}
@@ -194,7 +217,7 @@ export default function ConnectionForm (props) {
             </div>
             <div className='formContainer'>
               <FormGroup
-                disabled={isTesting || isSaving}
+                disabled={isTesting || isSaving || isLocked}
                 label=''
                 inline={true}
                 labelFor='connection-password'
@@ -208,7 +231,7 @@ export default function ConnectionForm (props) {
                 <InputGroup
                   id='connection-password'
                   type='password'
-                  disabled={isTesting || isSaving}
+                  disabled={isTesting || isSaving || isLocked}
                   placeholder='Enter Password'
                   defaultValue={password}
                   onChange={(e) => onPasswordChange(e.target.value)}
@@ -227,7 +250,7 @@ export default function ConnectionForm (props) {
               text='Test Connection'
               onClick={onTest}
               loading={isTesting}
-              disabled={isTesting || isSaving}
+              disabled={isTesting || isSaving || isLocked}
             />
           </div>
           <div style={{ display: 'flex' }}>
@@ -236,7 +259,7 @@ export default function ConnectionForm (props) {
               className='btn-save'
               icon='cloud-upload' intent='primary' text='Save Connection'
               loading={isSaving}
-              disabled={isSaving || isTesting}
+              disabled={isSaving || isTesting || isLocked}
               onClick={onSave}
             />
           </div>

--- a/config-ui/src/pages/configure/connections/EditConnection.jsx
+++ b/config-ui/src/pages/configure/connections/EditConnection.jsx
@@ -14,9 +14,7 @@ import Content from '@/components/Content'
 // import { ToastNotification } from '@/components/Toast'
 import ConnectionForm from '@/pages/configure/connections/ConnectionForm'
 import { integrationsData } from '@/pages/configure/mock-data/integrations'
-// import { connectionsData } from '@/pages/configure/mock-data/connections'
-// import { SERVER_HOST, DEVLAKE_ENDPOINT } from '@/utils/config'
-// import request from '@/utils/request'
+import { NullConnection } from '@/data/NullConnection'
 
 import useConnectionManager from '@/hooks/useConnectionManager'
 
@@ -37,14 +35,7 @@ export default function EditConnection () {
   const [integrations, setIntegrations] = useState(integrationsData)
   const [activeProvider, setActiveProvider] = useState(integrations[0])
 
-  const [activeConnection, setActiveConnection] = useState({
-    id: null,
-    name: null,
-    endpoint: null,
-    token: null,
-    username: null,
-    password: null,
-  })
+  const [activeConnection, setActiveConnection] = useState(NullConnection)
 
   const {
     testConnection,
@@ -124,7 +115,7 @@ export default function EditConnection () {
                 { href: '/integrations', icon: false, text: 'Integrations' },
                 { href: `/integrations/${activeProvider.id}`, icon: false, text: `${activeProvider.name}` },
                 {
-                  href: `/connections/edit/${activeProvider.id}/${activeConnection.id}`,
+                  href: `/connections/edit/${activeProvider.id}/${activeConnection.ID}`,
                   icon: false,
                   text: 'Edit Connection',
                   current: true
@@ -148,6 +139,7 @@ export default function EditConnection () {
               </div>
               <div className='editConnection' style={{ display: 'flex' }}>
                 <ConnectionForm
+                  activeProvider={activeProvider}
                   name={name}
                   endpointUrl={endpointUrl}
                   token={token}

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -16,6 +16,8 @@ import Content from '@/components/Content'
 import { ToastNotification } from '@/components/Toast'
 import request from '@/utils/request'
 
+import useConnectionManager from '@/hooks/useConnectionManager'
+
 import { SERVER_HOST, DEVLAKE_ENDPOINT } from '@/utils/config'
 
 import { integrationsData } from '@/pages/configure/mock-data/integrations'
@@ -38,6 +40,12 @@ export default function ManageIntegration () {
   const [integrations, setIntegrations] = useState(integrationsData)
   const [connections, setConnections] = useState([])
   const [activeProvider, setActiveProvider] = useState(integrations[0])
+
+  const {
+    sourceLimits,
+  } = useConnectionManager({
+    activeProvider
+  })
 
   const fetchConnections = async () => {
     setIsLoading(true)
@@ -101,6 +109,10 @@ export default function ManageIntegration () {
     fetchConnections()
   }
 
+  const maxConnectionsExceeded = (limit, totalConnections) => {
+    return totalConnections > 0 && totalConnections >= limit
+  }
+
   useEffect(() => {
     // Selected Provider
     // console.log(activeProvider)
@@ -115,6 +127,10 @@ export default function ManageIntegration () {
     setIntegrations(integrations)
     setActiveProvider(integrations.find(p => p.id === providerId))
   }, [])
+
+  useEffect(() => {
+    console.log('>> CONNECTION SOURCE LIMITS', sourceLimits)
+  }, [connections, sourceLimits])
 
   return (
     <>
@@ -208,6 +224,7 @@ export default function ManageIntegration () {
                 <>
                   <p>
                     <Button
+                      disabled={maxConnectionsExceeded(sourceLimits[activeProvider.id], connections.length)}
                       onClick={addConnection}
                       rightIcon='add'
                       intent='primary'
@@ -296,6 +313,12 @@ export default function ManageIntegration () {
                         ))}
                       </tbody>
                     </table>
+                    {maxConnectionsExceeded(sourceLimits[activeProvider.id], connections.length) && (
+                      <p style={{ margin: 0, padding: '10px', backgroundColor: '#f0f0f0', borderTop: '1px solid #cccccc' }}>
+                        <Icon icon='warning-sign' size='16' color={Colors.GRAY1} style={{ marginRight: '5px' }} />
+                        You have reached the maximum number of allowed connections for this provider.
+                      </p>
+                    )}
                   </Card>
                   <p style={{
                     textAlign: 'right',

--- a/config-ui/src/pages/configure/mock-data/epics.jsx
+++ b/config-ui/src/pages/configure/mock-data/epics.jsx
@@ -1,0 +1,11 @@
+const epicsData = [
+  { id: 0, title: 'Custom Field 1000', value: 'customfield_1000' },
+  { id: 1, title: 'Custom Field 2000', value: 'customfield_2000' },
+  { id: 2, title: 'Custom Field 3000', value: 'customfield_3000' },
+  { id: 3, title: 'Custom Field 4000', value: 'customfield_4000' },
+  { id: 4, title: 'Custom Field 5000', value: 'customfield_5000' },
+]
+
+export {
+  epicsData
+}

--- a/config-ui/src/pages/configure/mock-data/granularities.jsx
+++ b/config-ui/src/pages/configure/mock-data/granularities.jsx
@@ -1,0 +1,8 @@
+const granularitiesData = [
+  { id: 0, title: 'Story Points', value: 'customfield_6000' },
+  { id: 1, title: 'Original Estimate', value: 'customfield_7000' },
+]
+
+export {
+  granularitiesData
+}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -9,9 +9,12 @@ import ClearButton from '@/pages/plugins/jira//ClearButton'
 import { Button, MenuItem } from '@blueprintjs/core'
 import { Select } from '@blueprintjs/select'
 
+import { epicsData } from '@/pages/configure/mock-data/epics'
+import { boardsData } from '@/pages/configure/mock-data/boards'
+import { granularitiesData } from '@/pages/configure/mock-data/granularities'
+
 import '@/styles/integration.scss'
 import '@/styles/connections.scss'
-
 import '@blueprintjs/popover2/lib/css/blueprint-popover2.css'
 
 export default function JiraSettings (props) {
@@ -29,29 +32,13 @@ export default function JiraSettings (props) {
   const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState()
 
   const [selectedEpicItem, setSelectedEpicItem] = useState()
-  const [epics, setEpics] = useState([
-    { id: 0, title: 'Custom Field 1000', value: 'customfield_1000' },
-    { id: 1, title: 'Custom Field 2000', value: 'customfield_2000' },
-    { id: 2, title: 'Custom Field 3000', value: 'customfield_3000' },
-    { id: 3, title: 'Custom Field 4000', value: 'customfield_4000' },
-    { id: 4, title: 'Custom Field 5000', value: 'customfield_5000' },
-  ])
+  const [epics, setEpics] = useState(epicsData)
 
   const [selectedGranularityItem, setSelectedGranularityItem] = useState()
-  const [granularities, setGranularities] = useState([
-    { id: 0, title: 'Story Points', value: 'customfield_6000' },
-    { id: 1, title: 'Original Estimate', value: 'customfield_7000' },
-  ])
+  const [granularities, setGranularities] = useState(granularitiesData)
 
   const [selectedBoardItem, setSelectedBoardItem] = useState()
-  const [boards, setBoards] = useState([
-    { id: 1, title: 'Open', value: '1' },
-    { id: 2, title: 'Backlog', value: '2' },
-    { id: 3, title: 'QA / Testing', value: '3' },
-    { id: 4, title: 'Pre-release', value: '4' },
-    { id: 5, title: 'Production', value: '5' },
-    { id: 6, title: 'Closed', value: '6' },
-  ])
+  const [boards, setBoards] = useState(boardsData)
 
   useEffect(() => {
     const settings = {
@@ -109,7 +96,7 @@ export default function JiraSettings (props) {
       Incident: [],
       Requirement: []
     }
-    if (connection && connection.id) {
+    if (connection && connection.ID) {
       const types = connection.JIRA_ISSUE_TYPE_MAPPING.split(';').map(t => t.split(':')[0])
       if (types.lastIndexOf('') !== -1) {
         types.pop()
@@ -142,7 +129,7 @@ export default function JiraSettings (props) {
       // @todo FETCH & SET GRANULARITY KEY
       setSelectedGranularityItem(granularities.find(g => g.value === connection.JIRA_ISSUE_STORYPOINT_FIELD))
     }
-  }, [connection])
+  }, [connection, epics, granularities, boards])
 
   return (
     <>

--- a/config-ui/src/pages/triggers/index.jsx
+++ b/config-ui/src/pages/triggers/index.jsx
@@ -22,14 +22,15 @@ export default function Triggers () {
 
   const sendTrigger = async (e) => {
     e.preventDefault()
-    try {
-      await request.post(
-        `${Config.DEVLAKE_ENDPOINT}/task`,
-        textAreaBody
-      )
-    } catch (e) {
-      console.error(e)
-    }
+    // @todo RE_ACTIVATE Trigger Process!
+    // try {
+    //   await request.post(
+    //     `${Config.DEVLAKE_ENDPOINT}/task`,
+    //     textAreaBody
+    //   )
+    // } catch (e) {
+    //   console.error(e)
+    // }
   }
 
   const [pendingTasks, setPendingTasks] = useState([])


### PR DESCRIPTION
# Connection Limiting and use $ID Primary Key
> **WIP** DO NOT MERGE

### Key Points

- [x] Implement **Connection Limit** Feature so that providers w/o Multi-data support can be restricted until backend is able to offer these features.
    - **JIRA** Supports Multiple Connections
    - Jenkins and Gitlab Limited to 1 Connection Only
    - Add Connection Functionality LOCKED when limit reached
- [x] Use **$ID** as primary key parameter for connection sources
- [x] Fix Loading of JIRA Settings
- [x] Update Connection Manager Hook
  - Add routine for fetching All Connections
  - Add Logic for Connection Limiting

### Description
This PR is to continue the **Configuration UI Refactor** with regard to Multi-data connection sources UX. As JIRA is the only provider at this time that supports multi-connection sources, a connection limit feature has been added so that Gitlab and Jenkins will have restricted modes limiting them to only 1 instance.

### Screenshots
<img width="1410" alt="Screen Shot 2021-11-02 at 5 29 03 PM" src="https://user-images.githubusercontent.com/1742233/139954378-13e2fe4e-bc3a-4e75-b04e-10747575928f.png">
<img width="1410" alt="Screen Shot 2021-11-02 at 4 44 28 PM" src="https://user-images.githubusercontent.com/1742233/139954053-ed50d554-fb18-43c9-bda3-54fe9beeb748.png">


