### PR TITLE
feat: convert new fields of jira issue to domainlayer

### DIFF
--- a/plugins/domainlayer/models/ticket/issue.go
+++ b/plugins/domainlayer/models/ticket/issue.go
@@ -11,16 +11,25 @@ type Issue struct {
 	base.DomainEntity
 
 	// collected fields
-	BoardOriginKey string `gorm:"index"`
-	Url            string
-	Key            string
-	Summary        string
-	EpicKey        string
-	Type           string
-	Status         string
-	StoryPoint     uint
-	ResolutionDate sql.NullTime
-	CreatedDate    time.Time
-	UpdatedDate    time.Time
-	LeadTime       uint
+	BoardOriginKey           string `gorm:"index"`
+	Url                      string
+	Key                      string
+	Summary                  string
+	EpicKey                  string
+	Type                     string
+	Status                   string
+	StoryPoint               uint
+	OriginalEstimateMinutes  int64 // user input?
+	AggregateEstimateMinutes int64 // sum up of all subtasks?
+	RemainingEstimateMinutes int64 // could it be negative value?
+	CreatorOriginKey         string
+	AssigneeOriginKey        string
+	ResolutionDate           sql.NullTime
+	Priority                 string // not sure how to deal with it yet, copy the name for now
+	ParentOriginKey          string
+	SprintOriginKey          string
+	CreatedDate              time.Time
+	UpdatedDate              time.Time
+	SpentMinutes             int64
+	LeadTime                 uint
 }

--- a/plugins/jiradomain/tasks/issue_converter.go
+++ b/plugins/jiradomain/tasks/issue_converter.go
@@ -51,6 +51,7 @@ func ConvertIssues(sourceId uint64, boardId uint64) error {
 			RemainingEstimateMinutes: jiraIssue.RemainingEstimateMinutes,
 			CreatorOriginKey:         userOriginKeyGenerator.Generate(sourceId, jiraIssue.CreatorAccountId),
 			ResolutionDate:           jiraIssue.ResolutionDate,
+			Priority:                 jiraIssue.PriorityName,
 			CreatedDate:              jiraIssue.Created,
 			UpdatedDate:              jiraIssue.Updated,
 			LeadTime:                 jiraIssue.LeadTime,


### PR DESCRIPTION
# Summary

This closes #518 , convert collected jira new fields to domain layer.
Keep in mind you may have to drop and recreate your database due to data schema changed.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Step to verify:
1. Drop `jira_issues` and `issues` table if they have `id` column, because `gorm` doesn't delete column at all.
2. Create a jira data source if none existed: export env-var from `.env` file and run `scripts/pm.sh jira_source_post_full` to create  one.
3. Trigger jira plugin `scripts/pm.sh jira <source_id> <board_id>`
4. Trigger jiradomain plugin `scripts/pm.sh jiradomain <source_id>`
5. All new fields should have values except for `parent_origin_key` because collect issues by board would not fetch any subtask, so every issue we have in our database would not have a `parent`


### Does this close any open issues?
Closes #518
