### PR TITLE
#415 Config UI: Add Basic Auth Token Generator

### DIFF
--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -6,8 +6,12 @@ import {
   Icon,
   Tag,
   Elevation,
+  Popover,
+  Position,
   Intent
 } from '@blueprintjs/core'
+
+import GenerateTokenForm from '@/pages/configure/connections/GenerateTokenForm'
 
 import '@/styles/integration.scss'
 import '@/styles/connections.scss'
@@ -40,6 +44,7 @@ export default function ConnectionForm (props) {
   } = props
 
   const [allowedAuthTypes, setAllowedAuthTypes] = useState(['token', 'plain'])
+  const [showTokenCreator, setShowTokenCreator] = useState(false)
 
   const getConnectionStatusIcon = () => {
     let statusIcon = <Icon icon='full-circle' size='10' color={Colors.RED3} />
@@ -58,6 +63,10 @@ export default function ConnectionForm (props) {
     return statusIcon
   }
 
+  const handleTokenInteraction = (isOpen) => {
+    setShowTokenCreator(isOpen)
+  }
+
   useEffect(() => {
     if (!allowedAuthTypes.includes(authType)) {
       console.log('INVALID AUTH TYPE!')
@@ -66,12 +75,6 @@ export default function ConnectionForm (props) {
 
   useEffect(() => {
     setAllowedAuthTypes(['token', 'plain'])
-  }, [])
-
-  useEffect(() => {
-    if (activeProvider && activeProvider.id) {
-      console.log('>>> SOURCE LIMITS = ', sourceLimits[activeProvider.id])
-    }
   }, [])
 
   return (
@@ -121,7 +124,7 @@ export default function ConnectionForm (props) {
               id='connection-name'
               disabled={isTesting || isSaving || isLocked}
               placeholder='Enter Instance Name eg. ISSUES-AWS-US-EAST'
-              defaultValue={name}
+              value={name}
               onChange={(e) => onNameChange(e.target.value)}
               className='input'
               fill
@@ -146,7 +149,7 @@ export default function ConnectionForm (props) {
               id='connection-endpoint'
               disabled={isTesting || isSaving || isLocked}
               placeholder='Enter Endpoint URL eg. https://merico.atlassian.net/rest'
-              defaultValue={endpointUrl}
+              value={endpointUrl}
               onChange={(e) => onEndpointChange(e.target.value)}
               className='input'
               fill
@@ -173,12 +176,38 @@ export default function ConnectionForm (props) {
                 id='connection-token'
                 disabled={isTesting || isSaving || isLocked}
                 placeholder='Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'
-                defaultValue={token}
+                value={token}
                 onChange={(e) => onTokenChange(e.target.value)}
                 className='input'
                 fill
                 required
               />
+              <Popover
+                className='popover-generate-token'
+                position={Position.RIGHT}
+                autoFocus={false}
+                enforceFocus={false}
+                isOpen={showTokenCreator}
+                onInteraction={handleTokenInteraction}
+                onClosed={() => setShowTokenCreator(false)}
+                usePortal={false}
+              >
+                <Button
+                  disabled={isTesting || isSaving || isLocked}
+                  type='button' icon='key' intent={Intent.PRIMARY} style={{ marginLeft: '5px' }}
+                />
+                <>
+                  <div style={{ padding: '15px 20px 15px 15px' }}>
+                    <GenerateTokenForm
+                      isTesting={isTesting}
+                      isSaving={isSaving}
+                      isLocked={isLocked}
+                      onTokenChange={onTokenChange}
+                      setShowTokenCreator={setShowTokenCreator}
+                    />
+                  </div>
+                </>
+              </Popover>
               {/* <a href='#' style={{ margin: '5px 0 5px 5px' }}><Icon icon='info-sign' size='16' /></a> */}
             </FormGroup>
           </div>

--- a/config-ui/src/pages/configure/connections/GenerateTokenForm.jsx
+++ b/config-ui/src/pages/configure/connections/GenerateTokenForm.jsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Button, Colors,
+  FormGroup, InputGroup, Label,
+  Card,
+  Icon,
+  Tag,
+  Elevation,
+  Popover,
+  Position,
+  Switch,
+  Intent
+} from '@blueprintjs/core'
+import { Buffer } from 'buffer'
+import '@/styles/integration.scss'
+import '@/styles/connections.scss'
+import '@blueprintjs/popover2/lib/css/blueprint-popover2.css'
+
+export default function GenerateTokenForm (props) {
+  const {
+    isTesting,
+    isSaving,
+    isLocked,
+    onTokenChange,
+    setShowTokenCreator
+  } = props
+  const [generatorUsername, setGeneratorUsername] = useState('')
+  const [generatorPassword, setGeneratorPassword] = useState('')
+  const [newToken, setNewToken] = useState()
+
+  const generateAuthToken = (username, password) => {
+    const token = Buffer.from(`${username}:${password}`).toString('base64')
+    onTokenChange(token)
+    setNewToken(token)
+    console.log('>> BASIC AUTH TOKEN ENCODED = ', token)
+    setShowTokenCreator(false)
+  }
+
+  const resetTokenGenerator = () => {
+    setGeneratorUsername('')
+    setGeneratorPassword('')
+  }
+
+  useEffect(() => {
+    // --token-data-changed
+  }, [generatorUsername, generatorPassword, newToken])
+
+  return (
+    <>
+      <h3 style={{ margin: 0 }}>GENERATE TOKEN <Tag>base64</Tag></h3>
+      <p style={{ margin: '0 0 10px 0' }}>Enter <strong>Username</strong> (or E-mail) and <strong>Password</strong></p>
+      <div className='formContainer' style={{ marginBottom: '0.2rem' }}>
+        <FormGroup
+          label=''
+          disabled={isTesting || isSaving || isLocked}
+          inline={true}
+          labelFor='token-username'
+          className='formGroup'
+          contentClassName='formGroupContent'
+        >
+          <Label style={{ display: 'inline', minWidth: '50px', whiteSpace: 'nowrap' }}>
+            Username <span className='requiredStar'>*</span>
+          </Label>
+          <InputGroup
+            id='token-username'
+            disabled={isTesting || isSaving || isLocked}
+            placeholder='Enter Username'
+            value={generatorUsername}
+            onChange={(e) => setGeneratorUsername(e.target.value)}
+            className='input'
+            style={{ maxWidth: '300px' }}
+          />
+        </FormGroup>
+      </div>
+      <div className='formContainer' style={{ marginBottom: '0.2rem' }}>
+        <FormGroup
+          disabled={isTesting || isSaving || isLocked}
+          label=''
+          inline={true}
+          labelFor='token-password'
+          className='formGroup'
+          contentClassName='formGroupContent'
+        >
+          <Label style={{ display: 'inline', minWidth: '50px', whiteSpace: 'nowrap' }}>
+            Password <span className='requiredStar'>*</span>
+          </Label>
+          <InputGroup
+            id='token-password'
+            type='password'
+            disabled={isTesting || isSaving || isLocked}
+            placeholder='Enter Password'
+            value={generatorPassword}
+            onChange={(e) => setGeneratorPassword(e.target.value)}
+            className='input'
+            style={{ maxWidth: '300px' }}
+          />
+        </FormGroup>
+      </div>
+      <div style={{ display: 'flex' }}>
+        <Button
+          type='button' icon='eraser' text=''
+          style={{ display: 'flex', marginLeft: 'auto', marginRight: '5px' }}
+          onClick={resetTokenGenerator} small minimal
+        />
+        <Button
+          type='button' intent={Intent.PRIMARY} icon='random' text='Generate'
+          style={{ display: 'flex' }}
+          disabled={!generatorUsername || !generatorPassword}
+          onClick={() => generateAuthToken(generatorUsername, generatorPassword)} small
+        />
+      </div>
+    </>
+  )
+}

--- a/config-ui/src/pages/configure/settings/gitlab.jsx
+++ b/config-ui/src/pages/configure/settings/gitlab.jsx
@@ -338,7 +338,7 @@ export default function GitlabSettings (props) {
           <div className={Classes.DIALOG_FOOTER_ACTIONS}>
             <Button
               icon='cross'
-              outline
+              // outlined
               text='Cancel'
               loading={isSaving}
               disabled={isSaving}

--- a/config-ui/src/styles/common.scss
+++ b/config-ui/src/styles/common.scss
@@ -114,7 +114,7 @@
   display: flex;
   width: 100%;
   align-items: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4rem;
 }
 
 .jiraFormContainer {

--- a/config-ui/src/styles/connections.scss
+++ b/config-ui/src/styles/connections.scss
@@ -1,16 +1,19 @@
 .addConnection, .editConnection, .configureConnection {
-  .formContainer {}
+  .formContainer {
+    max-width: 90%;
+  }
 
   .bp3-form-group {
     display: flex;
     max-width: none;
+    margin-bottom: 10px;
 
     .bp3-form-content {
       width: 100%;
-      max-width: 50%;
-      min-width: 600px;
+      // @todo REVISE THESE RULES!
+      max-width: 100%;
+      // min-width: 600px;
       display: flex;
-
       .bp3-label {}
     }
 
@@ -19,14 +22,19 @@
       // width: 440px;
       // min-width: 440px;
       // max-width: 440px;    
-      .input {
-        input.bp3-input {}
+      // max-width: 600px;
+      .bp3-input {
+        
       }
     }
 
     .bp3-form-helper-text {
+      margin-top: 2px;
       margin-right: 10px;
       margin-left: 5px;
+      min-width: 80px;
+      display: flex;
+      justify-content: flex-start;
     }
 
     label {
@@ -49,7 +57,7 @@
 .configureConnection {
   .bp3-form-group {
     .bp3-form-content {
-      max-width: 60%;
+      max-width: 80%;
     }
   }
 
@@ -97,5 +105,11 @@
         white-space: nowrap;
       }         
     }
+  }
+}
+
+.bp3-popover-wrapper {
+  &.popover-generate-token {
+    width: auto;
   }
 }


### PR DESCRIPTION
### Basic Auth Token Generator

- [x] Add Popover Widget for Generating Base64 Token
- [x] Enhance Connection Form
- [x] Cleanup/fix CSS rules for input sizing

### Description
This PR allows the user to **Generate a Basic Auth Token** on-the-fly by providing `Username` (or E-mail) and `Password` while creating or editing the Connection settings for that instance. A Base64 string token is then generated from the two params using **Buffer**.


### Screenshots
<img width="1240" alt="Screen Shot 2021-11-03 at 1 23 43 PM" src="https://user-images.githubusercontent.com/1742233/140161947-fca2852b-06ff-4aa1-a985-566b6923581b.png">

