### PR TITLE
fix: remove dashboard from sidenav

### DIFF
--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -28,7 +28,7 @@ function App () {
     <Router>
       {/* Admin */}
       <Route exact path='/'>
-        <Configure />
+        <Integration />
       </Route>
       <Route path='/integrations/:providerId'>
         <ManageIntegration />

--- a/config-ui/src/components/Sidebar/MenuConfiguration.jsx
+++ b/config-ui/src/components/Sidebar/MenuConfiguration.jsx
@@ -3,19 +3,9 @@ const MenuConfiguration = (activeRoute) => {
   return [
     {
       id: 0,
-      label: 'Dashboard',
-      icon: 'layout-grid',
-      route: '/',
-      active: activeRoute.url === '/',
-      classNames: [],
-      children: [
-      ]
-    },
-    {
-      id: 1,
       label: 'Data Integrations',
       route: '/integrations',
-      active: activeRoute.url.startsWith('/integrations'),
+      active: activeRoute.url.startsWith('/integrations') || activeRoute.url === '/',
       icon: 'data-connection',
       classNames: [],
       children: [
@@ -46,7 +36,7 @@ const MenuConfiguration = (activeRoute) => {
       ]
     },
     {
-      id: 2,
+      id: 1,
       label: 'Jobs & Tasks',
       icon: 'automatic-updates',
       route: '/tasks',
@@ -56,7 +46,7 @@ const MenuConfiguration = (activeRoute) => {
       ]
     },
     {
-      id: 3,
+      id: 2,
       label: 'Triggers',
       icon: 'asterisk',
       classNames: [],
@@ -66,7 +56,7 @@ const MenuConfiguration = (activeRoute) => {
       ]
     },
     {
-      id: 4,
+      id: 3,
       label: 'Documentation',
       icon: 'help',
       classNames: [],

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -78,7 +78,7 @@ export default function AddConnection () {
   }, [activeProvider])
 
   useEffect(() => {
-    fetch(`${SERVER_HOST}/api/getenv`)
+    fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
       .then(response => response.json())
       .then(env => {
         // setDbUrl(env.DB_URL)


### PR DESCRIPTION
### Description
This PR changes the default landing page on config UI to "Data Integrations" instead of "Dashboard". The reason is that currently "Dashboard" is no different from "API Configuration" in the list, and is also misleading since it is not really a Dashboard. Furthermore, "Data Integrations" is more relevant to the user for now.

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/614
