### PR TITLE
feat: jira api forwarding

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -40,6 +40,7 @@ func RegisterRouter(r *gin.Engine) {
 								input.Params[param.Key] = param.Value
 							}
 						}
+						input.Query = c.Request.URL.Query()
 						if c.Request.Body != nil {
 							err := c.ShouldBindJSON(&input.Body)
 							if err != nil && err.Error() != "EOF" {

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -242,3 +242,31 @@ PUT /plugins/jira/sources/:sourceId/type-mapping/:userType
 ```
 DELETE /plugins/jira/sources/:sourceId/type-mapping/:userType
 ```
+- API forwarding
+```
+GET /plugins/jira/sources/:sourceId/proxy/rest/*path
+
+For example:
+Requests to http://your_devlake_host/plugins/jira/sources/1/proxy/rest/agile/1.0/board/8/sprint
+would forward to
+https://your_jira_host/rest/agile/1.0/board/8/sprint
+
+{
+    "maxResults": 1,
+    "startAt": 0,
+    "isLast": false,
+    "values": [
+        {
+            "id": 7,
+            "self": "https://merico.atlassian.net/rest/agile/1.0/sprint/7",
+            "state": "closed",
+            "name": "EE Sprint 7",
+            "startDate": "2020-06-12T00:38:51.882Z",
+            "endDate": "2020-06-26T00:38:00.000Z",
+            "completeDate": "2020-06-22T05:59:58.980Z",
+            "originBoardId": 8,
+            "goal": ""
+        }
+    ]
+}
+```

--- a/plugins/jira/api/jira_proxy.go
+++ b/plugins/jira/api/jira_proxy.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/merico-dev/lake/logger"
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/jira/models"
+)
+
+const (
+	TimeOut = 10 * time.Second
+)
+
+func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	sourceId := input.Params["sourceId"]
+	if sourceId == "" {
+		return nil, fmt.Errorf("missing sourceid")
+	}
+	jiraSourceId, err := strconv.ParseUint(sourceId, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sourceId")
+	}
+	jiraSource := &models.JiraSource{}
+	err = lakeModels.Db.First(jiraSource, jiraSourceId).Error
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(jiraSource.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	path := input.Params["path"]
+	u.Path = path
+	u.RawQuery = input.Query.Encode()
+	logger.Info("request to", u.String())
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Basic "+jiraSource.BasicAuthEncoded)
+	client := &http.Client{Timeout: TimeOut}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Body: json.RawMessage(body)}, nil
+}

--- a/plugins/jira/api/jira_proxy.go
+++ b/plugins/jira/api/jira_proxy.go
@@ -21,6 +21,9 @@ func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 		return nil, fmt.Errorf("missing sourceid")
 	}
 	jiraSourceId, err := strconv.ParseUint(sourceId, 10, 64)
+	if err != nil {
+		return nil, err
+	}
 	client, err := tasks.NewJiraApiClientBySourceId(jiraSourceId)
 	if err != nil {
 		return nil, err

--- a/plugins/jira/api/jira_proxy.go
+++ b/plugins/jira/api/jira_proxy.go
@@ -57,5 +57,11 @@ func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
+	// verify response body is json
+	var tmp interface{}
+	err = json.Unmarshal(body, &tmp)
+	if err != nil {
+		return nil, err
+	}
 	return &core.ApiResourceOutput{Body: json.RawMessage(body)}, nil
 }

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -214,6 +214,9 @@ func (plugin Jira) ApiResources() map[string]map[string]core.ApiResourceHandler 
 			"PUT":    api.PutIssueStatusMapping,
 			"DELETE": api.DeleteIssueStatusMapping,
 		},
+		"sources/:sourceId/proxy/*path": {
+			"GET": api.Proxy,
+		},
 	}
 }
 

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -214,7 +214,7 @@ func (plugin Jira) ApiResources() map[string]map[string]core.ApiResourceHandler 
 			"PUT":    api.PutIssueStatusMapping,
 			"DELETE": api.DeleteIssueStatusMapping,
 		},
-		"sources/:sourceId/proxy/*path": {
+		"sources/:sourceId/proxy/rest/*path": {
 			"GET": api.Proxy,
 		},
 	}


### PR DESCRIPTION
# Summary
Forward HTTP requests to Jira server

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Forward HTTP requests to Jira server

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/499


### New Behavior
Requests with path`/plugins/jira/sources/:sourceId/proxy/*path` would route to `api.Proxy` handler

for example:
Request to http://your_devlake_host/plugins/jira/sources/1/proxy/rest/agile/1.0/board/8/sprint
would forward to
https://your_jira_host/rest/agile/1.0/board/8/sprint
