### PR TITLE
Kk 620 UI task list

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -14,6 +14,7 @@ import (
 func RegisterRouter(r *gin.Engine) {
 	r.POST("/task", task.Post)
 	r.GET("/task", task.Get)
+	r.GET("/task/pending", task.GetPending)
 	r.DELETE("/task/:taskId", task.Delete)
 	r.POST("/env", env.Set)
 	r.GET("/env", env.Get)

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -47,9 +47,22 @@ func Get(ctx *gin.Context) {
 		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
-	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks, "count":count})
+	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks, "count": count})
 }
-
+func GetPending(ctx *gin.Context) {
+	var query services.TaskQuery
+	err := ctx.BindQuery(&query)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	tasks, err := services.GetPendingTasks()
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks})
+}
 func Delete(ctx *gin.Context) {
 	taskId := ctx.Param("taskId")
 	id, err := strconv.ParseUint(taskId, 10, 64)

--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -18,7 +18,7 @@ import AddConnection from '@/pages/configure/connections/AddConnection'
 import EditConnection from '@/pages/configure/connections/EditConnection'
 import ConfigureConnection from '@/pages/configure/connections/ConfigureConnection'
 import Triggers from '@/pages/triggers/index'
-import Documentation from '@/pages/documentation/index'
+import Tasks from '@/pages/tasks'
 import Jira from '@/pages/plugins/jira/index'
 import Gitlab from '@/pages/plugins/gitlab/index'
 import Jenkins from '@/pages/plugins/jenkins/index'
@@ -45,15 +45,18 @@ function App () {
       <Route exact path='/integrations'>
         <Integration />
       </Route>
+      <Route exact path='/tasks'>
+        <Tasks />
+      </Route>
       <Route exact path='/triggers'>
         <Triggers />
       </Route>
       <Route exact path='/lake/api/configuration'>
         <Configure />
       </Route>
-      <Route exact path='/documentation'>
+      {/* <Route exact path='/documentation'>
         <Documentation />
-      </Route>
+      </Route> */}
       {/* Plugins */}
       <Route exact path='/plugins/jira'>
         <Jira />

--- a/config-ui/src/components/Sidebar/MenuConfiguration.jsx
+++ b/config-ui/src/components/Sidebar/MenuConfiguration.jsx
@@ -37,10 +37,9 @@ const MenuConfiguration = (activeRoute) => {
     },
     {
       id: 1,
-      label: 'Jobs & Tasks',
+      label: 'Tasks',
       icon: 'automatic-updates',
       route: '/tasks',
-      disabled: true,
       active: activeRoute.url === '/tasks',
       children: [
       ]

--- a/config-ui/src/components/Sidebar/MenuConfiguration.jsx
+++ b/config-ui/src/components/Sidebar/MenuConfiguration.jsx
@@ -40,6 +40,7 @@ const MenuConfiguration = (activeRoute) => {
       label: 'Tasks',
       icon: 'automatic-updates',
       route: '/tasks',
+      disabled: true,
       active: activeRoute.url === '/tasks',
       children: [
       ]

--- a/config-ui/src/data/defaultTriggerValue.js
+++ b/config-ui/src/data/defaultTriggerValue.js
@@ -3,7 +3,8 @@ const someJson = [
     {
       plugin: 'jira',
       Options: {
-        boardId: 8
+        boardId: 8,
+        sourceId: 1
       }
     },
     {

--- a/config-ui/src/pages/tasks/index.jsx
+++ b/config-ui/src/pages/tasks/index.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react'
+import Nav from '../../components/Nav'
+import Sidebar from '../../components/Sidebar'
+import AppCrumbs from '@/components/Breadcrumbs'
+import Content from '../../components/Content'
+import {
+  Tooltip, Position, FormGroup, InputGroup, Button, Label, Icon, Classes, Dialog
+} from '@blueprintjs/core'
+import axios from 'axios'
+import { DEVLAKE_ENDPOINT } from '../../utils/config'
+import { LABEL } from '@blueprintjs/core/lib/esm/common/classes'
+
+export default function Tasks () {
+
+
+  useEffect(async () => {
+    let res = await axios.get(`${DEVLAKE_ENDPOINT}/task`)
+    console.log('res', res)
+  }, [])
+
+  return (
+    <>
+      <div className='container'>
+      <Nav />
+      <Sidebar />
+        <Content>
+          <main className='main'>
+            <>
+              <div className='headlineContainer'>
+                <h1>Tasks</h1>
+                <table>
+
+                </table>
+                {/* <table className='bp3-html-table bp3-html-table-bordered connections-table' style={{ width: '100%' }}>
+                      <thead>
+                        <tr>
+                          <th>Task Name</th>
+                          <th>Endpoint</th>
+                          <th>Status</th>
+                          <th />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {}
+                      </tbody>
+                    </table> */}
+              </div>
+            </>
+          </main>
+        </Content>
+      </div>
+    </>
+  )
+}

--- a/config-ui/src/pages/tasks/index.jsx
+++ b/config-ui/src/pages/tasks/index.jsx
@@ -1,21 +1,18 @@
 import React, { useEffect, useState } from 'react'
 import Nav from '../../components/Nav'
 import Sidebar from '../../components/Sidebar'
-import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '../../components/Content'
-import {
-  Tooltip, Position, FormGroup, InputGroup, Button, Label, Icon, Classes, Dialog
-} from '@blueprintjs/core'
-import axios from 'axios'
 import { DEVLAKE_ENDPOINT } from '../../utils/config'
-import { LABEL } from '@blueprintjs/core/lib/esm/common/classes'
+import request from '../../utils/request'
 
 export default function Tasks () {
 
-
+  let [tasks, setTasks] = useState([])
   useEffect(async () => {
-    let res = await axios.get(`${DEVLAKE_ENDPOINT}/task`)
-    console.log('res', res)
+    if (tasks.length === 0) {
+      let res = await request.get(`${DEVLAKE_ENDPOINT}/task`)
+      setTasks(res?.data?.tasks)
+    } 
   }, [])
 
   return (
@@ -28,22 +25,32 @@ export default function Tasks () {
             <>
               <div className='headlineContainer'>
                 <h1>Tasks</h1>
-                <table>
-
-                </table>
-                {/* <table className='bp3-html-table bp3-html-table-bordered connections-table' style={{ width: '100%' }}>
-                      <thead>
-                        <tr>
-                          <th>Task Name</th>
-                          <th>Endpoint</th>
-                          <th>Status</th>
-                          <th />
+                <table className='bp3-html-table bp3-html-table-bordered connections-table' style={{ width: '100%' }}>
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>CreatedAt</th>
+                      <th>Plugin</th>
+                      <th>Progress</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {
+                      tasks.length > 0 ?
+                      tasks.map((task, i) => 
+                        <tr key={i}>
+                          <td>{task.ID}</td>
+                          <td>{task.CreatedAt}</td>
+                          <td>{task.plugin}</td>
+                          <td>{task.progress}</td>
+                          <td>{task.status}</td>
                         </tr>
-                      </thead>
-                      <tbody>
-                        {}
-                      </tbody>
-                    </table> */}
+                        )
+                      : null
+                    }
+                  </tbody>
+                </table>
               </div>
             </>
           </main>

--- a/config-ui/src/pages/triggers/index.jsx
+++ b/config-ui/src/pages/triggers/index.jsx
@@ -14,8 +14,8 @@ import Nav from '../../components/Nav'
 import Sidebar from '../../components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '../../components/Content'
-import Config from '../../../config'
 import request from '../../utils/request'
+import { DEVLAKE_ENDPOINT } from '../../utils/config.js'
 
 export default function Triggers () {
   const [textAreaBody, setTextAreaBody] = useState(JSON.stringify(defaultTriggerValue, null, 2))
@@ -23,39 +23,41 @@ export default function Triggers () {
   const sendTrigger = async (e) => {
     e.preventDefault()
     // @todo RE_ACTIVATE Trigger Process!
-    // try {
-    //   await request.post(
-    //     `${Config.DEVLAKE_ENDPOINT}/task`,
-    //     textAreaBody
-    //   )
-    // } catch (e) {
-    //   console.error(e)
-    // }
+    try {
+      await request.post(
+        `${DEVLAKE_ENDPOINT}/task`,
+        textAreaBody
+      )
+    } catch (e) {
+      console.error(e)
+    }
   }
 
   const [pendingTasks, setPendingTasks] = useState([])
   const [stage, setStage] = useState(0)
-  const [grafanaUrl, setGrafanaUrl] = useState(3002)
-  // useEffect(() => {
-  //   let s = 0
-  //   const interval = setInterval(async () => {
-  //     try {
-  //       const res = await request.get('/api/triggers/pendings')
-  //       console.log(await res.data)
-  //       if (res.data.tasks.length > 0) {
-  //         s = 1
-  //       } else if (s === 1) {
-  //         s = 2
-  //       }
-  //       setStage(s)
-  //       setPendingTasks(res.data.tasks)
-  //       setGrafanaUrl(`${location.protocol}//${location.hostname}:${res.data.grafanaPort}`)
-  //     } catch (e) {
-  //       console.log(e)
-  //     }
-  //   }, 3000)
-  //   return () => clearInterval(interval)
-  // }, [])
+  const [grafanaUrl, setGrafanaUrl] = useState(`http://localhost:3002`)
+  useEffect(() => {
+    let s = 0
+    const interval = setInterval(async () => {
+      try {
+        if (stage != 2){
+          const res = await request.get(`${DEVLAKE_ENDPOINT}/task/pending`)
+          console.log("res.data", res.data)
+          if (res.data.tasks.length > 0) {
+            s = 1
+          } else if (s === 1) {
+            s = 2
+          }
+          setStage(s)
+          setPendingTasks(res.data.tasks)
+          // setGrafanaUrl(`http://localhost:${res.data.grafanaPort}`)
+        }
+      } catch (e) {
+        console.log(e)
+      }
+    }, 3000)
+    return () => clearInterval(interval)
+  }, [])
 
   return (
     <div className='container'>

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -119,7 +119,7 @@ curl -XPOST 'localhost:8080/task' \
     "options": {
         "sourceId": 1,
         "boardId": 8,
-				"since": "2006-01-02T15:04:05Z"
+        "since": "2006-01-02T15:04:05Z"
     }
 }]]'
 ```

--- a/services/task.go
+++ b/services/task.go
@@ -141,6 +141,16 @@ func CancelTask(taskId uint64) error {
 	return nil
 }
 
+func GetPendingTasks() ([]models.Task, error) {
+	tasks := make([]models.Task, 0)
+	whereClause := "progress < 1 AND status != 'TASK_FAILED'"
+	db := models.Db.Model(&models.Task{}).Where(whereClause).Order("id DESC")
+	err := db.Debug().Find(&tasks)
+	if err != nil {
+		return tasks, nil
+	}
+	return tasks, nil
+}
 func GetTasks(query *TaskQuery) ([]models.Task, int64, error) {
 	db := models.Db.Model(&models.Task{}).Order("id DESC")
 	if query.Status != "" {


### PR DESCRIPTION
### Description
Fixes the UI triggers page to query a new backend route that returns pending tasks. 

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/612
https://github.com/merico-dev/lake/issues/620

### Current Behavior
API call to dead route: /api/triggers/pending returns nothing.

### New Behavior
API call to /task/pending returns tasks that are in progress.

## Additional context

There was some back and forth discussion on how to achieve our goal for this iteration. In the end, we decided to re-activate the old way the Triggers Page worked.
This PR also contains a preliminary table I created for the "Tasks" page when I thought I was developing a different solution. This code may be useful in the future, so I'm leaving it in the PR. Eventually we probably will want a list of all tasks.