### PR TITLE
fix: jira board gitlab project ui data flow

### DIFF
--- a/config-ui/src/components/Sidebar/SidebarMenu.jsx
+++ b/config-ui/src/components/Sidebar/SidebarMenu.jsx
@@ -62,7 +62,7 @@ const SidebarMenu = (props) => {
         <Menu.Item text='Documentation' icon='help' href='https://github.com/merico-dev/lake/wiki' target='_blank' />
         <Menu.Item text='Merico Network' icon='globe-network'>
           <Menu.Item text='Merico GitHub' href='https://github.com/merico-dev' target='_blank' />
-          <Menu.Item text='Triforce Project' href='https://github.com/merico-dev/lake' target='_blank' />
+          <Menu.Item text='Dev Lake Github' href='https://github.com/merico-dev/lake' target='_blank' />
           <Menu.Item text='Merico Enterprise' href='https://meri.co/' target='_blank' />
         </Menu.Item>
       </Menu>

--- a/plugins/gitlab/api/gitlab_sources.go
+++ b/plugins/gitlab/api/gitlab_sources.go
@@ -10,14 +10,16 @@ import (
 var V *viper.Viper
 
 type GitlabConfig struct {
-	GITLAB_ENDPOINT string `mapstructure:"GITLAB_ENDPOINT"`
-	GITLAB_AUTH     string `mapstructure:"GITLAB_AUTH"`
+	GITLAB_ENDPOINT            string `mapstructure:"GITLAB_ENDPOINT"`
+	GITLAB_AUTH                string `mapstructure:"GITLAB_AUTH"`
+	JIRA_BOARD_GITLAB_PROJECTS string `mapstructure:"JIRA_BOARD_GITLAB_PROJECTS"`
 }
 type GitlabSource struct {
-	Endpoint string
-	Auth     string
-	Name     string
-	ID       int
+	Endpoint                string
+	Auth                    string
+	Name                    string
+	ID                      int
+	JIRA_BOARD_GITLAB_PROJECTS string
 }
 
 /*
@@ -37,6 +39,7 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	V := config.LoadConfigFile()
 	V.Set("GITLAB_ENDPOINT", gitlabSource.Endpoint)
 	V.Set("GITLAB_AUTH", gitlabSource.Auth)
+	V.Set("JIRA_BOARD_GITLAB_PROJECTS", gitlabSource.JIRA_BOARD_GITLAB_PROJECTS)
 	err = V.WriteConfig()
 	if err != nil {
 		return nil, err
@@ -78,9 +81,10 @@ func GetSourceFromEnv() (*GitlabSource, error) {
 		return nil, err
 	}
 	return &GitlabSource{
-		Endpoint: configJson.GITLAB_ENDPOINT,
-		Auth:     configJson.GITLAB_AUTH,
-		Name:     "Gitlab",
-		ID:       1,
+		Endpoint:                configJson.GITLAB_ENDPOINT,
+		Auth:                    configJson.GITLAB_AUTH,
+		Name:                    "Gitlab",
+		ID:                      1,
+		JIRA_BOARD_GITLAB_PROJECTS: configJson.JIRA_BOARD_GITLAB_PROJECTS,
 	}, nil
 }


### PR DESCRIPTION

### Description
On the GitLab settings page, the "Map JIRA Boards to GitLab" field was not reading data from the backend. This PR fixes that issue so it reads and writes to and from the backend.

### Screenshots
![image](https://user-images.githubusercontent.com/27032263/140510868-1c40a904-6f8b-45fb-b2d9-f8dfb6284611.png)

