### PR TITLE
#647 FIX: Set Connection Name as READ-ONLY for Single-Limit Instances

### DIFF
--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -1,24 +1,19 @@
 import React, { useEffect, useState } from 'react'
-import axios from 'axios'
 import {
   useParams,
   Link,
   useHistory
 } from 'react-router-dom'
 import {
-  Button, Card, Elevation, Colors,
-  FormGroup, InputGroup, Tooltip, Label,
   Icon,
 } from '@blueprintjs/core'
 import Nav from '@/components/Nav'
 import Sidebar from '@/components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '@/components/Content'
-import { ToastNotification } from '@/components/Toast'
 import ConnectionForm from '@/pages/configure/connections/ConnectionForm'
 import { integrationsData } from '@/pages/configure/mock-data/integrations'
-// import { connectionsData } from '@/pages/configure/mock-data/connections'
-import { SERVER_HOST, DEVLAKE_ENDPOINT } from '@/utils/config'
+import { DEVLAKE_ENDPOINT } from '@/utils/config'
 
 import useConnectionManager from '@/hooks/useConnectionManager'
 
@@ -30,11 +25,11 @@ export default function AddConnection () {
   const history = useHistory()
   const { providerId } = useParams()
 
-  const [name, setName] = useState()
-  const [endpointUrl, setEndpointUrl] = useState()
-  const [token, setToken] = useState()
-  const [username, setUsername] = useState()
-  const [password, setPassword] = useState()
+  // const [name, setName] = useState()
+  // const [endpointUrl, setEndpointUrl] = useState()
+  // const [token, setToken] = useState()
+  // const [username, setUsername] = useState()
+  // const [password, setPassword] = useState()
 
   const [integrations, setIntegrations] = useState(integrationsData)
   const [activeProvider, setActiveProvider] = useState(integrations[0])
@@ -46,15 +41,26 @@ export default function AddConnection () {
     isTesting,
     showError,
     testStatus,
-    fetchAllConnections,
-    connectionLimitReached,
-  } = useConnectionManager({
-    activeProvider,
     name,
     endpointUrl,
     token,
     username,
     password,
+    setName,
+    setEndpointUrl,
+    setUsername,
+    setPassword,
+    setToken,
+    fetchAllConnections,
+    connectionLimitReached,
+    Providers
+  } = useConnectionManager({
+    activeProvider,
+    // name,
+    // endpointUrl,
+    // token,
+    // username,
+    // password,
   })
 
   const cancel = () => {
@@ -74,6 +80,18 @@ export default function AddConnection () {
     console.log(activeProvider)
     if (activeProvider && activeProvider.id) {
       fetchAllConnections()
+      switch (activeProvider.id) {
+        case Providers.GITLAB:
+          setName('Gitlab')
+          break
+        case Providers.JENKINS:
+          setName('Jenkins')
+          break
+        case Providers.JIRA:
+        default:
+          setName('')
+          break
+      }
     }
   }, [activeProvider])
 

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -111,6 +111,7 @@ export default function ConnectionForm (props) {
         <div className='formContainer'>
           <FormGroup
             disabled={isTesting || isSaving || isLocked}
+            readOnly={['gitlab', 'jenkins'].includes(activeProvider.id)}
             label=''
             inline={true}
             labelFor='connection-name'
@@ -124,10 +125,12 @@ export default function ConnectionForm (props) {
             <InputGroup
               id='connection-name'
               disabled={isTesting || isSaving || isLocked}
+              readOnly={['gitlab', 'jenkins'].includes(activeProvider.id)}
               placeholder='Enter Instance Name eg. ISSUES-AWS-US-EAST'
               value={name}
               onChange={(e) => onNameChange(e.target.value)}
-              className='input'
+              className='input connection-name-input'
+              leftIcon={['gitlab', 'jenkins'].includes(activeProvider.id) ? 'lock' : null}
               fill
             />
           </FormGroup>

--- a/config-ui/src/styles/connections.scss
+++ b/config-ui/src/styles/connections.scss
@@ -26,6 +26,20 @@
       .bp3-input {
         flex: 1;
       }
+
+      &.connection-name-input {
+        .bp3-input {
+          &:read-only {
+            background-color: #ffffee;
+            font-weight: bold;
+          }
+        }
+        svg[data-icon="lock"] {
+          width: 10px;
+          height: 10px;
+          margin-top: 2px;
+        }
+      }      
     }
 
     .bp3-form-helper-text {


### PR DESCRIPTION
### Key Points

- [x] Connection Name is READ-ONLY for Gitlab and Jenkins
  - Locked for ADD mode
  - Locked for MODIFY/Edit Mode
- [x] Connection Name is READ-WRITE for JIRA (Add & Modify)
- [x] Fix missing settings on Request Payload

### Description
This PR makes Connection Name read-only for single-limit instances such as Jenkins and Gitlab.

### Does this close any open issues?
#647

### Current Behavior
Users can set connection name for a Gitlab or Jenkins instance but this isn't a customizable field as yet it should not be modified.

### New Behavior
Connection Name is now read-only for Gitlab and Jenkins instances.

### Screenshots
<img width="1172" alt="Screen Shot 2021-11-05 at 9 49 40 AM" src="https://user-images.githubusercontent.com/1742233/140522533-f0e019f5-7db2-4b2c-80b4-bbdc3291e034.png">
<img width="1172" alt="Screen Shot 2021-11-05 at 9 49 12 AM" src="https://user-images.githubusercontent.com/1742233/140522545-ac030079-da6d-46f5-9a68-e73b6b573db3.png">
<img width="1164" alt="Screen Shot 2021-11-05 at 9 48 54 AM" src="https://user-images.githubusercontent.com/1742233/140522549-883b1de7-5a8f-4f4f-b3b5-9e0e5e27438a.png">
<img width="1161" alt="Screen Shot 2021-11-05 at 9 47 14 AM" src="https://user-images.githubusercontent.com/1742233/140522552-05ca965d-1fd0-4267-997f-c3687302490d.png">
<img width="1160" alt="Screen Shot 2021-11-05 at 9 44 55 AM" src="https://user-images.githubusercontent.com/1742233/140522556-f40c8584-d275-4746-a44b-73ad46db9aa2.png">


