### PR TITLE
fix: jira sprint collection incompleteness

### DIFF
--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -99,7 +99,7 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 			"collectIssues":     true,
 			"collectChangelogs": true,
 			"enrichIssues":      true,
-			"collectSprint":     true,
+			"collectSprints":    true,
 		}
 	}
 
@@ -156,7 +156,7 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 			}
 		}
 		setBoardProgress(i, 0.8)
-		if tasksToRun["collectSprint"]{
+		if tasksToRun["collectSprints"] {
 			err = tasks.CollectSprint(jiraApiClient, source, boardId)
 			if err != nil {
 				return err


### PR DESCRIPTION
# Summary

Closes #665 

### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated

### Description
We assumed all APIs accept 100 as maximal value for `maxResults` parameter, which is not true.
API like `agile sprints` is configurable, and it was 50 on our instance.
So use a fixed value like 100 to increase our `startAt` parameter is unreliable, and causing some sprints were missed out during collection.
This PR fix this issue by updating the `maxResults` value dynamically base on the `length` we actually received, and use this value  to increase `startAt` parameter.

### Does this close any open issues?
Closes #665 
