### PR TITLE
Config-UI: GitLab placeholder text fix and remove token gen button 

### DIFF
--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -46,7 +46,7 @@ export default function ConnectionForm (props) {
 
   const [allowedAuthTypes, setAllowedAuthTypes] = useState(['token', 'plain'])
   const [showTokenCreator, setShowTokenCreator] = useState(false)
-
+  const [placeholderUrl, setPlaceholderUrl] = useState('www.example.com')
   const getConnectionStatusIcon = () => {
     let statusIcon = <Icon icon='full-circle' size='10' color={Colors.RED3} />
     switch (testStatus) {
@@ -76,6 +76,8 @@ export default function ConnectionForm (props) {
 
   useEffect(() => {
     setAllowedAuthTypes(['token', 'plain'])
+    let exampleUrl = activeProvider.id === 'jira' ? 'https://merico.atlassian.net/rest' : 'https://gitlab.com/api/v4/'
+    setPlaceholderUrl(exampleUrl)
   }, [])
 
   return (
@@ -133,7 +135,7 @@ export default function ConnectionForm (props) {
               id='connection-name'
               disabled={isTesting || isSaving || isLocked}
               readOnly={['gitlab', 'jenkins'].includes(activeProvider.id)}
-              placeholder='Enter Instance Name eg. ISSUES-AWS-US-EAST'
+              placeholder='Enter Instance Name'
               value={name}
               onChange={(e) => onNameChange(e.target.value)}
               className='input connection-name-input'
@@ -159,7 +161,7 @@ export default function ConnectionForm (props) {
             <InputGroup
               id='connection-endpoint'
               disabled={isTesting || isSaving || isLocked}
-              placeholder='Enter Endpoint URL eg. https://merico.atlassian.net/rest'
+              placeholder={`Enter Endpoint URL eg. ${placeholderUrl}`}
               value={endpointUrl}
               onChange={(e) => onEndpointChange(e.target.value)}
               className='input'
@@ -193,32 +195,35 @@ export default function ConnectionForm (props) {
                 fill
                 required
               />
-              <Popover
-                className='popover-generate-token'
-                position={Position.RIGHT}
-                autoFocus={false}
-                enforceFocus={false}
-                isOpen={showTokenCreator}
-                onInteraction={handleTokenInteraction}
-                onClosed={() => setShowTokenCreator(false)}
-                usePortal={false}
-              >
-                <Button
-                  disabled={isTesting || isSaving || isLocked}
-                  type='button' icon='key' intent={Intent.PRIMARY} style={{ marginLeft: '5px' }}
-                />
-                <>
-                  <div style={{ padding: '15px 20px 15px 15px' }}>
-                    <GenerateTokenForm
-                      isTesting={isTesting}
-                      isSaving={isSaving}
-                      isLocked={isLocked}
-                      onTokenChange={onTokenChange}
-                      setShowTokenCreator={setShowTokenCreator}
-                    />
-                  </div>
-                </>
-              </Popover>
+              {
+                activeProvider.id === 'jira' &&
+                <Popover
+                  className='popover-generate-token'
+                  position={Position.RIGHT}
+                  autoFocus={false}
+                  enforceFocus={false}
+                  isOpen={showTokenCreator}
+                  onInteraction={handleTokenInteraction}
+                  onClosed={() => setShowTokenCreator(false)}
+                  usePortal={false}
+                >
+                  <Button
+                    disabled={isTesting || isSaving || isLocked}
+                    type='button' icon='key' intent={Intent.PRIMARY} style={{ marginLeft: '5px' }}
+                  />
+                  <>
+                    <div style={{ padding: '15px 20px 15px 15px' }}>
+                      <GenerateTokenForm
+                        isTesting={isTesting}
+                        isSaving={isSaving}
+                        isLocked={isLocked}
+                        onTokenChange={onTokenChange}
+                        setShowTokenCreator={setShowTokenCreator}
+                      />
+                    </div>
+                  </>
+                </Popover>
+              }
               {/* <a href='#' style={{ margin: '5px 0 5px 5px' }}><Icon icon='info-sign' size='16' /></a> */}
             </FormGroup>
           </div>


### PR DESCRIPTION
### Description
In Config-UI, GitLab configuration had some incorrect placeholder text. In addition, it displayed the token generator button for Jira. The latter has been removed, and the placeholder text fixed by creating a conditional statement between plugins (if Jira, then example A text).

### Does this close any open issues?
#651 

### Screenshots
![image](https://user-images.githubusercontent.com/27032263/140792445-e6fb7bc7-b0f5-4a27-b39f-0b591261f51f.png)

