### PR TITLE
#677 Config UI: JIRA Connections Management - Show Connection Source ID

### DIFF
--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -7,6 +7,8 @@ import {
 import {
   Button, Card, Elevation, Colors,
   Spinner,
+  Tooltip,
+  Position,
   Icon,
 } from '@blueprintjs/core'
 import Nav from '@/components/Nav'
@@ -42,6 +44,7 @@ export default function ManageIntegration () {
 
   const {
     sourceLimits,
+    Providers
   } = useConnectionManager({
     activeProvider
   })
@@ -236,6 +239,7 @@ export default function ManageIntegration () {
                     <table className='bp3-html-table bp3-html-table-bordered connections-table' style={{ width: '100%' }}>
                       <thead>
                         <tr>
+                          {activeProvider.id === Providers.JIRA && (<th>ID</th>)}
                           <th>Connection Name</th>
                           <th>Endpoint</th>
                           <th>Status</th>
@@ -248,13 +252,27 @@ export default function ManageIntegration () {
                             key={`connection-row-${idx}`}
                             className={connection.status === 0 ? 'connection-offline' : ''}
                           >
+                            {activeProvider.id === Providers.JIRA && (
+                              <td
+                                style={{ cursor: 'pointer' }}
+                                className='cell-name'
+                              >
+                                <Tooltip content='Use this SourceID for Triggers' position={Position.TOP}>
+                                  <span style={{ color: Colors.BLUE3, fontWeight: 'bold' }}>
+                                    {connection.ID}
+                                  </span>
+                                </Tooltip>
+                              </td>
+                            )}
                             <td
                               onClick={(e) => configureConnection(connection, e)}
                               style={{ cursor: 'pointer' }}
                               className='cell-name'
                             >
                               {/* <Icon icon='power' color={Colors.GRAY4} size={10} style={{ float: 'right', marginLeft: '10px' }} /> */}
-                              <strong>{connection.name || connection.Name}</strong>
+                              <strong>
+                                {connection.name || connection.Name}
+                              </strong>
                               <a
                                 href='#'
                                 data-provider={connection.id}


### PR DESCRIPTION
### Key Points

- [x] Show **Source ID** (Connection ID) on JIRA Management Table
  - Clicking this cell will NOT Route to MODIFY Page
  - User can highlight ID # to copy and paste on triggers page
- [x] Exclude ID Column for _Gitlab_ and _Jenkins_ 

### Description
This PR updates the Connection Management Table for JIRA Provider so that the Connection's Source ID / `sourceID` is visible to the user. In order to trigger collection this ID will be needed for the JSON Options payload. This is only a workaround solution until the Triggers Page is re-designed, and the Collect table row action(s) are restored on the management table.

### Does this close any open issues?
#677 

### Current Behavior
User has no way of determining connection Source ID other than URL Bar inspection or by snooping the JSON API Response from Lake.

### New Behavior
User can clearly see **Connection Source ID**, along with a tooltip that instructs them this ID should be used on the Triggers page.

### Screenshots
<img width="1085" alt="Screen Shot 2021-11-08 at 2 05 40 PM" src="https://user-images.githubusercontent.com/1742233/140803045-f3900323-f386-4286-a18e-57b24b950305.png">
<img width="1082" alt="Screen Shot 2021-11-08 at 2 05 50 PM" src="https://user-images.githubusercontent.com/1742233/140803057-955c079f-b402-4097-944c-8fa3d3624efb.png">

