### PR TITLE
Update .env.example and Jira plugin readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,26 +19,7 @@ NOTIFICATION_SECRET=
 # Jira configuration #
 ######################
 
-# Jira: basics #
-
-JIRA_ENDPOINT=
-# ex: echo -n <jira login email>:<jira token> | base64
-JIRA_BASIC_AUTH_ENCODED=
-
-# Jira: issue type #
-
-# Format:
-#   STANDARD_TYPE_1:YOUR_TYPE_1,YOUR_TYPE_2;STANDARD_TYPE_2:....
-JIRA_ISSUE_TYPE_MAPPING=
-
-# Jira: epic issue #
-
-JIRA_ISSUE_EPIC_KEY_FIELD=
-
-# Jira: story point #
-
-JIRA_ISSUE_STORYPOINT_COEFFICIENT=1
-JIRA_ISSUE_STORYPOINT_FIELD=
+# Jira configuration has been migrated into MySQL #
 
 ########################
 # Gitlab configuration #

--- a/plugins/jira/README-zh-CN.md
+++ b/plugins/jira/README-zh-CN.md
@@ -23,13 +23,13 @@
 
 ## 配置
 
-插件运行前，你需要在 `.env` 文件中进行以下配置：
+插件运行前，需要在Dev Lake提供的config UI中设置以下变量：
 
 ### 设置 JIRA_ENDPOINT
 
 这是所有 Jira API 调用的基础设置。你可以在你所有的 Jira Urls 中看到它作为 Url 的开头。
 
-例如：如果你看到 `https://mydomain.atlassian.net/secure/RapidBoard.jspa?rapidView=999&projectKey=XXX`, 你需要在你的 `.env` 文件中设置 `JIRA_ENDPOINT=https://mydomain.atlassian.net`
+例如：如果你看到 `https://mydomain.atlassian.net/secure/RapidBoard.jspa?rapidView=999&projectKey=XXX`, 你需要在config UI中将 `JIRA_ENDPOINT`设置为`https://mydomain.atlassian.net/rest`
 
 ### 生成 API token
 
@@ -47,7 +47,7 @@
  - `故障（Bug）`
  - `事故（Incident）`
 
-例如，假设我们使用 `故事` 和 `任务` 来表示需求，用 `客户投诉` 表示事故，用 `QABug` 表示故障。我们要做的是在运行 Devlake 之前在 `.env` 文件下设置环境变量：
+例如，假设我们使用 `故事` 和 `任务` 来表示需求，用 `客户投诉` 表示事故，用 `QABug` 表示故障。我们要做的是在运行 Dev Lake 之前在config UI中设置环境变量：
 
 ```sh
 # JIRA_ISSUE_TYPE_MAPPING=<STANDARD_TYPE>:<YOUR_TYPE_1>,<YOUR_TYPE_2>;....
@@ -69,7 +69,7 @@ Jira 是高度可定制的，不同公司可能使用不同的状态来表示一
 - 对于 `Bug` 类型的事务：使用 `已修复` 表示 "Resolved"，用 `拒绝`和 `无法复现` 表示 "Rejected"；
 - 对于 `Incident` 类型的事务：使用 `已修复` 表示 "Resolved"，用 `拒绝` 表示 "Rejected"；
 - 对于 `Story` 类型的事务：使用 `已完成` 表示 "Resolved"，用 `推迟` 表示 "Rejected"；
-我们要做的是在运行 Devlake 之前在 `.env` 文件下设置环境变量：
+我们要做的是在运行 Devlake 之前在config UI中进行如下设置：
 
 ```sh
 #JIRA_ISSUE_<YOUR_TYPE>_STATUS_MAPPING=<STANDARD_STATUS>:<YOUR_STATUS>;...
@@ -109,7 +109,7 @@ JIRA_ISSUE_STORYPOINT_FIELD=customfield_10026
 ## 如何触发此插件进行数据收集
  
 你可以向 `/task` 发起一个POST请求来触发数据收集。由于我们通过 Jira 来决定收集的数据范畴，因此需要在请求里带上 Jira board id<br>
-注意：此请求会在收集全部数据时自动触发，你无需单独执行这一请求，也不需要在 `.env` 文件中设置这个。
+注意：此请求会在收集全部数据时自动触发，你无需单独执行这一请求，也不需要在数据源层面设置这个变量。
 
 ```
 curl -XPOST 'localhost:8080/task' \

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -23,7 +23,7 @@ Incident Count per 1k Lines of Code | Amount of incidents per 1000 lines of code
 
 ## Configuration
 
-In order to fully use this plugin, you will need to set various config variables in the root of this project in the `.env` file.
+In order to fully use this plugin, you will need to set various configurations via Dev Lake's configuration UI.
 
 ### Set JIRA_ENDPOINT
 
@@ -31,7 +31,7 @@ This is the setting that is used as the base of all Jira API calls. You can see 
 
 **Example:**
 
-If you see `https://mydomain.atlassian.net/secure/RapidBoard.jspa?rapidView=999&projectKey=XXX`, you will need to set `JIRA_ENDPOINT=https://mydomain.atlassian.net` in your `.env` file.
+If you see `https://mydomain.atlassian.net/secure/RapidBoard.jspa?rapidView=999&projectKey=XXX`, you will need to set `JIRA_ENDPOINT` to `https://mydomain.atlassian.net/rest` in the config UI.
 
 ## Generating API token
 1. Once logged into Jira, visit the url `https://id.atlassian.com/manage-profile/security/api-tokens`
@@ -79,7 +79,7 @@ Type mapping is critical for some metrics, like **Requirement Count**, make sure
 
 This applies to JIRA_ISSUE_STORYPOINT_FIELD and JIRA_ISSUE_EPIC_KEY_FIELD
 
-Custom fields can be applied to Jira stories. We use this to set `JIRA_ISSUE_EPIC_KEY_FIELD` in the `.env` file.
+Custom fields can be applied to Jira stories. We use this to set `JIRA_ISSUE_EPIC_KEY_FIELD` in the config UI.
 
 **Example:** `JIRA_ISSUE_EPIC_KEY_FIELD=customfield_10024`
 
@@ -100,7 +100,8 @@ This is a value you can set to something other than the default of 1 if you want
 
 ![Screen Shot 2021-08-13 at 10 07 19 AM](https://user-images.githubusercontent.com/27032263/129363083-df0afa18-e147-4612-baf9-d284a8bb7a59.png)
 
-Your board id is used in all REST requests to DevLake. You do not need to set this in your `.env` file.
+Your board id is used in all REST requests to DevLake. You do not need to configure this at the data source level.
+
 ## How do I find the custom field ID in Jira?
 Using URL
 1. Navigate to Administration >> Issues >> Custom Fields .


### PR DESCRIPTION

# Summary

This PR does 3 things:

1. Remove jira configurations from `.env.example` to avoid user confusion
2. Replace .env with config UI for jira English readme
3. Replace .env with config UI for jira Chinese readme

However, the readmes still need more polishment. I only had time to do some basic cleaning.