### PR TITLE
fix: update command configure-dev in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ configure:
 	docker-compose up config-ui
 
 configure-dev:
-	cd config-ui; yarn; npm run dev;
+	cd config-ui; npm start;
 
 compose:
 	docker-compose up grafana


### PR DESCRIPTION
# Summary

When I tried to set up config-ui with `make configure-dev`, I noticed the command hasn't been updated for the new config-ui setup. This PR simply updates that command.
