### PR TITLE
fix: change mysqldb to mysql to allow grafana to connect to mysql

### DIFF
--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -4,7 +4,7 @@ apiVersion: 1
 datasources:
   - name: mysql
     type: mysql
-    url: mysqldb:3306
+    url: mysql:3306
     database: lake
     user: merico
     secureJsonData:


### PR DESCRIPTION
# Summary

After I collected data under dev mode, I noticed that Grafana dashboard can't connect to mySQL database. I had to edit the datasource setting in grafana to make it work. Seems like it's due to us removing hostname in `docker-compose.yml` file.

fixes https://github.com/merico-dev/lake/issues/685
