### PR TITLE
feat: all api routes hooked up and tested

### DIFF
--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -61,7 +61,7 @@ const ProviderFormLabels = {
     // token: 'Auth Token(s)',
     token: (
       <Tooltip
-        content={(<span>Due to Github’s rate limit, input more <br /> tokens to accelerate data collection.</span>)}
+        content={(<span>Due to Github’s rate limit, input more tokens, <br />comma separated, to accelerate data collection.</span>)}
         intent='primary'
       >
         Auth Token(s)

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -275,6 +275,9 @@ function useConnectionManager ({
         case Providers.GITLAB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
           break
+        case Providers.GITHUB:
+          setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
+          break
         case Providers.JIRA:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
           break

--- a/config-ui/src/pages/plugins/gitlab/index.jsx
+++ b/config-ui/src/pages/plugins/gitlab/index.jsx
@@ -1,137 +1,137 @@
-import React, { useState, useEffect } from 'react'
-import { FormGroup, InputGroup, Button, Label, Tooltip, Position } from '@blueprintjs/core'
-import Nav from '../../../components/Nav'
-import Sidebar from '../../../components/Sidebar'
-import Content from '../../../components/Content'
-import SaveAlert from '../../../components/SaveAlert'
-import { DEVLAKE_ENDPOINT } from '../../../utils/config'
+// import React, { useState, useEffect } from 'react'
+// import { FormGroup, InputGroup, Button, Label, Tooltip, Position } from '@blueprintjs/core'
+// import Nav from '../../../components/Nav'
+// import Sidebar from '../../../components/Sidebar'
+// import Content from '../../../components/Content'
+// import SaveAlert from '../../../components/SaveAlert'
+// import { DEVLAKE_ENDPOINT } from '../../../utils/config'
 
-export default function Gitlab () {
-  const [alertOpen, setAlertOpen] = useState(false)
-  const [gitlabEndpoint, setGitlabEndpoint] = useState()
-  const [gitlabAuth, setGitlabAuth] = useState()
-  const [jiraBoardGitlabeProjects, setJiraBoardGitlabeProjects] = useState()
+// export default function Gitlab () {
+//   const [alertOpen, setAlertOpen] = useState(false)
+//   const [gitlabEndpoint, setGitlabEndpoint] = useState()
+//   const [gitlabAuth, setGitlabAuth] = useState()
+//   const [jiraBoardGitlabeProjects, setJiraBoardGitlabeProjects] = useState()
 
-  function updateEnv (key, value) {
-    fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
-  }
+//   function updateEnv (key, value) {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
+//   }
 
-  function saveAll (e) {
-    e.preventDefault()
-    updateEnv('GITLAB_ENDPOINT', gitlabEndpoint)
-    updateEnv('GITLAB_AUTH', gitlabAuth)
-    updateEnv('JIRA_BOARD_GITLAB_PROJECTS', jiraBoardGitlabeProjects)
-    setAlertOpen(true)
-  }
+//   function saveAll (e) {
+//     e.preventDefault()
+//     updateEnv('GITLAB_ENDPOINT', gitlabEndpoint)
+//     updateEnv('GITLAB_AUTH', gitlabAuth)
+//     updateEnv('JIRA_BOARD_GITLAB_PROJECTS', jiraBoardGitlabeProjects)
+//     setAlertOpen(true)
+//   }
 
-  useEffect(() => {
-    fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
-      .then(response => response.json())
-      .then(env => {
-        setGitlabEndpoint(env.GITLAB_ENDPOINT)
-        setGitlabAuth(env.GITLAB_AUTH)
-        setJiraBoardGitlabeProjects(env.JIRA_BOARD_GITLAB_PROJECTS)
-      })
-  }, [])
+//   useEffect(() => {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
+//       .then(response => response.json())
+//       .then(env => {
+//         setGitlabEndpoint(env.GITLAB_ENDPOINT)
+//         setGitlabAuth(env.GITLAB_AUTH)
+//         setJiraBoardGitlabeProjects(env.JIRA_BOARD_GITLAB_PROJECTS)
+//       })
+//   }, [])
 
-  return (
-    <div className='container'>
+//   return (
+//     <div className='container'>
 
-      <Nav />
-      <Sidebar />
-      <Content>
-        <main className='main'>
+//       <Nav />
+//       <Sidebar />
+//       <Content>
+//         <main className='main'>
 
-          <form className='form'>
-            <div className='headlineContainer'>
-              <h2 className='headline'>Gitlab Configuration</h2>
-              <p className='description'>Gitlab account and config settings</p>
-            </div>
+//           <form className='form'>
+//             <div className='headlineContainer'>
+//               <h2 className='headline'>Gitlab Configuration</h2>
+//               <p className='description'>Gitlab account and config settings</p>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='gitlab-endpoint'
-                helperText='GITLAB_ENDPOINT'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  API&nbsp;Endpoint <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='gitlab-endpoint'
-                    placeholder='Enter Gitlab API endpoint'
-                    defaultValue={gitlabEndpoint}
-                    onChange={(e) => setGitlabEndpoint(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='gitlab-endpoint'
+//                 helperText='GITLAB_ENDPOINT'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   API&nbsp;Endpoint <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='gitlab-endpoint'
+//                     placeholder='Enter Gitlab API endpoint'
+//                     defaultValue={gitlabEndpoint}
+//                     onChange={(e) => setGitlabEndpoint(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='gitlab-auth'
-                helperText='GITLAB_AUTH'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Auth&nbsp;Token <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='gitlab-auth'
-                    placeholder='Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz'
-                    defaultValue={gitlabAuth}
-                    onChange={(e) => setGitlabAuth(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='gitlab-auth'
+//                 helperText='GITLAB_AUTH'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Auth&nbsp;Token <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='gitlab-auth'
+//                     placeholder='Enter Gitlab Auth Token eg. uJVEDxabogHbfFyu2riz'
+//                     defaultValue={gitlabAuth}
+//                     onChange={(e) => setGitlabAuth(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='headlineContainer'>
-              <h3 className='headline'>Jira / Gitlab Connection</h3>
-              <p className='description'>Connect jira board to gitlab projects</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h3 className='headline'>Jira / Gitlab Connection</h3>
+//               <p className='description'>Connect jira board to gitlab projects</p>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jira-board-projects'
-                helperText='JIRA_BOARD_GITLAB_PROJECTS'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Tooltip content='Jira board and Gitlab projects relationship' position={Position.TOP}>
-                  <Label>
-                    Jira&nbsp;Board&nbsp;Gitlab&nbsp;Projects
-                    <InputGroup
-                      id='jira-storypoint-field'
-                      placeholder='<JIRA_BOARD>:<GITLAB_PROJECT_ID>,...; eg. 8:8967944,8967945;9:8967946,8967947'
-                      defaultValue={jiraBoardGitlabeProjects}
-                      onChange={(e) => setJiraBoardGitlabeProjects(e.target.value)}
-                      className='input'
-                    />
-                  </Label>
-                </Tooltip>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jira-board-projects'
+//                 helperText='JIRA_BOARD_GITLAB_PROJECTS'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Tooltip content='Jira board and Gitlab projects relationship' position={Position.TOP}>
+//                   <Label>
+//                     Jira&nbsp;Board&nbsp;Gitlab&nbsp;Projects
+//                     <InputGroup
+//                       id='jira-storypoint-field'
+//                       placeholder='<JIRA_BOARD>:<GITLAB_PROJECT_ID>,...; eg. 8:8967944,8967945;9:8967946,8967947'
+//                       defaultValue={jiraBoardGitlabeProjects}
+//                       onChange={(e) => setJiraBoardGitlabeProjects(e.target.value)}
+//                       className='input'
+//                     />
+//                   </Label>
+//                 </Tooltip>
+//               </FormGroup>
+//             </div>
 
-            <Button
-              type='submit'
-              outlined={true}
-              large={true}
-              className='saveBtn'
-              onClick={(e) => saveAll(e)}
-            >
-              Save Config
-            </Button>
+//             <Button
+//               type='submit'
+//               outlined={true}
+//               large={true}
+//               className='saveBtn'
+//               onClick={(e) => saveAll(e)}
+//             >
+//               Save Config
+//             </Button>
 
-            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
-          </form>
-        </main>
-      </Content>
-    </div>
-  )
-}
+//             <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
+//           </form>
+//         </main>
+//       </Content>
+//     </div>
+//   )
+// }

--- a/config-ui/src/pages/plugins/jenkins/index.jsx
+++ b/config-ui/src/pages/plugins/jenkins/index.jsx
@@ -1,129 +1,129 @@
-import React, { useState, useEffect } from 'react'
-import { FormGroup, InputGroup, Button, Label } from '@blueprintjs/core'
-import Nav from '../../../components/Nav'
-import Sidebar from '../../../components/Sidebar'
-import Content from '../../../components/Content'
-import SaveAlert from '../../../components/SaveAlert'
-import { DEVLAKE_ENDPOINT } from '../../../utils/config'
+// import React, { useState, useEffect } from 'react'
+// import { FormGroup, InputGroup, Button, Label } from '@blueprintjs/core'
+// import Nav from '../../../components/Nav'
+// import Sidebar from '../../../components/Sidebar'
+// import Content from '../../../components/Content'
+// import SaveAlert from '../../../components/SaveAlert'
+// import { DEVLAKE_ENDPOINT } from '../../../utils/config'
 
-export default function Jenkins () {
-  const [alertOpen, setAlertOpen] = useState(false)
-  const [jenkinsEndpoint, setJenkinsEndpoint] = useState()
-  const [jenkinsUsername, setJenkinsUsername] = useState()
-  const [jenkinsPassword, setJenkinsPassword] = useState()
+// export default function Jenkins () {
+//   const [alertOpen, setAlertOpen] = useState(false)
+//   const [jenkinsEndpoint, setJenkinsEndpoint] = useState()
+//   const [jenkinsUsername, setJenkinsUsername] = useState()
+//   const [jenkinsPassword, setJenkinsPassword] = useState()
 
-  function updateEnv (key, value) {
-    fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
-  }
+//   function updateEnv (key, value) {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
+//   }
 
-  function saveAll (e) {
-    e.preventDefault()
-    updateEnv('JENKINS_ENDPOINT', jenkinsEndpoint)
-    updateEnv('JENKINS_USERNAME', jenkinsUsername)
-    updateEnv('JENKINS_PASSWORD', jenkinsPassword)
-    setAlertOpen(true)
-  }
+//   function saveAll (e) {
+//     e.preventDefault()
+//     updateEnv('JENKINS_ENDPOINT', jenkinsEndpoint)
+//     updateEnv('JENKINS_USERNAME', jenkinsUsername)
+//     updateEnv('JENKINS_PASSWORD', jenkinsPassword)
+//     setAlertOpen(true)
+//   }
 
-  useEffect(() => {
-    fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
-      .then(response => response.json())
-      .then(env => {
-        setJenkinsEndpoint(env.JENKINS_ENDPOINT)
-        setJenkinsUsername(env.JENKINS_USERNAME)
-        setJenkinsPassword(env.JENKINS_PASSWORD)
-      })
-  }, [])
+//   useEffect(() => {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
+//       .then(response => response.json())
+//       .then(env => {
+//         setJenkinsEndpoint(env.JENKINS_ENDPOINT)
+//         setJenkinsUsername(env.JENKINS_USERNAME)
+//         setJenkinsPassword(env.JENKINS_PASSWORD)
+//       })
+//   }, [])
 
-  return (
-    <div className='container'>
+//   return (
+//     <div className='container'>
 
-      <Nav />
-      <Sidebar />
-      <Content>
-        <main className='main'>
-          <form className='form'>
+//       <Nav />
+//       <Sidebar />
+//       <Content>
+//         <main className='main'>
+//           <form className='form'>
 
-            <div className='headlineContainer'>
-              <h2 className='headline'>Jenkins Configuration</h2>
-              <p className='description'>Jenkins account and config settings</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h2 className='headline'>Jenkins Configuration</h2>
+//               <p className='description'>Jenkins account and config settings</p>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jenkins-endpoint'
-                helperText='JENKINS_ENDPOINT'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  API&nbsp;Endpoint <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='jenkins-endpoint'
-                    placeholder='Enter Jenkins API endpoint'
-                    defaultValue={jenkinsEndpoint}
-                    onChange={(e) => setJenkinsEndpoint(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jenkins-endpoint'
+//                 helperText='JENKINS_ENDPOINT'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   API&nbsp;Endpoint <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='jenkins-endpoint'
+//                     placeholder='Enter Jenkins API endpoint'
+//                     defaultValue={jenkinsEndpoint}
+//                     onChange={(e) => setJenkinsEndpoint(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jenkins-username'
-                helperText='JENKINS_USERNAME'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Username <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='jenkins-username'
-                    placeholder='Enter Jenkins Username'
-                    defaultValue={jenkinsUsername}
-                    onChange={(e) => setJenkinsUsername(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jenkins-username'
+//                 helperText='JENKINS_USERNAME'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Username <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='jenkins-username'
+//                     placeholder='Enter Jenkins Username'
+//                     defaultValue={jenkinsUsername}
+//                     onChange={(e) => setJenkinsUsername(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jenkins-password'
-                helperText='JENKINS_PASSWORD'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Password <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='jenkins-password'
-                    placeholder='Enter Jenkins Password'
-                    defaultValue={jenkinsPassword}
-                    onChange={(e) => setJenkinsPassword(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jenkins-password'
+//                 helperText='JENKINS_PASSWORD'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Password <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='jenkins-password'
+//                     placeholder='Enter Jenkins Password'
+//                     defaultValue={jenkinsPassword}
+//                     onChange={(e) => setJenkinsPassword(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
-            <Button
-              type='submit'
-              outlined={true}
-              large={true}
-              className='saveBtn'
-              onClick={(e) => saveAll(e)}
-            >
-              Save Config
-            </Button>
-          </form>
-        </main>
-      </Content>
-    </div>
-  )
-}
+//             <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
+//             <Button
+//               type='submit'
+//               outlined={true}
+//               large={true}
+//               className='saveBtn'
+//               onClick={(e) => saveAll(e)}
+//             >
+//               Save Config
+//             </Button>
+//           </form>
+//         </main>
+//       </Content>
+//     </div>
+//   )
+// }

--- a/config-ui/src/pages/plugins/jira/ClearButton.jsx
+++ b/config-ui/src/pages/plugins/jira/ClearButton.jsx
@@ -1,14 +1,14 @@
-import React from 'react'
-import { Button } from '@blueprintjs/core'
+// import React from 'react'
+// import { Button } from '@blueprintjs/core'
 
-const ClearButton = ({ onClick }) => {
-  return (
-    <Button
-      icon='cross'
-      minimal={true}
-      onClick={onClick}
-    />
-  )
-}
+// const ClearButton = ({ onClick }) => {
+//   return (
+//     <Button
+//       icon='cross'
+//       minimal={true}
+//       onClick={onClick}
+//     />
+//   )
+// }
 
-export default ClearButton
+// export default ClearButton

--- a/config-ui/src/pages/plugins/jira/MappingTag.jsx
+++ b/config-ui/src/pages/plugins/jira/MappingTag.jsx
@@ -1,37 +1,37 @@
-import React from 'react'
-import { Tooltip, Position, FormGroup, Label, Tag, TagInput } from '@blueprintjs/core'
+// import React from 'react'
+// import { Tooltip, Position, FormGroup, Label, Tag, TagInput } from '@blueprintjs/core'
 
-const MappingTag = ({ labelIntent, labelName, onChange, rightElement, helperText, typeOrStatus, values, placeholderText }) => {
-  return (
-    <>
-      <p>Issue {typeOrStatus === 'type' ? 'types' : 'statuses'} mapped to&nbsp;&nbsp;<Tag intent={labelIntent}>{labelName}</Tag></p>
+// const MappingTag = ({ labelIntent, labelName, onChange, rightElement, helperText, typeOrStatus, values, placeholderText }) => {
+//   return (
+//     <>
+//       <p>Issue {typeOrStatus === 'type' ? 'types' : 'statuses'} mapped to&nbsp;&nbsp;<Tag intent={labelIntent}>{labelName}</Tag></p>
 
-      <div className='formContainer'>
-        <FormGroup
-          inline={true}
-          labelFor='jira-issue-type-mapping'
-          helperText={helperText}
-          className='formGroup'
-          contentClassName='formGroup'
-        >
-          <Tooltip content={`Map custom Jira types to main ${labelName} status`} position={Position.TOP}>
-            <Label>
-              <TagInput
-                placeholder={placeholderText}
-                values={values || []}
-                fill={true}
-                onChange={value => setTimeout(() => onChange([...new Set(value)]), 0)}
-                addOnPaste={true}
-                rightElement={rightElement}
-                onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
-                className='tagInput'
-              />
-            </Label>
-          </Tooltip>
-        </FormGroup>
-      </div>
-    </>
-  )
-}
+//       <div className='formContainer'>
+//         <FormGroup
+//           inline={true}
+//           labelFor='jira-issue-type-mapping'
+//           helperText={helperText}
+//           className='formGroup'
+//           contentClassName='formGroup'
+//         >
+//           <Tooltip content={`Map custom Jira types to main ${labelName} status`} position={Position.TOP}>
+//             <Label>
+//               <TagInput
+//                 placeholder={placeholderText}
+//                 values={values || []}
+//                 fill={true}
+//                 onChange={value => setTimeout(() => onChange([...new Set(value)]), 0)}
+//                 addOnPaste={true}
+//                 rightElement={rightElement}
+//                 onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
+//                 className='tagInput'
+//               />
+//             </Label>
+//           </Tooltip>
+//         </FormGroup>
+//       </div>
+//     </>
+//   )
+// }
 
-export default MappingTag
+// export default MappingTag

--- a/config-ui/src/pages/plugins/jira/MappingTagStatus.jsx
+++ b/config-ui/src/pages/plugins/jira/MappingTagStatus.jsx
@@ -1,29 +1,29 @@
-import React from 'react'
-import MappingTag from './MappingTag'
+// import React from 'react'
+// import MappingTag from './MappingTag'
 
-const MappingTagStatus = ({ reqValue, resValue, envName, clearBtnReq, clearBtnRes, onChangeReq, onChangeRes }) => {
-  return (
-    <>
-      <MappingTag
-        labelName='Rejected'
-        labelIntent='danger'
-        placeholderText='Add Issue Statuses...'
-        values={reqValue}
-        helperText={envName}
-        rightElement={clearBtnReq}
-        onChange={onChangeReq}
-      />
-      <MappingTag
-        labelName='Resolved'
-        labelIntent='success'
-        placeholderText='Add Issue Statuses...'
-        values={resValue}
-        helperText={envName}
-        rightElement={clearBtnRes}
-        onChange={onChangeRes}
-      />
-    </>
-  )
-}
+// const MappingTagStatus = ({ reqValue, resValue, envName, clearBtnReq, clearBtnRes, onChangeReq, onChangeRes }) => {
+//   return (
+//     <>
+//       <MappingTag
+//         labelName='Rejected'
+//         labelIntent='danger'
+//         placeholderText='Add Issue Statuses...'
+//         values={reqValue}
+//         helperText={envName}
+//         rightElement={clearBtnReq}
+//         onChange={onChangeReq}
+//       />
+//       <MappingTag
+//         labelName='Resolved'
+//         labelIntent='success'
+//         placeholderText='Add Issue Statuses...'
+//         values={resValue}
+//         helperText={envName}
+//         rightElement={clearBtnRes}
+//         onChange={onChangeRes}
+//       />
+//     </>
+//   )
+// }
 
-export default MappingTagStatus
+// export default MappingTagStatus

--- a/config-ui/src/pages/plugins/jira/index.jsx
+++ b/config-ui/src/pages/plugins/jira/index.jsx
@@ -1,408 +1,408 @@
-import React, { useState, useEffect } from 'react'
-import {
-  Tooltip, Position, FormGroup, InputGroup, Button, Label, Icon, Classes, Dialog
-} from '@blueprintjs/core'
-import Nav from '../../../components/Nav'
-import Sidebar from '../../../components/Sidebar'
-import Content from '../../../components/Content'
-import SaveAlert from '../../../components/SaveAlert'
-import MappingTag from './MappingTag'
-import MappingTagStatus from './MappingTagStatus'
-import ClearButton from './ClearButton'
-import { findStrBetween } from '../../../utils/findStrBetween'
-import { DEVLAKE_ENDPOINT } from '../../../utils/config'
+// import React, { useState, useEffect } from 'react'
+// import {
+//   Tooltip, Position, FormGroup, InputGroup, Button, Label, Icon, Classes, Dialog
+// } from '@blueprintjs/core'
+// import Nav from '../../../components/Nav'
+// import Sidebar from '../../../components/Sidebar'
+// import Content from '../../../components/Content'
+// import SaveAlert from '../../../components/SaveAlert'
+// import MappingTag from './MappingTag'
+// import MappingTagStatus from './MappingTagStatus'
+// import ClearButton from './ClearButton'
+// import { findStrBetween } from '../../../utils/findStrBetween'
+// import { DEVLAKE_ENDPOINT } from '../../../utils/config'
 
-export default function Jira () {
-  const [alertOpen, setAlertOpen] = useState(false)
-  const [jiraEndpoint, setJiraEndpoint] = useState()
-  const [jiraBasicAuthEncoded, setJiraBasicAuthEncoded] = useState()
-  const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState()
-  const [jiraIssueStoryCoefficient, setJiraIssueStoryCoefficient] = useState()
-  const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState()
+// export default function Jira () {
+//   const [alertOpen, setAlertOpen] = useState(false)
+//   const [jiraEndpoint, setJiraEndpoint] = useState()
+//   const [jiraBasicAuthEncoded, setJiraBasicAuthEncoded] = useState()
+//   const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState()
+//   const [jiraIssueStoryCoefficient, setJiraIssueStoryCoefficient] = useState()
+//   const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState()
 
-  // Type mappings state
-  const [typeMappingBug, setTypeMappingBug] = useState()
-  const [typeMappingIncident, setTypeMappingIncident] = useState()
-  const [typeMappingRequirement, setTypeMappingRequirement] = useState()
-  const [typeMappingAll, setTypeMappingAll] = useState()
+//   // Type mappings state
+//   const [typeMappingBug, setTypeMappingBug] = useState()
+//   const [typeMappingIncident, setTypeMappingIncident] = useState()
+//   const [typeMappingRequirement, setTypeMappingRequirement] = useState()
+//   const [typeMappingAll, setTypeMappingAll] = useState()
 
-  const [statusMappings, setStatusMappings] = useState()
+//   const [statusMappings, setStatusMappings] = useState()
 
-  function setStatusMapping (key, values, status) {
-    setStatusMappings(statusMappings.map(mapping => {
-      if (mapping.key === key) {
-        mapping.mapping[status] = values
-      }
-      return mapping
-    }))
-  }
+//   function setStatusMapping (key, values, status) {
+//     setStatusMappings(statusMappings.map(mapping => {
+//       if (mapping.key === key) {
+//         mapping.mapping[status] = values
+//       }
+//       return mapping
+//     }))
+//   }
 
-  const [customStatusOverlay, setCustomStatusOverlay] = useState(false)
-  const [customStatusName, setCustomStatusName] = useState('')
+//   const [customStatusOverlay, setCustomStatusOverlay] = useState(false)
+//   const [customStatusName, setCustomStatusName] = useState('')
 
-  function addStatusMapping (e) {
-    const type = customStatusName.trim().toUpperCase()
-    if (statusMappings.find(e => e.type === type)) {
-      return
-    }
-    const result = [
-      ...statusMappings,
-      {
-        type,
-        key: `JIRA_ISSUE_${type}_STATUS_MAPPING`,
-        mapping: {
-          Resolved: [],
-          Rejected: [],
-        }
-      }
-    ]
-    setStatusMappings(result)
-    setCustomStatusOverlay(false)
-    e.preventDefault()
-  }
+//   function addStatusMapping (e) {
+//     const type = customStatusName.trim().toUpperCase()
+//     if (statusMappings.find(e => e.type === type)) {
+//       return
+//     }
+//     const result = [
+//       ...statusMappings,
+//       {
+//         type,
+//         key: `JIRA_ISSUE_${type}_STATUS_MAPPING`,
+//         mapping: {
+//           Resolved: [],
+//           Rejected: [],
+//         }
+//       }
+//     ]
+//     setStatusMappings(result)
+//     setCustomStatusOverlay(false)
+//     e.preventDefault()
+//   }
 
-  function updateEnv (key, value) {
-    fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
-  }
+//   function updateEnv (key, value) {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/setenv/${key}/${encodeURIComponent(value)}`)
+//   }
 
-  function saveAll (e) {
-    e.preventDefault()
-    updateEnv('JIRA_ENDPOINT', jiraEndpoint)
-    updateEnv('JIRA_BASIC_AUTH_ENCODED', jiraBasicAuthEncoded)
-    updateEnv('JIRA_ISSUE_EPIC_KEY_FIELD', jiraIssueEpicKeyField)
-    updateEnv('JIRA_ISSUE_TYPE_MAPPING', typeMappingAll)
-    updateEnv('JIRA_ISSUE_STORYPOINT_COEFFICIENT', jiraIssueStoryCoefficient)
-    updateEnv('JIRA_ISSUE_STORYPOINT_FIELD', jiraIssueStoryPointField)
+//   function saveAll (e) {
+//     e.preventDefault()
+//     updateEnv('JIRA_ENDPOINT', jiraEndpoint)
+//     updateEnv('JIRA_BASIC_AUTH_ENCODED', jiraBasicAuthEncoded)
+//     updateEnv('JIRA_ISSUE_EPIC_KEY_FIELD', jiraIssueEpicKeyField)
+//     updateEnv('JIRA_ISSUE_TYPE_MAPPING', typeMappingAll)
+//     updateEnv('JIRA_ISSUE_STORYPOINT_COEFFICIENT', jiraIssueStoryCoefficient)
+//     updateEnv('JIRA_ISSUE_STORYPOINT_FIELD', jiraIssueStoryPointField)
 
-    // Save all custom status data
-    statusMappings.forEach(mapping => {
-      const { Resolved, Rejected } = mapping.mapping
-      updateEnv(mapping.key,
-        `Rejected:${Rejected ? Rejected.join(',') : ''};Resolved:${Resolved ? Resolved.join(',') : ''};`)
-    })
+//     // Save all custom status data
+//     statusMappings.forEach(mapping => {
+//       const { Resolved, Rejected } = mapping.mapping
+//       updateEnv(mapping.key,
+//         `Rejected:${Rejected ? Rejected.join(',') : ''};Resolved:${Resolved ? Resolved.join(',') : ''};`)
+//     })
 
-    setAlertOpen(true)
-  }
+//     setAlertOpen(true)
+//   }
 
-  useEffect(() => {
-    if (typeMappingBug && typeMappingIncident && typeMappingRequirement) {
-      const typeBug = 'Bug:' + typeMappingBug.toString() + ';'
-      const typeIncident = 'Incident:' + typeMappingIncident.toString() + ';'
-      const typeRequirement = 'Requirement:' + typeMappingRequirement.toString() + ';'
-      const all = typeBug + typeIncident + typeRequirement
-      setTypeMappingAll(all)
-    }
-  }, [typeMappingBug, typeMappingIncident, typeMappingRequirement])
+//   useEffect(() => {
+//     if (typeMappingBug && typeMappingIncident && typeMappingRequirement) {
+//       const typeBug = 'Bug:' + typeMappingBug.toString() + ';'
+//       const typeIncident = 'Incident:' + typeMappingIncident.toString() + ';'
+//       const typeRequirement = 'Requirement:' + typeMappingRequirement.toString() + ';'
+//       const all = typeBug + typeIncident + typeRequirement
+//       setTypeMappingAll(all)
+//     }
+//   }, [typeMappingBug, typeMappingIncident, typeMappingRequirement])
 
-  useEffect(() => {
-    fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
-      .then(response => response.json())
-      .then(env => {
-        setJiraEndpoint(env.JIRA_ENDPOINT)
-        setJiraBasicAuthEncoded(env.JIRA_BASIC_AUTH_ENCODED)
-        setJiraIssueEpicKeyField(env.JIRA_ISSUE_EPIC_KEY_FIELD)
-        setJiraIssueStoryCoefficient(env.JIRA_ISSUE_STORYPOINT_COEFFICIENT)
-        setJiraIssueStoryPointField(env.JIRA_ISSUE_STORYPOINT_FIELD)
-        setTypeMappingBug(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Bug:', 4))
-        setTypeMappingIncident(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Incident:', 9))
-        setTypeMappingRequirement(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Requirement:', 12))
+//   useEffect(() => {
+//     fetch(`${DEVLAKE_ENDPOINT}/api/getenv`)
+//       .then(response => response.json())
+//       .then(env => {
+//         setJiraEndpoint(env.JIRA_ENDPOINT)
+//         setJiraBasicAuthEncoded(env.JIRA_BASIC_AUTH_ENCODED)
+//         setJiraIssueEpicKeyField(env.JIRA_ISSUE_EPIC_KEY_FIELD)
+//         setJiraIssueStoryCoefficient(env.JIRA_ISSUE_STORYPOINT_COEFFICIENT)
+//         setJiraIssueStoryPointField(env.JIRA_ISSUE_STORYPOINT_FIELD)
+//         setTypeMappingBug(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Bug:', 4))
+//         setTypeMappingIncident(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Incident:', 9))
+//         setTypeMappingRequirement(findStrBetween(env.JIRA_ISSUE_TYPE_MAPPING, 'Requirement:', 12))
 
-        // status mapping
-        const defaultStatusMappings = []
-        for (const [key, value] of Object.entries(env)) {
-          const m = /^JIRA_ISSUE_([A-Z]+)_STATUS_MAPPING$/.exec(key)
-          if (!m) {
-            continue
-          }
-          const type = m[1]
-          const rejected = findStrBetween(value, 'Rejected:', 9)
-          const resolved = findStrBetween(value, 'Resolved:', 9)
+//         // status mapping
+//         const defaultStatusMappings = []
+//         for (const [key, value] of Object.entries(env)) {
+//           const m = /^JIRA_ISSUE_([A-Z]+)_STATUS_MAPPING$/.exec(key)
+//           if (!m) {
+//             continue
+//           }
+//           const type = m[1]
+//           const rejected = findStrBetween(value, 'Rejected:', 9)
+//           const resolved = findStrBetween(value, 'Resolved:', 9)
 
-          defaultStatusMappings.push({
-            type,
-            key,
-            mapping: {
-              Resolved: resolved || [],
-              Rejected: rejected || [],
-            }
-          })
-        }
-        setStatusMappings(defaultStatusMappings)
-      })
-  }, [])
+//           defaultStatusMappings.push({
+//             type,
+//             key,
+//             mapping: {
+//               Resolved: resolved || [],
+//               Rejected: rejected || [],
+//             }
+//           })
+//         }
+//         setStatusMappings(defaultStatusMappings)
+//       })
+//   }, [])
 
-  return (
-    <div className='container'>
+//   return (
+//     <div className='container'>
 
-      <Nav />
-      <Sidebar />
-      <Content>
-        <main className='main'>
+//       <Nav />
+//       <Sidebar />
+//       <Content>
+//         <main className='main'>
 
-          <form className='form'>
+//           <form className='form'>
 
-            <div className='headlineContainer'>
-              <h2 className='headline'>Jira Plugin</h2>
-              <p className='description'>Jira Account and config settings</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h2 className='headline'>Jira Plugin</h2>
+//               <p className='description'>Jira Account and config settings</p>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                label=''
-                inline={true}
-                labelFor='jira-endpoint'
-                helperText='JIRA_ENDPOINT'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Endpoint&nbsp;URL <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='jira-endpoint'
-                    placeholder='Enter Jira endpoint eg. https://merico.atlassian.net/rest'
-                    defaultValue={jiraEndpoint}
-                    onChange={(e) => setJiraEndpoint(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 label=''
+//                 inline={true}
+//                 labelFor='jira-endpoint'
+//                 helperText='JIRA_ENDPOINT'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Endpoint&nbsp;URL <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='jira-endpoint'
+//                     placeholder='Enter Jira endpoint eg. https://merico.atlassian.net/rest'
+//                     defaultValue={jiraEndpoint}
+//                     onChange={(e) => setJiraEndpoint(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jira-basic-auth'
-                helperText='JIRA_BASIC_AUTH_ENCODED'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Basic&nbsp;Auth&nbsp;Token <span className='requiredStar'>*</span>
-                  <InputGroup
-                    id='jira-basic-auth'
-                    placeholder='Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47'
-                    defaultValue={jiraBasicAuthEncoded}
-                    onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
-                    className='input'
-                  />
-                </Label>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jira-basic-auth'
+//                 helperText='JIRA_BASIC_AUTH_ENCODED'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Basic&nbsp;Auth&nbsp;Token <span className='requiredStar'>*</span>
+//                   <InputGroup
+//                     id='jira-basic-auth'
+//                     placeholder='Enter Jira Auth eg. EJrLG8DNeXADQcGOaaaX4B47'
+//                     defaultValue={jiraBasicAuthEncoded}
+//                     onChange={(e) => setJiraBasicAuthEncoded(e.target.value)}
+//                     className='input'
+//                   />
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='headlineContainer'>
-              <h3 className='headline'>Issue Type Mappings</h3>
-              <p className='description'>Map your own issue types to Dev Lake's standard types</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h3 className='headline'>Issue Type Mappings</h3>
+//               <p className='description'>Map your own issue types to Dev Lake's standard types</p>
+//             </div>
 
-            <MappingTag
-              labelName='Bug'
-              labelIntent='danger'
-              typeOrStatus='type'
-              placeholderText='Add Issue Types...'
-              values={typeMappingBug}
-              helperText='JIRA_ISSUE_TYPE_MAPPING'
-              rightElement={<ClearButton onClick={() => setTypeMappingBug([])} />}
-              onChange={(values) => setTypeMappingBug(values)}
-            />
+//             <MappingTag
+//               labelName='Bug'
+//               labelIntent='danger'
+//               typeOrStatus='type'
+//               placeholderText='Add Issue Types...'
+//               values={typeMappingBug}
+//               helperText='JIRA_ISSUE_TYPE_MAPPING'
+//               rightElement={<ClearButton onClick={() => setTypeMappingBug([])} />}
+//               onChange={(values) => setTypeMappingBug(values)}
+//             />
 
-            <MappingTag
-              labelName='Incident'
-              labelIntent='warning'
-              typeOrStatus='type'
-              placeholderText='Add Issue Types...'
-              values={typeMappingIncident}
-              helperText='JIRA_ISSUE_TYPE_MAPPING'
-              rightElement={<ClearButton onClick={() => setTypeMappingIncident([])} />}
-              onChange={(values) => setTypeMappingIncident(values)}
-            />
+//             <MappingTag
+//               labelName='Incident'
+//               labelIntent='warning'
+//               typeOrStatus='type'
+//               placeholderText='Add Issue Types...'
+//               values={typeMappingIncident}
+//               helperText='JIRA_ISSUE_TYPE_MAPPING'
+//               rightElement={<ClearButton onClick={() => setTypeMappingIncident([])} />}
+//               onChange={(values) => setTypeMappingIncident(values)}
+//             />
 
-            <MappingTag
-              labelName='Requirement'
-              labelIntent='primary'
-              typeOrStatus='type'
-              placeholderText='Add Issue Types...'
-              values={typeMappingRequirement}
-              helperText='JIRA_ISSUE_TYPE_MAPPING'
-              rightElement={<ClearButton onClick={() => setTypeMappingRequirement([])} />}
-              onChange={(values) => setTypeMappingRequirement(values)}
-            />
+//             <MappingTag
+//               labelName='Requirement'
+//               labelIntent='primary'
+//               typeOrStatus='type'
+//               placeholderText='Add Issue Types...'
+//               values={typeMappingRequirement}
+//               helperText='JIRA_ISSUE_TYPE_MAPPING'
+//               rightElement={<ClearButton onClick={() => setTypeMappingRequirement([])} />}
+//               onChange={(values) => setTypeMappingRequirement(values)}
+//             />
 
-            <div className='headlineContainer'>
-              <h3 className='headline'>Issue Status Mappings</h3>
-              <p className='description'>Map your own issue statuses to Dev Lake's standard statuses for every issue type</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h3 className='headline'>Issue Status Mappings</h3>
+//               <p className='description'>Map your own issue statuses to Dev Lake's standard statuses for every issue type</p>
+//             </div>
 
-            <div className='jiraFormContainer'>
+//             <div className='jiraFormContainer'>
 
-              {(statusMappings && statusMappings.length > 0) && statusMappings.map((statusMapping, i) =>
-                <div key={statusMapping.key} className='jiraFormContainerItem'>
-                  <p>Mapping {statusMapping.type} </p>
-                  <div>
-                    <MappingTagStatus
-                      reqValue={statusMapping.mapping.Rejected || []}
-                      resValue={statusMapping.mapping.Resolved || []}
-                      envName={statusMapping.key}
-                      clearBtnReq={<ClearButton onClick={() => setStatusMapping(statusMapping.key, [], 'Rejected')} />}
-                      clearBtnRes={<ClearButton onClick={() => setStatusMapping(statusMapping.key, [], 'Resolved')} />}
-                      onChangeReq={values => setStatusMapping(statusMapping.key, values, 'Rejected')}
-                      onChangeRes={values => setStatusMapping(statusMapping.key, values, 'Resolved')}
-                      className='mappingTagStatus'
-                    />
-                  </div>
-                </div>
-              )}
-              <Button icon='add' onClick={() => setCustomStatusOverlay(true)} className='addNewStatusBtn'>Add New</Button>
+//               {(statusMappings && statusMappings.length > 0) && statusMappings.map((statusMapping, i) =>
+//                 <div key={statusMapping.key} className='jiraFormContainerItem'>
+//                   <p>Mapping {statusMapping.type} </p>
+//                   <div>
+//                     <MappingTagStatus
+//                       reqValue={statusMapping.mapping.Rejected || []}
+//                       resValue={statusMapping.mapping.Resolved || []}
+//                       envName={statusMapping.key}
+//                       clearBtnReq={<ClearButton onClick={() => setStatusMapping(statusMapping.key, [], 'Rejected')} />}
+//                       clearBtnRes={<ClearButton onClick={() => setStatusMapping(statusMapping.key, [], 'Resolved')} />}
+//                       onChangeReq={values => setStatusMapping(statusMapping.key, values, 'Rejected')}
+//                       onChangeRes={values => setStatusMapping(statusMapping.key, values, 'Resolved')}
+//                       className='mappingTagStatus'
+//                     />
+//                   </div>
+//                 </div>
+//               )}
+//               <Button icon='add' onClick={() => setCustomStatusOverlay(true)} className='addNewStatusBtn'>Add New</Button>
 
-              <Dialog
-                icon='diagram-tree'
-                onClose={() => setCustomStatusOverlay(false)}
-                title='Add a New Status Mapping'
-                isOpen={customStatusOverlay}
-                onOpened={() => setCustomStatusName('')}
-                autoFocus={false}
-                className='customStatusDialog'
-              >
-                <div className={Classes.DIALOG_BODY}>
-                  <form onSubmit={() => addStatusMapping}>
-                    <FormGroup
-                      className='formGroup customStatusFormGroup'
-                    >
-                      <InputGroup
-                        id='custom-status'
-                        placeholder='Enter custom status name'
-                        onChange={(e) => setCustomStatusName(e.target.value)}
-                        className='customStatusInput'
-                        autoFocus={true}
-                      />
-                      <Button
-                        icon='add'
-                        onClick={() => addStatusMapping}
-                        className='addNewStatusBtnDialog'
-                        onSubmit={(e) => e.preventDefault()}
-                      >
-                        Add New
-                      </Button>
-                    </FormGroup>
-                  </form>
-                </div>
-              </Dialog>
+//               <Dialog
+//                 icon='diagram-tree'
+//                 onClose={() => setCustomStatusOverlay(false)}
+//                 title='Add a New Status Mapping'
+//                 isOpen={customStatusOverlay}
+//                 onOpened={() => setCustomStatusName('')}
+//                 autoFocus={false}
+//                 className='customStatusDialog'
+//               >
+//                 <div className={Classes.DIALOG_BODY}>
+//                   <form onSubmit={() => addStatusMapping}>
+//                     <FormGroup
+//                       className='formGroup customStatusFormGroup'
+//                     >
+//                       <InputGroup
+//                         id='custom-status'
+//                         placeholder='Enter custom status name'
+//                         onChange={(e) => setCustomStatusName(e.target.value)}
+//                         className='customStatusInput'
+//                         autoFocus={true}
+//                       />
+//                       <Button
+//                         icon='add'
+//                         onClick={() => addStatusMapping}
+//                         className='addNewStatusBtnDialog'
+//                         onSubmit={(e) => e.preventDefault()}
+//                       >
+//                         Add New
+//                       </Button>
+//                     </FormGroup>
+//                   </form>
+//                 </div>
+//               </Dialog>
 
-            </div>
+//             </div>
 
-            <div className='headlineContainer'>
-              <h3 className='headline'>Additional Customization Settings</h3>
-              <p className='description'>Additional Jira settings</p>
-            </div>
+//             <div className='headlineContainer'>
+//               <h3 className='headline'>Additional Customization Settings</h3>
+//               <p className='description'>Additional Jira settings</p>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jira-epic-key'
-                helperText='JIRA_ISSUE_EPIC_KEY_FIELD'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Label>
-                  Issue&nbsp;Epic&nbsp;Key&nbsp;Field
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jira-epic-key'
+//                 helperText='JIRA_ISSUE_EPIC_KEY_FIELD'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Label>
+//                   Issue&nbsp;Epic&nbsp;Key&nbsp;Field
 
-                  <div>
-                    <Tooltip content='Get help with Issue Epic Key Field' position={Position.TOP}>
-                      <a
-                        href='https://github.com/merico-dev/lake/tree/main/plugins/jira#set-jira-custom-fields'
-                        rel='noreferrer'
-                        target='_blank'
-                        className='helpIcon'
-                      >
-                        <Icon icon='help' size={15} />
-                      </a>
-                    </Tooltip>
-                  </div>
+//                   <div>
+//                     <Tooltip content='Get help with Issue Epic Key Field' position={Position.TOP}>
+//                       <a
+//                         href='https://github.com/merico-dev/lake/tree/main/plugins/jira#set-jira-custom-fields'
+//                         rel='noreferrer'
+//                         target='_blank'
+//                         className='helpIcon'
+//                       >
+//                         <Icon icon='help' size={15} />
+//                       </a>
+//                     </Tooltip>
+//                   </div>
 
-                  <Tooltip content='Your custom epic key field' position={Position.TOP}>
-                    <InputGroup
-                      id='jira-epic-key'
-                      placeholder='Enter Jira epic key field'
-                      defaultValue={jiraIssueEpicKeyField}
-                      onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
-                      className='helperInput'
-                    />
-                  </Tooltip>
-                </Label>
-              </FormGroup>
-            </div>
+//                   <Tooltip content='Your custom epic key field' position={Position.TOP}>
+//                     <InputGroup
+//                       id='jira-epic-key'
+//                       placeholder='Enter Jira epic key field'
+//                       defaultValue={jiraIssueEpicKeyField}
+//                       onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
+//                       className='helperInput'
+//                     />
+//                   </Tooltip>
+//                 </Label>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jira-storypoint-field'
-                helperText='JIRA_ISSUE_STORYPOINT_FIELD'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Tooltip content='Your custom story point key field' position={Position.TOP}>
-                  <Label>
-                    Issue&nbsp;Storypoint&nbsp;Field
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jira-storypoint-field'
+//                 helperText='JIRA_ISSUE_STORYPOINT_FIELD'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Tooltip content='Your custom story point key field' position={Position.TOP}>
+//                   <Label>
+//                     Issue&nbsp;Storypoint&nbsp;Field
 
-                    <div>
-                      <Tooltip content='Get help with Issue Story Point Field' position={Position.TOP}>
-                        <a
-                          href='https://github.com/merico-dev/lake/tree/main/plugins/jira#set-jira-custom-fields'
-                          target='_blank'
-                          className='helpIcon'
-                          rel='noreferrer'
-                        >
-                          <Icon icon='help' size={15} />
-                        </a>
-                      </Tooltip>
-                    </div>
-                    <InputGroup
-                      id='jira-storypoint-field'
-                      placeholder='Enter Jira Story Point Field'
-                      defaultValue={jiraIssueStoryPointField}
-                      onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
-                      className='input'
-                    />
-                  </Label>
-                </Tooltip>
-              </FormGroup>
-            </div>
+//                     <div>
+//                       <Tooltip content='Get help with Issue Story Point Field' position={Position.TOP}>
+//                         <a
+//                           href='https://github.com/merico-dev/lake/tree/main/plugins/jira#set-jira-custom-fields'
+//                           target='_blank'
+//                           className='helpIcon'
+//                           rel='noreferrer'
+//                         >
+//                           <Icon icon='help' size={15} />
+//                         </a>
+//                       </Tooltip>
+//                     </div>
+//                     <InputGroup
+//                       id='jira-storypoint-field'
+//                       placeholder='Enter Jira Story Point Field'
+//                       defaultValue={jiraIssueStoryPointField}
+//                       onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
+//                       className='input'
+//                     />
+//                   </Label>
+//                 </Tooltip>
+//               </FormGroup>
+//             </div>
 
-            <div className='formContainer'>
-              <FormGroup
-                inline={true}
-                labelFor='jira-storypoint-coef'
-                helperText='JIRA_ISSUE_STORYPOINT_COEFFICIENT'
-                className='formGroup'
-                contentClassName='formGroup'
-              >
-                <Tooltip content='Your custom story point coefficent (optional)' position={Position.TOP}>
-                  <Label>
-                    Issue&nbsp;Storypoint&nbsp;Coefficient <span className='requiredStar'>*</span>
-                    <InputGroup
-                      id='jira-storypoint-coef'
-                      placeholder='Enter Jira Story Point Coefficient'
-                      defaultValue={jiraIssueStoryCoefficient}
-                      onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
-                      className='input'
-                    />
-                  </Label>
-                </Tooltip>
-              </FormGroup>
-            </div>
+//             <div className='formContainer'>
+//               <FormGroup
+//                 inline={true}
+//                 labelFor='jira-storypoint-coef'
+//                 helperText='JIRA_ISSUE_STORYPOINT_COEFFICIENT'
+//                 className='formGroup'
+//                 contentClassName='formGroup'
+//               >
+//                 <Tooltip content='Your custom story point coefficent (optional)' position={Position.TOP}>
+//                   <Label>
+//                     Issue&nbsp;Storypoint&nbsp;Coefficient <span className='requiredStar'>*</span>
+//                     <InputGroup
+//                       id='jira-storypoint-coef'
+//                       placeholder='Enter Jira Story Point Coefficient'
+//                       defaultValue={jiraIssueStoryCoefficient}
+//                       onChange={(e) => setJiraIssueStoryCoefficient(e.target.value)}
+//                       className='input'
+//                     />
+//                   </Label>
+//                 </Tooltip>
+//               </FormGroup>
+//             </div>
 
-            <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
-            <Button
-              type='submit'
-              outlined={true}
-              large={true}
-              className='saveBtn'
-              onClick={(e) => saveAll(e)}
-            >
-              Save Config
-            </Button>
-          </form>
-        </main>
-      </Content>
-    </div>
-  )
-}
+//             <SaveAlert alertOpen={alertOpen} onClose={() => setAlertOpen(false)} />
+//             <Button
+//               type='submit'
+//               outlined={true}
+//               large={true}
+//               className='saveBtn'
+//               onClick={(e) => saveAll(e)}
+//             >
+//               Save Config
+//             </Button>
+//           </form>
+//         </main>
+//       </Content>
+//     </div>
+//   )
+// }

--- a/plugins/github/api/github_sources.go
+++ b/plugins/github/api/github_sources.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"github.com/merico-dev/lake/config"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/mitchellh/mapstructure"
+)
+
+type GithubConfig struct {
+	GITHUB_ENDPOINT string `mapstructure:"GITHUB_ENDPOINT"`
+	GITHUB_AUTH     string `mapstructure:"GITHUB_AUTH"`
+}
+
+// This object conforms to what the frontend currently sends.
+type GithubSource struct {
+	GITHUB_ENDPOINT string
+	GITHUB_AUTH     string
+}
+
+// This object conforms to what the frontend currently expects.
+type GithubResponse struct {
+	Endpoint string
+	Auth     string
+	Name     string
+	ID       int
+}
+
+/*
+PUT /plugins/github/sources/:sourceId
+*/
+func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	githubSource := GithubSource{}
+	err := mapstructure.Decode(input.Body, &githubSource)
+	if err != nil {
+		return nil, err
+	}
+	V := config.LoadConfigFile()
+	if githubSource.GITHUB_ENDPOINT != "" {
+		V.Set("GITHUB_ENDPOINT", githubSource.GITHUB_ENDPOINT)
+	}
+	if githubSource.GITHUB_AUTH != "" {
+		V.Set("GITHUB_AUTH", githubSource.GITHUB_AUTH)
+	}
+	err = V.WriteConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.ApiResourceOutput{Body: "Success"}, nil
+}
+
+/*
+GET /plugins/github/sources
+*/
+func ListSources(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	// RETURN ONLY 1 SOURCE (FROM ENV) until multi-source is developed.
+	githubSources, err := GetSourceFromEnv()
+	response := []GithubResponse{*githubSources}
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Body: response}, nil
+}
+
+/*
+GET /plugins/github/sources/:sourceId
+*/
+func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	//  RETURN ONLY 1 SOURCE FROM ENV (Ignore ID until multi-source is developed.)
+	githubSources, err := GetSourceFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return &core.ApiResourceOutput{Body: githubSources}, nil
+}
+
+func GetSourceFromEnv() (*GithubResponse, error) {
+	V := config.LoadConfigFile()
+	var configJson GithubConfig
+	err := V.Unmarshal(&configJson)
+	if err != nil {
+		return nil, err
+	}
+	return &GithubResponse{
+		Endpoint: configJson.GITHUB_ENDPOINT,
+		Auth:     configJson.GITHUB_AUTH,
+		Name:     "Github",
+		ID:       1,
+	}, nil
+}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -8,6 +8,7 @@ import (
 	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/logger" // A pseudo type for Plugin Interface implementation
 	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/github/api"
 	"github.com/merico-dev/lake/plugins/github/tasks"
 	"github.com/merico-dev/lake/utils"
 	"github.com/mitchellh/mapstructure"
@@ -121,7 +122,7 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> Enriching Issues")
 		enrichmentError := tasks.EnrichIssues()
 		if enrichmentError != nil {
-			return fmt.Errorf("Could not enrich issues: %v", enrichmentError)
+			return fmt.Errorf("could not enrich issues: %v", enrichmentError)
 		}
 
 	}
@@ -138,7 +139,16 @@ func (plugin Github) RootPkgPath() string {
 }
 
 func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandler {
-	return make(map[string]map[string]core.ApiResourceHandler)
+	return map[string]map[string]core.ApiResourceHandler{
+		"sources": {
+			"GET":  api.ListSources,
+			"POST": api.PutSource,
+		},
+		"sources/:sourceId": {
+			"GET": api.GetSource,
+			"PUT": api.PutSource,
+		},
+	}
 }
 
 // Export a variable named PluginEntry for Framework to search and load

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -157,7 +157,8 @@ func (plugin Gitlab) RootPkgPath() string {
 func (plugin Gitlab) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
 		"sources": {
-			"GET": api.ListSources,
+			"GET":  api.ListSources,
+			"POST": api.PutSource,
 		},
 		"sources/:sourceId": {
 			"GET": api.GetSource,


### PR DESCRIPTION
Fixes: 

TODO - 2.5. Github api routes in plugin layer for sources @Kevin @jon

This allows github to be fully hooked up in config ui.

Routes added:

```
func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandler {
	return map[string]map[string]core.ApiResourceHandler{
		"sources": {
			"GET":  api.ListSources,
			"POST": api.PutSource,
		},
		"sources/:sourceId": {
			"GET": api.GetSource,
			"PUT": api.PutSource,
		},
	}
}
```
![Screen Shot 2021-11-11 at 9 44 02 AM](https://user-images.githubusercontent.com/3011407/141308437-8de9d5c1-57a3-4fbd-a557-f9f656ff0388.png)

![Screen Shot 2021-11-11 at 9 44 47 AM](https://user-images.githubusercontent.com/3011407/141308539-12eb0df7-556a-4a56-bea7-b6736ae6c50f.png)


