### PR TITLE
feat: nginx api forwarding / grafana redirection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,8 @@ GITHUB_ENDPOINT=https://api.github.com/
 GITHUB_AUTH=***
 
 
-########################
+##########################
 # ConfigUI configuration #
-########################
-DEVLAKE_ENDPOINT=http://localhost:8080
-GRAFANA_ENDPOINT=http://localhost:3002/d/RXJZNpMnz/homepage?orgId=1
+##########################
+DEVLAKE_ENDPOINT=devlake:8080
+GRAFANA_ENDPOINT=http://localhost:3002

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Commonly, we have requirement to synchorize data periodly. We providered a tool 
 
 Otherwise, if you just want to use the cron job, please check `docker-compose` version at [here](./devops/sync/README.md)
 
+## Deploy to TeamCode
+1. **IMPORTANT: MAKE SURE config-ui service is protected on TeamCode Control Panel before you set it up, or your TOKEN/PASSWORD might leak**
+2. The following Environment Variables are to be set for `config-ui` service:
+```
+GRAFANA_ENDPOINT=<URL_TO_GRAFANA>
+```
 
 ## Developer Setup<a id="dev-setup"></a>
 

--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:latest
 RUN rm /etc/nginx/conf.d/default.conf
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf.tpl
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY ./dist/* ./
 EXPOSE 80 443
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+CMD envsubst '${DEVLAKE_ENDPOINT} ${GRAFANA_ENDPOINT}' < /etc/nginx/conf.d/default.conf.tpl > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'

--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -1,9 +1,21 @@
-server { 
- listen 80;
- server_name localhost;
- location / {
-   root /usr/share/nginx/html;
-   index index.html;
-   try_files $uri /index.html;
- }
+upstream devlake {
+    server ${DEVLAKE_ENDPOINT} fail_timeout=5s max_fails=5;
+}
+server {
+  listen 80;
+  server_name localhost;
+  location / {
+    root /usr/share/nginx/html;
+    index index.html;
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    rewrite /api/(.*) /$1  break;
+    proxy_pass http://devlake;
+  }
+
+  location /grafana {
+    rewrite /grafana(.*)$ ${GRAFANA_ENDPOINT}$1;
+  }
 }

--- a/config-ui/src/components/Sidebar.jsx
+++ b/config-ui/src/components/Sidebar.jsx
@@ -6,6 +6,7 @@ import {
 import { Button, Card, Elevation } from '@blueprintjs/core'
 import SidebarMenu from '@/components/Sidebar/SidebarMenu'
 import MenuConfiguration from '@/components/Sidebar/MenuConfiguration'
+import { GRAFANA_ENDPOINT } from '@/utils/config'
 
 import '@/styles/sidebar.scss'
 
@@ -21,7 +22,7 @@ const Sidebar = () => {
   return (
     <Card interactive={false} elevation={Elevation.ZERO} className='card sidebar-card'>
       <img src='/logo.svg' className='logo' />
-      <a href='http://localhost:3002' rel='noreferrer' target='_blank' className='dashboardBtnLink'>
+      <a href={GRAFANA_ENDPOINT} rel='noreferrer' target='_blank' className='dashboardBtnLink'>
         <Button icon='grouped-bar-chart' outlined={true} className='dashboardBtn'>View Dashboards</Button>
       </a>
 

--- a/config-ui/src/utils/config.js
+++ b/config-ui/src/utils/config.js
@@ -1,2 +1,2 @@
-export const DEVLAKE_ENDPOINT = process.env.DEVLAKE_ENDPOINT || '/api'
-export const GRAFANA_ENDPOINT = process.env.GRAFANA_ENDPOINT || '/grafana'
+export const DEVLAKE_ENDPOINT = '/api'
+export const GRAFANA_ENDPOINT = '/grafana/d/RXJZNpMnz/homepage?orgId=1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     depends_on:
       - mysql
   devlake:
-    image: mericodev/lake:0.3.0
+    image: mericodev/lake
     ports:
       - 127.0.0.1:8080:8080
     env_file:
@@ -41,13 +41,13 @@ services:
     depends_on:
       - grafana
   config-ui:
-    image: mericodev/config-ui:0.3.0
+    image: mericodev/config-ui
     ports:
-      - 127.0.0.1:4000:4000
+      - 127.0.0.1:4000:80
+    env_file:
+      - ./.env
     environment:
       - ENV_FILEPATH=/.env
-      - DEVLAKE_ENDPOINT=http://devlake:8080
-      - GRAFANA_PORT=3002/d/RXJZNpMnz/homepage?orgId=1
     volumes:
       - ./.env:/.env:rw
 volumes:


### PR DESCRIPTION
# Summary

Closes #708 
This PR make nginx proxies `/api` to $DEVLAKE_ENDPOINT and redirects `/grafana` to $GRAFANA_ENDPOINT which then can support Cloud deployment like TeamCode

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
