### PR TITLE
fix: standardize issue lead time to minutes

### DIFF
--- a/plugins/domainlayer/models/ticket/issue.go
+++ b/plugins/domainlayer/models/ticket/issue.go
@@ -31,5 +31,5 @@ type Issue struct {
 	CreatedDate              time.Time
 	UpdatedDate              time.Time
 	SpentMinutes             int64
-	LeadTime                 uint
+	LeadTimeMinutes          uint
 }

--- a/plugins/github-domain/tasks/issue_converter.go
+++ b/plugins/github-domain/tasks/issue_converter.go
@@ -37,7 +37,7 @@ func convertToIssueModel(issue *githubModels.GithubIssue) *ticket.Issue {
 		Priority:          issue.Priority,
 		Type:              issue.Type,
 		AssigneeOriginKey: issue.Assignee,
-		LeadTime:          issue.LeadTime,
+		LeadTimeMinutes:   issue.LeadTimeMinutes,
 		CreatedDate:       issue.GithubCreatedAt,
 		UpdatedDate:       issue.GithubUpdatedAt,
 		ResolutionDate:    issue.ClosedAt,

--- a/plugins/github/models/github_issue.go
+++ b/plugins/github/models/github_issue.go
@@ -16,7 +16,7 @@ type GithubIssue struct {
 	Priority        string
 	Type            string
 	Assignee        string
-	LeadTime        uint
+	LeadTimeMinutes uint
 	ClosedAt        sql.NullTime
 	GithubCreatedAt time.Time
 	GithubUpdatedAt time.Time

--- a/plugins/github/tasks/github_issues_collector.go
+++ b/plugins/github/tasks/github_issues_collector.go
@@ -88,7 +88,7 @@ func convertGithubIssue(issue *IssuesResponse) (*models.GithubIssue, error) {
 	}
 
 	if issue.ClosedAt.ToSqlNullTime().Valid {
-		githubIssue.LeadTime = uint(issue.ClosedAt.ToTime().Sub(issue.GithubCreatedAt.ToTime()).Seconds())
+		githubIssue.LeadTimeMinutes = uint(issue.ClosedAt.ToTime().Sub(issue.GithubCreatedAt.ToTime()).Minutes())
 	}
 
 	return githubIssue, nil

--- a/plugins/jira/models/jira_issue.go
+++ b/plugins/jira/models/jira_issue.go
@@ -48,11 +48,11 @@ type JiraIssue struct {
 	// DevelopmentLeadTime         uint
 	// TestLeadTime                uint
 	// DeliveryLeadTime            uint
-	SpentMinutes  int64
-	LeadTime      uint
-	StdStoryPoint uint
-	StdType       string
-	StdStatus     string
+	SpentMinutes    int64
+	LeadTimeMinutes uint
+	StdStoryPoint   uint
+	StdType         string
+	StdStatus       string
 
 	// internal status tracking
 	ChangelogUpdated sql.NullTime

--- a/plugins/jira/tasks/jira_issue_enricher.go
+++ b/plugins/jira/tasks/jira_issue_enricher.go
@@ -67,7 +67,7 @@ func EnrichIssues(source *models.JiraSource, boardId uint64) (err error) {
 			return err
 		}
 		if jiraIssue.ResolutionDate.Valid {
-			jiraIssue.LeadTime = uint(jiraIssue.ResolutionDate.Time.Unix()-jiraIssue.Created.Unix()) / 60
+			jiraIssue.LeadTimeMinutes = uint(jiraIssue.ResolutionDate.Time.Unix()-jiraIssue.Created.Unix()) / 60
 		}
 		jiraIssue.StdStoryPoint = uint(jiraIssue.StoryPoint * source.StoryPointCoefficient)
 		jiraIssue.StdType = getStdType(jiraIssue.Type)

--- a/plugins/jiradomain/tasks/issue_converter.go
+++ b/plugins/jiradomain/tasks/issue_converter.go
@@ -54,7 +54,7 @@ func ConvertIssues(sourceId uint64, boardId uint64) error {
 			Priority:                 jiraIssue.PriorityName,
 			CreatedDate:              jiraIssue.Created,
 			UpdatedDate:              jiraIssue.Updated,
-			LeadTime:                 jiraIssue.LeadTime,
+			LeadTimeMinutes:          jiraIssue.LeadTimeMinutes,
 			SpentMinutes:             jiraIssue.SpentMinutes,
 		}
 		if jiraIssue.AssigneeAccountId != "" {


### PR DESCRIPTION
### Description
This PR names the Domain Layer Issue Lead Time to LeadTImeMinutes. It also renames the Jira Issue LeadTime to LeadTimeMinutes (as is accurate). Thirdly, it changes the GitHub conversion from seconds to minutes to conform to this standard.

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/733
