### PR TITLE
fix: update grafana charts

### DIFF
--- a/grafana/dashboards/HowFastDoWeRespondToCustomerRequirements.json
+++ b/grafana/dashboards/HowFastDoWeRespondToCustomerRequirements.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 34,
+  "id": 11,
   "links": [
     {
       "asDropdown": false,
@@ -108,7 +108,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "with _requirements as(\n  select \n    DATE_ADD(date(resolution_date), INTERVAL -DAY(date(resolution_date))+1 DAY) as time,\n    avg(lead_time)/1440 as lead_time\n  from issues i\n  where \n    type = 'Requirement'\n    and $__timeFilter(resolution_date)\n  group by time\n)\n\nselect\n  date_format(time,'%M %Y') as month,\n  lead_time as 'Average Requirement Lead Time (day)'\nfrom _requirements\norder by time asc",
+          "rawSql": "with _requirements as(\n  select \n    DATE_ADD(date(resolution_date), INTERVAL -DAY(date(resolution_date))+1 DAY) as time,\n    avg(lead_time_minutes)/1440 as lead_time_days\n  from issues i\n  where \n    type = 'Requirement'\n    and $__timeFilter(resolution_date)\n  group by time\n)\n\nselect\n  date_format(time,'%M %Y') as month,\n  lead_time_days as 'Average Requirement Lead Time (day)'\nfrom _requirements\norder by time asc",
           "refId": "A",
           "select": [
             [
@@ -197,5 +197,5 @@
   "timezone": "",
   "title": "How fast do we respond to customer requirements?",
   "uid": "SupYz7c7z",
-  "version": 36
+  "version": 2
 }

--- a/grafana/dashboards/IsThisMonthMoreProductiveThanLast.json
+++ b/grafana/dashboards/IsThisMonthMoreProductiveThanLast.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 36,
-  "iteration": 1636652519256,
+  "id": 14,
+  "iteration": 1636742090003,
   "links": [
     {
       "asDropdown": false,
@@ -257,5 +257,5 @@
   "timezone": "",
   "title": "Is this month more productive than last?",
   "uid": "ddREk75nk",
-  "version": 15
+  "version": 1
 }

--- a/grafana/dashboards/WasOurQualityImprovedOrNot.json
+++ b/grafana/dashboards/WasOurQualityImprovedOrNot.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 37,
+  "id": 12,
   "links": [
     {
       "asDropdown": false,
@@ -194,5 +194,5 @@
   "timezone": "",
   "title": "Was our quality improved or not?",
   "uid": "G4DEk75nz",
-  "version": 20
+  "version": 1
 }


### PR DESCRIPTION

### Description
Updates grafana charts for Jira...mainly fixes "How fast do we respond to customer requirements?" to pull lead_time_minutes instead of lead_time (which is deprecated)
