### PR TITLE
feat: config-ui supports set GITHUB_PROXY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ install:
 test: unit-test e2e-test
 
 unit-test: build
-	ENV_FILE=`pwd`/.env go test -v $$(go list ./... | grep -v /test/)
+	go test -v $$(go list ./... | grep -v /test/)
 
 e2e-test: build
-	ENV_FILE=`pwd`/.env go test -v ./test/...
+	PLUGIN_DIR=$(shell readlink -f bin/plugins) go test -v ./test/...
 
 lint:
 	golangci-lint run

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -3,6 +3,11 @@ import {
   useParams,
   useHistory
 } from 'react-router-dom'
+import {
+  FormGroup,
+  InputGroup,
+  Label,
+} from '@blueprintjs/core'
 
 import '@/styles/integration.scss'
 import '@/styles/connections.scss'
@@ -11,6 +16,7 @@ export default function GithubSettings (props) {
   const { connection, provider, isSaving, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
+  const [githubProxy, setGithubProxy] = useState(null)
 
   const [errors, setErrors] = useState([])
 
@@ -30,16 +36,45 @@ export default function GithubSettings (props) {
     })
   }, [errors, onSettingsChange, connectionId, providerId])
 
+  useEffect(() => {
+    setGithubProxy(connection.proxy)
+  }, [connection])
+
+  useEffect(() => {
+    const settings = {
+      GITHUB_PROXY: githubProxy
+    }
+    console.log('>> GITHUB INSTANCE SETTINGS FIELDS CHANGED!', settings)
+    onSettingsChange(settings)
+  }, [
+    githubProxy,
+    onSettingsChange
+  ])
+
   return (
     <>
-      <div className='headlineContainer'>
-        <h3 className='headline'>No Additional Settings</h3>
-        <p className='description'>
-          This integration doesn’t require any configuration.
-          You can continue to&nbsp;
-          <a href='#' style={{ textDecoration: 'underline' }} onClick={cancel}>add other data sources</a>&nbsp;
-          or trigger collection at the <a href='#' style={{ textDecoration: 'underline' }} onClick={cancel}>previous page</a>.
-        </p>
+      <h3 className='headline'>Github Proxy</h3>
+      <p className=''>Optional</p>
+      <div className='formContainer'>
+        <FormGroup
+          disabled={isSaving}
+          labelFor='github-proxy'
+          helperText='GITHUB_PROXY'
+          className='formGroup'
+          contentClassName='formGroupContent'
+        >
+          <Label>
+            Proxy URL
+          </Label>
+          <InputGroup
+            id='github-proxy'
+            placeholder='http://your-proxy-server.com:1080'
+            defaultValue={githubProxy}
+            onChange={(e) => setGithubProxy(e.target.value)}
+            disabled={isSaving}
+            className='input'
+          />
+        </FormGroup>
       </div>
     </>
   )

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ func LoadConfigFile() *viper.Viper {
 func init() {
 	V := LoadConfigFile()
 	V.SetDefault("PORT", ":8080")
+	V.SetDefault("PLUGIN_DIR", "bin/plugins")
 	// This line is essential for reading and writing
 	V.WatchConfig()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,6 @@ func init() {
 }
 
 func GetConfigJson() (*Config, error) {
-	V := LoadConfigFile()
 	var configJson Config
 	err := V.Unmarshal(&configJson)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,6 @@
 package config
 
 import (
-	"os"
-	"path"
-
 	"github.com/spf13/viper"
 )
 
@@ -35,35 +32,7 @@ var V *viper.Viper
 
 func LoadConfigFile() *viper.Viper {
 	V = viper.New()
-	configFile := os.Getenv("ENV_FILE")
-	if configFile != "" {
-		if !path.IsAbs(configFile) {
-			panic("Please set ENV_FILE with absolute path. " +
-				"Currently it should only be used for go test to load ENVs.")
-		}
-		V.SetConfigFile(configFile)
-		V.Set("WORKING_DIRECTORY", path.Dir(configFile))
-	} else {
-		V.SetConfigName(".env")
-		V.SetConfigType("env")
-
-		V.AddConfigPath(".")
-		// For testing in subdirectories 1 level down (ex. ./config)
-		V.AddConfigPath("../")
-		V.AddConfigPath("conf")
-		V.AddConfigPath("etc")
-
-		execPath, execErr := os.Executable()
-		if execErr == nil {
-			V.AddConfigPath(path.Dir(execPath))
-			V.AddConfigPath(path.Join(path.Dir(execPath), "conf"))
-			V.AddConfigPath(path.Join(path.Dir(execPath), "etc"))
-		}
-
-		wdPath, _ := os.Getwd()
-		V.Set("WORKING_DIRECTORY", wdPath)
-	}
-
+	V.SetConfigFile(".env")
 	_ = V.ReadInConfig()
 	V.AutomaticEnv()
 	return V

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,9 @@ services:
     image: mericodev/lake
     ports:
       - 127.0.0.1:8080:8080
-    env_file:
-      - ./.env
     restart: always
+    volumes:
+      - ./.env:/app/.env
     depends_on:
       - grafana
   config-ui:
@@ -46,10 +46,6 @@ services:
       - 127.0.0.1:4000:80
     env_file:
       - ./.env
-    environment:
-      - ENV_FILEPATH=/.env
-    volumes:
-      - ./.env:/.env:rw
 volumes:
   mysql-storage:
   grafana-storage:

--- a/plugins/github/api/github_sources.go
+++ b/plugins/github/api/github_sources.go
@@ -9,12 +9,14 @@ import (
 type GithubConfig struct {
 	GITHUB_ENDPOINT string `mapstructure:"GITHUB_ENDPOINT"`
 	GITHUB_AUTH     string `mapstructure:"GITHUB_AUTH"`
+	GITHUB_PROXY    string `mapstructure:"GITHUB_PROXY"`
 }
 
 // This object conforms to what the frontend currently sends.
 type GithubSource struct {
 	GITHUB_ENDPOINT string
 	GITHUB_AUTH     string
+	GITHUB_PROXY    string
 }
 
 // This object conforms to what the frontend currently expects.
@@ -23,6 +25,7 @@ type GithubResponse struct {
 	Auth     string
 	Name     string
 	ID       int
+	Proxy    string `json:"proxy"`
 }
 
 /*
@@ -41,6 +44,7 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if githubSource.GITHUB_AUTH != "" {
 		V.Set("GITHUB_AUTH", githubSource.GITHUB_AUTH)
 	}
+	V.Set("GITHUB_PROXY", githubSource.GITHUB_PROXY)
 	err = V.WriteConfig()
 	if err != nil {
 		return nil, err
@@ -86,5 +90,6 @@ func GetSourceFromEnv() (*GithubResponse, error) {
 		Auth:     configJson.GITHUB_AUTH,
 		Name:     "Github",
 		ID:       1,
+		Proxy:    configJson.GITHUB_PROXY,
 	}, nil
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"path"
 	"path/filepath"
 	"plugin"
 	"strings"
@@ -60,9 +59,5 @@ func RunPlugin(name string, options map[string]interface{}, progress chan<- floa
 
 func PluginDir() string {
 	pluginDir := config.V.GetString("PLUGIN_DIR")
-	if !path.IsAbs(pluginDir) {
-		wd := config.V.GetString("WORKING_DIRECTORY")
-		pluginDir = filepath.Join(wd, pluginDir)
-	}
 	return pluginDir
 }

--- a/test/plugins/plugins_test.go
+++ b/test/plugins/plugins_test.go
@@ -1,12 +1,8 @@
 package plugins
 
 import (
-	"path"
-	"strings"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
-	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/plugins"
 	"github.com/merico-dev/lake/plugins/core"
 )
@@ -37,10 +33,4 @@ func TestPluginsLoading(t *testing.T) {
 	// 	t.Error(err)
 	// }
 
-}
-
-func TestPluginDir(t *testing.T) {
-	pluginDir := plugins.PluginDir()
-	assert.Equal(t, path.IsAbs(pluginDir), true)
-	assert.Equal(t, strings.HasSuffix(pluginDir, config.V.GetString("PLUGIN_DIR")), true)
 }


### PR DESCRIPTION
# Summary

This is a must in mainland china

Also fix the .env file not found error from TeamCode deployment

1. `devalke` service ditch `env_file` altogether, since it's the highest priority in `viper`, thus, even thoug settings  got saved into `.env` file, when reopen `config-ui`, all settings on page went back to old values, unless we restart devlake
2. removed unused settings of `config-ui` service to avoid confusion
3. simplify configuration loading logic

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

