### PR TITLE
fix: update grafana link to demo-homepage

### DIFF
--- a/config-ui/config.js
+++ b/config-ui/config.js
@@ -1,6 +1,6 @@
 const someJson = {
   DEVLAKE_ENDPOINT: '/api',
-  GRAFANA_ENDPOINT: '/grafana/d/RXJZNpMnz/homepage?orgId=1'
+  GRAFANA_ENDPOINT: '/grafana/d/0Rjxknc7z/demo-homepage?orgId=1'
 }
 
 export default someJson


### PR DESCRIPTION
# Summary

Update grafana link to `Demo Homepage` dashboard

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
before:
![vs7NZpWpJz](https://user-images.githubusercontent.com/61080/141750757-3078a6a7-d4a0-491d-a91c-9a66d5d43ec1.png)
after:
![6C3xtvz5c0](https://user-images.githubusercontent.com/61080/141750778-9d453da8-a40e-46f4-a103-9981e57f1996.png)

