### PR TITLE
fix: #771 use compressed format ipv6 loopback address

### DIFF
--- a/config-ui/webpack.config.js
+++ b/config-ui/webpack.config.js
@@ -118,7 +118,7 @@ module.exports = (env = {}) => {
       host: '0.0.0.0',
       historyApiFallback: true,
       proxy: {
-        '/api/': { target: 'http://localhost:8080', pathRewrite: { '^/api': '' }, changeOrigin: true },
+        '/api': { target: 'http://[::1]:8080', pathRewrite: { '^/api': '' }, changeOrigin: true },
         // this should be a redirection instead of proxy
         '/grafana': { target: 'http://localhost:3002', pathRewrite: { '^/grafana': '' }, changeOrigin: true }
       }


### PR DESCRIPTION
 

### Config-UI / Webpack / devServer Proxy

- [x] fix: use compressed format ipv6 loopback address


### Description
Update the `devServer` Configuration for Webpack and change the `localhost` reference to compressed format `[::1]`

### Does this close any open issues?
#771

### Current Behavior
When pulling `main` branch OSX users are unable to fetch data from `/api` because the devServer proxy fails to work as configured resulting in network 404s.

### New Behavior
Using the compressed format for localhost this should be more compatible with more environments including OSX so developers don't have to apply a patch to the configuration in order to reach `DEVLAKE_ENDPOINT` 
