### PR TITLE
fix: #619 Config-UI - Setup Delete Connection UX Workflow

### DIFF
--- a/config-ui/src/components/actions/DeleteAction.jsx
+++ b/config-ui/src/components/actions/DeleteAction.jsx
@@ -1,0 +1,87 @@
+import React, { Fragment } from 'react'
+import {
+  Button, Card, Elevation, Colors,
+  Spinner,
+  Tooltip,
+  Position,
+  Icon,
+  Intent,
+  Popover,
+  Popover2,
+  Classes
+} from '@blueprintjs/core'
+
+const DeleteAction = (props) => {
+  const {
+    id, connection, showConfirmation = () => {}, onConfirm = () => {}, onCancel = () => {},
+    isDisabled = false,
+    isLoading = false,
+    text = 'Delete',
+    children
+  } = props
+  return (
+    <Popover
+      key={`delete-popover-key-${connection.ID}`}
+      className='trigger-delete-connection'
+      popoverClassName='popover-delete-connection'
+      position={Position.RIGHT}
+      autoFocus={false}
+      enforceFocus={false}
+      isOpen={id === connection.ID}
+      usePortal={false}
+    >
+      <a
+        href='#'
+        intent={Intent.DANGER}
+        data-provider={connection.id}
+        className='table-action-link actions-link'
+        onClick={showConfirmation}
+        style={{ color: '#DB3737' }}
+      >
+        <Icon icon='trash' color={Colors.RED3} size={12} />
+        Delete
+      </a>
+      <>
+        <div style={{ padding: '15px 20px 15px 15px' }}>
+          {children}
+          {/* <h3 style={{ color: 'rgb(219, 55, 55)' }}>DELETE CONFIRMATION</h3>
+          <p className='confirmation-text'>
+            <strong style={{
+              fontFamily: 'Montserrat, sans-serif',
+              fontSize: '14px',
+              fontWeight: '800',
+              color: 'rgb(219, 55, 55)'
+            }}
+            >
+              Are you sure you want to continue?
+            </strong>
+            &nbsp;This instance will be permanently deleted and cannot be restored.
+          </p> */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 15 }}>
+            <Button
+              className={Classes.POPOVER2_DISMISS}
+              style={{ marginRight: 10 }}
+              disabled={isDisabled || isLoading}
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={isDisabled}
+              loading={isLoading}
+              onClick={(e) => onConfirm(connection, e)}
+              intent={Intent.DANGER}
+              icon='remove'
+              className={Classes.POPOVER2_DISMISS}
+              style={{ fontWeight: 'bold' }}
+            >
+              {text}
+            </Button>
+          </div>
+        </div>
+      </>
+    </Popover>
+  )
+}
+
+export default DeleteAction

--- a/config-ui/src/components/actions/DeleteConfirmationMessage.jsx
+++ b/config-ui/src/components/actions/DeleteConfirmationMessage.jsx
@@ -1,0 +1,18 @@
+import React, { Fragment } from 'react'
+
+const DeleteConfirmationMessage = (props) => {
+  const { title = 'DELETE CONFIRMATION' } = props
+  return (
+    <>
+      <h3>{title}</h3>
+      <p className='confirmation-text'>
+        <strong>
+          Are you sure you want to continue?
+        </strong>
+        &nbsp;This instance will be permanently deleted and cannot be restored.
+      </p>
+    </>
+  )
+}
+
+export default DeleteConfirmationMessage

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -48,6 +48,7 @@ function useConnectionManager ({
   const [connectionLimitReached, setConnectionLimitReached] = useState(false)
 
   const [saveComplete, setSaveComplete] = useState(false)
+  const [deleteComplete, setDeleteComplete] = useState(false)
 
   const testConnection = () => {
     setIsTesting(true)
@@ -248,20 +249,25 @@ function useConnectionManager ({
     }
   }, [activeProvider.id, sourceLimits])
 
-  const deleteConnection = () => {
-    // @todo Implement DELETE
+  const deleteConnection = useCallback(async (connection) => {
     try {
       setIsDeleting(true)
       setErrors([])
-      console.log('>> TRYING TO DELETE CONNECTION...', isDeleting)
-      // const d = await request.delete(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${connectionId}`)
-      // setIsDeleting(false)
+      console.log('>> TRYING TO DELETE CONNECTION...', connection)
+      const d = await request.delete(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${connection.ID}`)
+      console.log('>> CONNECTION DELETED...', d)
+      setIsDeleting(false)
+      setDeleteComplete({
+        provider: activeProvider,
+        connection: d.data
+      })
     } catch (e) {
       setIsDeleting(false)
+      setDeleteComplete(false)
       setErrors([e.message])
       console.log('>> FAILED TO DELETE CONNECTION', e)
     }
-  }
+  }, [activeProvider.id])
 
   useEffect(() => {
     if (activeConnection && activeConnection.ID !== null) {
@@ -350,7 +356,8 @@ function useConnectionManager ({
     connectionCount,
     connectionLimitReached,
     Providers,
-    saveComplete
+    saveComplete,
+    deleteComplete
   }
 }
 

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -19,6 +19,7 @@ import useConnectionManager from '@/hooks/useConnectionManager'
 import useSettingsManager from '@/hooks/useSettingsManager'
 import ConnectionForm from '@/pages/configure/connections/ConnectionForm'
 import DeleteAction from '@/components/actions/DeleteAction'
+import DeleteConfirmationMessage from '@/components/actions/DeleteConfirmationMessage'
 
 import { integrationsData } from '@/data/integrations'
 // import { NullConnection } from '@/data/NullConnection'
@@ -171,18 +172,22 @@ export default function ConfigureConnection () {
                     <h1 style={{ margin: 0 }}>
                       Manage <strong style={{ fontWeight: 900 }}>{activeProvider.name}</strong> Settings
                     </h1>
-                    <div style={{ paddingTop: '5px' }}>
-                      <DeleteAction
-                        id={deleteId}
-                        connection={activeConnection}
-                        text='Delete'
-                        showConfirmation={() => setDeleteId(activeConnection.ID)}
-                        onConfirm={deleteConnection}
-                        onCancel={(e) => setDeleteId(null)}
-                        isDisabled={isDeletingConnection}
-                        isLoading={isDeletingConnection}
-                      />
-                    </div>
+                    {activeProvider.multiSource && (
+                      <div style={{ paddingTop: '5px' }}>
+                        <DeleteAction
+                          id={deleteId}
+                          connection={activeConnection}
+                          text='Delete'
+                          showConfirmation={() => setDeleteId(activeConnection.ID)}
+                          onConfirm={deleteConnection}
+                          onCancel={(e) => setDeleteId(null)}
+                          isDisabled={isDeletingConnection}
+                          isLoading={isDeletingConnection}
+                        >
+                          <DeleteConfirmationMessage title={`DELETE "${activeConnection.name}"`} />
+                        </DeleteAction>
+                      </div>
+                    )}
                   </div>
                   {activeConnection && (
                     <>

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -18,6 +18,7 @@ import Content from '@/components/Content'
 import useConnectionManager from '@/hooks/useConnectionManager'
 import useSettingsManager from '@/hooks/useSettingsManager'
 import ConnectionForm from '@/pages/configure/connections/ConnectionForm'
+import DeleteAction from '@/components/actions/DeleteAction'
 
 import { integrationsData } from '@/data/integrations'
 // import { NullConnection } from '@/data/NullConnection'
@@ -42,6 +43,7 @@ export default function ConfigureConnection () {
   // const [activeConnection, setActiveConnection] = useState(NullConnection)
   const [connections, setConnections] = useState([])
   const [showConnectionSettings, setShowConnectionSettings] = useState(true)
+  const [deleteId, setDeleteId] = useState(false)
 
   const [settings, setSettings] = useState(NullSettings)
 
@@ -65,12 +67,13 @@ export default function ConfigureConnection () {
     setPassword,
     setToken,
     saveComplete: saveConnectionComplete,
-    showError: showConnectionError
+    showError: showConnectionError,
+    isDeleting: isDeletingConnection,
+    deleteConnection,
+    deleteComplete
   } = useConnectionManager({
     activeProvider,
-    // activeConnection,
     connectionId,
-    // setActiveConnection,
   }, true)
 
   const {
@@ -89,7 +92,7 @@ export default function ConfigureConnection () {
     history.push(`/integrations/${activeProvider.id}`)
   }
 
-  const renderProviderSettings = (providerId, activeProvider) => {
+  const renderProviderSettings = useCallback((providerId, activeProvider) => {
     console.log('>>> RENDERING PROVIDER SETTINGS...')
     let settingsComponent = null
     if (activeProvider && activeProvider.settings) {
@@ -104,7 +107,7 @@ export default function ConfigureConnection () {
       console.log('>> WARNING: NO PROVIDER SETTINGS RENDERED, PROVIDER = ', activeProvider)
     }
     return settingsComponent
-  }
+  }, [activeConnection, isSaving])
 
   useEffect(() => {
     console.log('>>>> DETECTED PROVIDER ID = ', providerId)
@@ -123,6 +126,13 @@ export default function ConfigureConnection () {
   useEffect(() => {
 
   }, [connections])
+
+  useEffect(() => {
+    if (deleteComplete) {
+      console.log('>>> DELETE COMPLETE!')
+      history.replace(`/integrations/${deleteComplete.provider?.id}`)
+    }
+  }, [deleteComplete, history])
 
   // useEffect(() => {
   //   // CONNECTION SAVED!
@@ -157,7 +167,23 @@ export default function ConfigureConnection () {
                   <span style={{ marginRight: '10px' }}>{activeProvider.icon}</span>
                 </div>
                 <div style={{ justifyContent: 'flex-start' }}>
-                  <h1 style={{ margin: 0 }}>Manage <strong style={{ fontWeight: 900 }}>{activeProvider.name}</strong> Settings </h1>
+                  <div style={{ display: 'flex' }}>
+                    <h1 style={{ margin: 0 }}>
+                      Manage <strong style={{ fontWeight: 900 }}>{activeProvider.name}</strong> Settings
+                    </h1>
+                    <div style={{ paddingTop: '5px' }}>
+                      <DeleteAction
+                        id={deleteId}
+                        connection={activeConnection}
+                        text='Delete'
+                        showConfirmation={() => setDeleteId(activeConnection.ID)}
+                        onConfirm={deleteConnection}
+                        onCancel={(e) => setDeleteId(null)}
+                        isDisabled={isDeletingConnection}
+                        isLoading={isDeletingConnection}
+                      />
+                    </div>
+                  </div>
                   {activeConnection && (
                     <>
                       <h2 style={{ margin: 0 }}>{activeConnection.name}</h2>

--- a/config-ui/src/pages/configure/integration/index.jsx
+++ b/config-ui/src/pages/configure/integration/index.jsx
@@ -49,7 +49,7 @@ export default function Integration () {
             <AppCrumbs
               items={[
                 { href: '/', icon: false, text: 'Dashboard' },
-                { href: '/integrations', icon: false, text: 'Integrations', current: true}
+                { href: '/integrations', icon: false, text: 'Integrations', current: true }
               ]}
             />
             <div className='headlineContainer'>

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -22,6 +22,7 @@ import useConnectionManager from '@/hooks/useConnectionManager'
 
 import { integrationsData } from '@/data/integrations'
 import DeleteAction from '@/components/actions/DeleteAction'
+import DeleteConfirmationMessage from '@/components/actions/DeleteConfirmationMessage'
 
 import '@/styles/integration.scss'
 
@@ -318,13 +319,7 @@ export default function ManageIntegration () {
                                   isDisabled={isRunningDelete || isDeletingConnection}
                                   isLoading={isRunningDelete || isDeletingConnection}
                                 >
-                                  <h3 style={{ color: 'rgb(219, 55, 55)' }}>DELETE CONFIRMATION</h3>
-                                  <p className='confirmation-text'>
-                                    <strong>
-                                      Are you sure you want to continue?
-                                    </strong>
-                                    &nbsp;This instance will be permanently deleted and cannot be restored.
-                                  </p>
+                                  <DeleteConfirmationMessage title={`DELETE "${connection.name}"`} />
                                 </DeleteAction>
                               )}
                               {/* <a

--- a/config-ui/src/styles/connections.scss
+++ b/config-ui/src/styles/connections.scss
@@ -129,11 +129,17 @@
   }
 
   .popover-delete-connection {
-    max-width: 250px;
+    max-width: 280px;
     white-space: normal;
+    overflow: hidden;
 
     h3 {
-      margin: 0 0 10px 0;
+      margin: 0 0 8px 0;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: rgba(219, 55, 55, 0.9);
+      font-size: 17px;
     }
 
     .bp3-popover-content {

--- a/config-ui/src/styles/connections.scss
+++ b/config-ui/src/styles/connections.scss
@@ -124,11 +124,40 @@
 }
 
 .bp3-popover-wrapper {
-  &.popover-generate-token {
+  &.popover-generate-token, &.popover-delete-connection, &.trigger-delete-connection {
     width: auto;
+  }
+
+  .popover-delete-connection {
+    max-width: 250px;
+    white-space: normal;
+
+    h3 {
+      margin: 0 0 10px 0;
+    }
+
+    .bp3-popover-content {
+      white-space: normal;
+    }
+  }
+
+  &.trigger-delete-connection {
+    .bp3-popover-target {
+      width: auto;
+    }
   }
 }
 
 .app-error-card.bp3-elevation-0 {
   box-shadow: none;
+}
+
+.confirmation-text {
+
+  strong {
+    font-family: "Montserrat", sans-serif;
+    font-size: 14px;
+    font-weight: 800;
+    color: rgb(219, 55, 55);
+  }
 }

--- a/config-ui/src/utils/request.js
+++ b/config-ui/src/utils/request.js
@@ -28,5 +28,14 @@ export default {
         headers
       }
     )
+  },
+  delete: async (url, body) => {
+    return await axios.delete(
+      url,
+      body,
+      {
+        headers
+      }
+    )
   }
 }


### PR DESCRIPTION
# Config-UI / Integrations / JIRA (Multi-source) / **DELETE**

### Key Points

- [x] Enable **DELETE** UX for _multi-source_ Providers such as **JIRA**
- [x] Add Delete Trigger to **Provider Connections List** View
- [x] Add Delete Trigger to **Configure Connection** View
- [x] Disable (hide) delete for single-source connections

### Description
This PR adds support for deleting connections for providers that are flagged as "Multi-source", primarily **JIRA** at this moment. Single-source providers such as GitHub and Jenkins are unaffected by this change.

### Does this close any open issues?
#619

### Current Behavior
Users can add multiple connections for **JIRA** but are unable to remove them.

### New Behavior
Users are able to **DELETE** a connection added to a multi-source provider such as **JIRA**.

### Screenshots
<img width="1110" alt="Screen Shot 2021-11-17 at 5 58 49 PM" src="https://user-images.githubusercontent.com/1742233/142297767-964f8d48-f1a3-475c-8320-639f8fa88c65.png">
<img width="1111" alt="Screen Shot 2021-11-17 at 5 58 56 PM" src="https://user-images.githubusercontent.com/1742233/142297765-d8bd903e-68d2-4ae7-bb66-cfdf54ac1273.png">
<img width="1161" alt="Screen Shot 2021-11-17 at 5 59 15 PM" src="https://user-images.githubusercontent.com/1742233/142297761-d87ffc43-e617-43f0-abf7-f79470d8bc38.png">
