### PR TITLE
Refactor: remove type assertion from jira issue collector

### DIFF
--- a/plugins/core/iso8601time.go
+++ b/plugins/core/iso8601time.go
@@ -3,9 +3,12 @@ package core
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 /*
@@ -95,4 +98,55 @@ func ConvertStringToTime(timeString string) (t time.Time, err error) {
 	}
 	t, err = time.Parse(time.RFC3339, timeString)
 	return
+}
+
+func Iso8601TimeToTime(iso8601Time *Iso8601Time) *time.Time {
+	if iso8601Time == nil {
+		return nil
+	}
+	t := iso8601Time.ToTime()
+	return &t
+}
+
+// mapstructure.Decode with time.Time and Iso8601Time support
+func DecodeMapStruct(input map[string]interface{}, result interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Metadata: nil,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+				if t != reflect.TypeOf(Iso8601Time{}) && t != reflect.TypeOf(time.Time{}) {
+					return data, nil
+				}
+
+				var tt time.Time
+				var err error
+
+				switch f.Kind() {
+				case reflect.String:
+					tt, err = ConvertStringToTime(data.(string))
+				case reflect.Float64:
+					tt = time.Unix(0, int64(data.(float64))*int64(time.Millisecond))
+				case reflect.Int64:
+					tt = time.Unix(0, data.(int64)*int64(time.Millisecond))
+				}
+				if err != nil {
+					return data, nil
+				}
+
+				if t == reflect.TypeOf(Iso8601Time{}) {
+					return Iso8601Time{time: tt}, nil
+				}
+				return tt, nil
+			},
+		),
+		Result: result,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		return err
+	}
+	return err
 }

--- a/plugins/core/iso8601time_test.go
+++ b/plugins/core/iso8601time_test.go
@@ -13,6 +13,14 @@ type Iso8601TimeRecord struct {
 	Created Iso8601Time
 }
 
+type Iso8601TimeRecordP struct {
+	Created *Iso8601Time
+}
+
+type TimeRecord struct {
+	Created time.Time
+}
+
 func TimeMustParse(text string) time.Time {
 	t, err := time.Parse(time.RFC3339, text)
 	if err != nil {
@@ -37,6 +45,7 @@ func TestToSqlNullTime(t *testing.T) {
 	assert.Equal(t, expected.Time.Day(), actual.Time.Day())
 	assert.Equal(t, expected.Valid, actual.Valid)
 }
+
 func TestToSqlNullTime_EmptyString(t *testing.T) {
 	input := `{ "Created": "" }`
 	var record Iso8601TimeRecord
@@ -52,6 +61,7 @@ func TestToSqlNullTime_EmptyString(t *testing.T) {
 	assert.Equal(t, expected.Time.Day(), actual.Time.Day())
 	assert.Equal(t, expected.Valid, record.Created.ToSqlNullTime().Valid)
 }
+
 func TestIso8601Time(t *testing.T) {
 	pairs := map[string]time.Time{
 		`{ "Created": "2021-07-30T19:14:33Z" }`:          TimeMustParse("2021-07-30T19:14:33Z"),
@@ -66,5 +76,24 @@ func TestIso8601Time(t *testing.T) {
 		err := json.Unmarshal([]byte(input), &record)
 		assert.Nil(t, err)
 		assert.Equal(t, expected, record.Created.ToTime().UTC())
+
+		var ms map[string]interface{}
+		err = json.Unmarshal([]byte(input), &ms)
+		assert.Nil(t, err)
+
+		var record2 Iso8601TimeRecord
+		err = DecodeMapStruct(ms, &record2)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record2.Created.ToTime().UTC())
+
+		var record3 Iso8601TimeRecordP
+		err = DecodeMapStruct(ms, &record3)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record3.Created.ToTime().UTC())
+
+		var record4 TimeRecord
+		err = DecodeMapStruct(ms, &record4)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, record4.Created.UTC())
 	}
 }

--- a/plugins/domainlayer/models/ticket/issue.go
+++ b/plugins/domainlayer/models/ticket/issue.go
@@ -1,7 +1,6 @@
 package ticket
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/merico-dev/lake/plugins/domainlayer/models/base"
@@ -25,7 +24,7 @@ type Issue struct {
 	RemainingEstimateMinutes int64 // could it be negative value?
 	CreatorOriginKey         string
 	AssigneeOriginKey        string
-	ResolutionDate           sql.NullTime
+	ResolutionDate           *time.Time
 	Priority                 string // not sure how to deal with it yet, copy the name for now
 	ParentOriginKey          string
 	SprintOriginKey          string

--- a/plugins/github/models/github_issue.go
+++ b/plugins/github/models/github_issue.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/merico-dev/lake/models"
@@ -18,7 +17,7 @@ type GithubIssue struct {
 	Status          string
 	Assignee        string
 	LeadTimeMinutes uint
-	ClosedAt        sql.NullTime
+	ClosedAt        *time.Time
 	GithubCreatedAt time.Time
 	GithubUpdatedAt time.Time
 

--- a/plugins/github/tasks/github_issues_collector.go
+++ b/plugins/github/tasks/github_issues_collector.go
@@ -28,9 +28,9 @@ type IssuesResponse struct {
 		Login string
 		Id    int
 	}
-	ClosedAt        core.Iso8601Time `json:"closed_at"`
-	GithubCreatedAt core.Iso8601Time `json:"created_at"`
-	GithubUpdatedAt core.Iso8601Time `json:"updated_at"`
+	ClosedAt        *core.Iso8601Time `json:"closed_at"`
+	GithubCreatedAt core.Iso8601Time  `json:"created_at"`
+	GithubUpdatedAt core.Iso8601Time  `json:"updated_at"`
 }
 
 func CollectIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
@@ -82,7 +82,7 @@ func convertGithubIssue(issue *IssuesResponse) (*models.GithubIssue, error) {
 		Title:           issue.Title,
 		Body:            issue.Body,
 		Assignee:        issue.Assignee.Login,
-		ClosedAt:        issue.ClosedAt.ToSqlNullTime(),
+		ClosedAt:        core.Iso8601TimeToTime(issue.ClosedAt),
 		GithubCreatedAt: issue.GithubCreatedAt.ToTime(),
 		GithubUpdatedAt: issue.GithubUpdatedAt.ToTime(),
 	}

--- a/plugins/jira/models/jira_issue.go
+++ b/plugins/jira/models/jira_issue.go
@@ -38,7 +38,7 @@ type JiraIssue struct {
 	ParentKey                string
 	SprintId                 uint64 // latest sprint, issue might cross multiple sprints, would be addressed by #514
 	SprintName               string
-	ResolutionDate           sql.NullTime
+	ResolutionDate           *time.Time
 	Created                  time.Time
 	Updated                  time.Time
 

--- a/plugins/jira/tasks/jira_issue_enricher.go
+++ b/plugins/jira/tasks/jira_issue_enricher.go
@@ -66,8 +66,8 @@ func EnrichIssues(source *models.JiraSource, boardId uint64) (err error) {
 		if err != nil {
 			return err
 		}
-		if jiraIssue.ResolutionDate.Valid {
-			jiraIssue.LeadTimeMinutes = uint(jiraIssue.ResolutionDate.Time.Unix()-jiraIssue.Created.Unix()) / 60
+		if jiraIssue.ResolutionDate != nil {
+			jiraIssue.LeadTimeMinutes = uint(jiraIssue.ResolutionDate.Unix()-jiraIssue.Created.Unix()) / 60
 		}
 		jiraIssue.StdStoryPoint = uint(jiraIssue.StoryPoint * source.StoryPointCoefficient)
 		jiraIssue.StdType = getStdType(jiraIssue.Type)

--- a/plugins/jira/tasks/jira_project_collector.go
+++ b/plugins/jira/tasks/jira_project_collector.go
@@ -9,8 +9,8 @@ import (
 
 // This has to be called JiraUserProjects since it is a different api call than JiraProjects.
 // This call retreives all projects that the user has access to
-type JiraUserProjectApiRes []JiraProject
-type JiraProject struct {
+type JiraUserProjectApiRes []JiraApiProject
+type JiraApiProject struct {
 	Id   string `json:"id"`
 	Key  string `json:"key"`
 	Name string `json:"name"`
@@ -32,11 +32,11 @@ func CollectProjects(
 		return err
 	}
 	// process issues
-	for _, project := range *jiraApiProjects {
-		project, _ := convertProject(&project, sourceId)
+	for _, jiraApiProject := range *jiraApiProjects {
+		jiraProject, _ := convertProject(&jiraApiProject, sourceId)
 		err = lakeModels.Db.Clauses(clause.OnConflict{
 			UpdateAll: true,
-		}).Create(project).Error
+		}).Create(jiraProject).Error
 		if err != nil {
 			return err
 		}
@@ -44,12 +44,12 @@ func CollectProjects(
 	return nil
 }
 
-func convertProject(user *JiraProject, sourceId uint64) (*models.JiraProject, error) {
+func convertProject(jiraApiProject *JiraApiProject, sourceId uint64) (*models.JiraProject, error) {
 	jiraProject := &models.JiraProject{
 		SourceId: sourceId,
-		Id:       user.Id,
-		Key:      user.Key,
-		Name:     user.Name,
+		Id:       jiraApiProject.Id,
+		Key:      jiraApiProject.Key,
+		Name:     jiraApiProject.Name,
 	}
 	return jiraProject, nil
 }

--- a/plugins/jira/tasks/jira_sprint_collector.go
+++ b/plugins/jira/tasks/jira_sprint_collector.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-type Sprint struct {
-	ID            uint64     `json:"id"`
+type JiraApiSprint struct {
+	Id            uint64     `json:"id"`
 	Self          string     `json:"self"`
 	State         string     `json:"state"`
 	Name          string     `json:"name"`
@@ -22,30 +22,30 @@ type Sprint struct {
 	CompleteDate  *time.Time `json:"completeDate,omitempty"`
 	OriginBoardID uint64     `json:"originBoardId,omitempty"`
 }
-type JiraApiSprint struct {
-	MaxResults int      `json:"maxResults"`
-	StartAt    int      `json:"startAt"`
-	Total      int      `json:"total"`
-	IsLast     bool     `json:"isLast"`
-	Values     []Sprint `json:"values"`
+type JiraApiSprintsResponse struct {
+	MaxResults int             `json:"maxResults"`
+	StartAt    int             `json:"startAt"`
+	Total      int             `json:"total"`
+	IsLast     bool            `json:"isLast"`
+	Values     []JiraApiSprint `json:"values"`
 }
 
 func CollectSprint(jiraApiClient *JiraApiClient, source *models.JiraSource, boardId uint64) error {
 	err := jiraApiClient.FetchWithoutPaginationHeaders(fmt.Sprintf("/agile/1.0/board/%v/sprint", boardId), nil, func(res *http.Response) (int, error) {
-		jiraApiSprint := &JiraApiSprint{}
-		err := core.UnmarshalResponse(res, jiraApiSprint)
+		jiraApiSprints := &JiraApiSprintsResponse{}
+		err := core.UnmarshalResponse(res, jiraApiSprints)
 		if err != nil {
 			logger.Error("Error: ", err)
 			return 0, err
 		}
-		if len(jiraApiSprint.Values) == 0 {
+		if len(jiraApiSprints.Values) == 0 {
 			return 0, nil
 		}
-		logger.Info("got jira sprints ", len(jiraApiSprint.Values))
-		for _, value := range jiraApiSprint.Values {
+		logger.Info("got jira sprints ", len(jiraApiSprints.Values))
+		for _, value := range jiraApiSprints.Values {
 			jiraSprint := &models.JiraSprint{
 				SourceId:      source.ID,
-				SprintId:      value.ID,
+				SprintId:      value.Id,
 				Self:          value.Self,
 				State:         value.State,
 				Name:          value.Name,
@@ -65,14 +65,14 @@ func CollectSprint(jiraApiClient *JiraApiClient, source *models.JiraSource, boar
 			err = lakeModels.Db.FirstOrCreate(&models.JiraBoardSprint{
 				SourceId: source.ID,
 				BoardId:  boardId,
-				SprintId: value.ID,
+				SprintId: value.Id,
 			}).Error
 			if err != nil {
 				logger.Error("Error: ", err)
 				return 0, err
 			}
 		}
-		return len(jiraApiSprint.Values), nil
+		return len(jiraApiSprints.Values), nil
 	})
 	if err != nil {
 		return err

--- a/plugins/jira/tasks/jira_user_collector.go
+++ b/plugins/jira/tasks/jira_user_collector.go
@@ -14,7 +14,7 @@ type JiraUserApiRes []JiraApiUser
 type JiraApiUser struct {
 	AccountId   string `json:"accountId"`
 	AccountType string `json:"accountType"`
-	Name        string `json:"displayName"`
+	DisplayName string `json:"displayName"`
 	Email       string `json:"emailAddress"`
 	Timezone    string `json:"timeZone"`
 	AvatarUrls  struct {
@@ -70,7 +70,7 @@ func convertUser(user *JiraApiUser, sourceId uint64) (*models.JiraUser, error) {
 		SourceId:    sourceId,
 		AccountId:   user.AccountId,
 		AccountType: user.AccountType,
-		Name:        user.Name,
+		Name:        user.DisplayName,
 		Email:       user.Email,
 		Timezone:    user.Timezone,
 		AvatarUrl:   user.AvatarUrls.Url,


### PR DESCRIPTION
# Summary

A long overdue refactor.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description

1. type assertion are error prone and hard to debug, replaced with
`mapstructure.Decode` which is easy to understand and maintain.
2. replace `sql.NullTime` with `*time.Time` for maintainability.
3. unify struct naming to help distinguish Api structs and Db structs

### Does this close any open issues?
Closes #563
