### PR TITLE
Handle url query strings with net/url package

### DIFF
--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -93,7 +93,7 @@ func (apiClient *ApiClient) Do(
 	headers *map[string]string,
 ) (*http.Response, error) {
 
-	uri, err := getURIStringPointer(apiClient.endpoint, path, query)
+	uri, err := GetURIStringPointer(apiClient.endpoint, path, query)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func UnmarshalResponse(res *http.Response, v interface{}) error {
 	return json.Unmarshal(resBody, &v)
 }
 
-func getURIStringPointer(baseUrl string, relativePath string, queryParams *url.Values) (*string, error) {
+func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.Values) (*string, error) {
 	base, err := url.Parse(baseUrl)
 	if err != nil {
 		return nil, err

--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/merico-dev/lake/logger"
@@ -78,7 +79,7 @@ func (apiClient *ApiClient) SetProxy(proxyUrl string) error {
 	if err != nil {
 		return err
 	}
-	if pu.Scheme == "http" || pu.Scheme == "socks5"{
+	if pu.Scheme == "http" || pu.Scheme == "socks5" {
 		apiClient.client.Transport = &http.Transport{Proxy: http.ProxyURL(pu)}
 	}
 	return nil
@@ -91,16 +92,11 @@ func (apiClient *ApiClient) Do(
 	body *map[string]interface{},
 	headers *map[string]string,
 ) (*http.Response, error) {
-	uri := apiClient.endpoint + path
 
-	// append query
-	if query != nil {
-		queryString := query.Encode()
-		if queryString != "" {
-			uri += "?" + queryString
-		}
+	uri, err := getURIStringPointer(apiClient.endpoint, path, query)
+	if err != nil {
+		return nil, err
 	}
-
 	// process body
 	var reqBody io.Reader
 	if body != nil {
@@ -110,7 +106,7 @@ func (apiClient *ApiClient) Do(
 		}
 		reqBody = bytes.NewBuffer(reqJson)
 	}
-	req, err := http.NewRequest(method, uri, reqBody)
+	req, err := http.NewRequest(method, *uri, reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +135,7 @@ func (apiClient *ApiClient) Do(
 	var res *http.Response
 	retry := 0
 	for {
-		logger.Print(fmt.Sprintf("[api-client][retry %v] %v %v", retry, method, uri))
+		logger.Print(fmt.Sprintf("[api-client][retry %v] %v %v", retry, method, *uri))
 		res, err = apiClient.client.Do(req)
 		if err != nil {
 			if retry < apiClient.maxRetry-1 {
@@ -179,4 +175,24 @@ func UnmarshalResponse(res *http.Response, v interface{}) error {
 		return err
 	}
 	return json.Unmarshal(resBody, &v)
+}
+
+func getURIStringPointer(baseUrl string, relativePath string, queryParams *url.Values) (*string, error) {
+	base, err := url.Parse(baseUrl)
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(relativePath)
+	if err != nil {
+		return nil, err
+	}
+	if queryParams != nil {
+		queryString := u.Query()
+		for key, value := range *queryParams {
+			queryString.Set(key, strings.Join(value, ""))
+		}
+		u.RawQuery = queryString.Encode()
+	}
+	uri := base.ResolveReference(u).String()
+	return &uri, nil
 }

--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -1,0 +1,30 @@
+package core
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetURIStringPointer_WithSlash(t *testing.T) {
+	baseUrl := "http://my-site.com/"
+	relativePath := "/api/stuff"
+	queryParams := &url.Values{}
+	queryParams.Set("id", "1")
+	expected := "http://my-site.com/api/stuff?id=1"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+
+}
+func TestGetURIStringPointer_WithNoSlash(t *testing.T) {
+	baseUrl := "http://my-site.com"
+	relativePath := "api/stuff"
+	queryParams := &url.Values{}
+	queryParams.Set("id", "1")
+	expected := "http://my-site.com/api/stuff?id=1"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+}

--- a/plugins/github/tasks/github_commits_collector.go
+++ b/plugins/github/tasks/github_commits_collector.go
@@ -35,7 +35,7 @@ type Commit struct {
 
 func CollectCommits(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repositoryName)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 20, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_issue_comments_collector.go
+++ b/plugins/github/tasks/github_issue_comments_collector.go
@@ -25,7 +25,7 @@ type IssueComment struct {
 
 func CollectIssueComments(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repositoryName, issue.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueCommentResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_issue_events_collector.go
+++ b/plugins/github/tasks/github_issue_events_collector.go
@@ -23,9 +23,9 @@ type IssueEvent struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectIssueEvents(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {	
+func CollectIssueEvents(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/events", owner, repositoryName, issue.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueEventResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_issue_labels_collector.go
+++ b/plugins/github/tasks/github_issue_labels_collector.go
@@ -23,7 +23,7 @@ type IssueLabel struct {
 
 func CollectIssueLabelsForSinglePullRequest(owner string, repositoryName string, pr *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repositoryName, pr.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueLabelResponse{}
 			if res.StatusCode == 200 {
@@ -52,7 +52,7 @@ func CollectIssueLabelsForSinglePullRequest(owner string, repositoryName string,
 }
 func CollectIssueLabelsForSingleIssue(owner string, repositoryName string, issue *models.GithubIssue, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/labels", owner, repositoryName, issue.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueLabelResponse{}
 			if res.StatusCode == 200 {
@@ -81,7 +81,7 @@ func CollectIssueLabelsForSingleIssue(owner string, repositoryName string, issue
 }
 func CollectRepositoryIssueLabels(owner string, repositoryName string, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/labels", owner, repositoryName)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueLabelResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_issues_collector.go
+++ b/plugins/github/tasks/github_issues_collector.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -34,8 +35,10 @@ type IssuesResponse struct {
 }
 
 func CollectIssues(owner string, repositoryName string, repositoryId int, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
-	getUrl := fmt.Sprintf("repos/%v/%v/issues?state=all", owner, repositoryName)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 20, scheduler,
+	getUrl := fmt.Sprintf("repos/%v/%v/issues", owner, repositoryName)
+	queryParams := &url.Values{}
+	queryParams.Set("state", "all")
+	return githubApiClient.FetchWithPaginationAnts(getUrl, queryParams, 100, 20, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssuesResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_pull_request_comments_collector.go
+++ b/plugins/github/tasks/github_pull_request_comments_collector.go
@@ -25,7 +25,7 @@ type PullRequestComment struct {
 
 func CollectPullRequestComments(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommentResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_commits_collector.go
+++ b/plugins/github/tasks/github_pull_request_commits_collector.go
@@ -35,7 +35,7 @@ type PrCommit struct {
 
 func CollectPullRequestCommits(owner string, repositoryName string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/commits", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommitResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_reviewer_collector.go
+++ b/plugins/github/tasks/github_pull_request_reviewer_collector.go
@@ -27,7 +27,7 @@ type PullRequestReview struct {
 
 func CollectPullRequestReviews(owner string, repositoryName string, repositoryId int, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, githubApiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews", owner, repositoryName, pull.Number)
-	return githubApiClient.FetchWithPaginationAnts(getUrl, 100, 1, scheduler,
+	return githubApiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestReviewResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_single_pull_request_collector.go
+++ b/plugins/github/tasks/github_single_pull_request_collector.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -20,8 +21,10 @@ type ApiSinglePullResponse struct {
 }
 
 func CollectPullRequest(owner string, repositoryName string, repositoryId int, pr *models.GithubPullRequest, githubApiClient *GithubApiClient) error {
-	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v?state=all", owner, repositoryName, pr.Number)
-	res, getErr := githubApiClient.Get(getUrl, nil, nil)
+	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v", owner, repositoryName, pr.Number)
+	queryParams := &url.Values{}
+	queryParams.Set("state", "all")
+	res, getErr := githubApiClient.Get(getUrl, queryParams, nil)
 	if getErr != nil {
 		logger.Error("GET Error: ", getErr)
 		return getErr

--- a/plugins/gitlab/tasks/gitlab_commit_collector.go
+++ b/plugins/gitlab/tasks/gitlab_commit_collector.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -36,8 +37,10 @@ type GitlabApiCommit struct {
 
 func CollectCommits(projectId int, scheduler *utils.WorkerScheduler) error {
 	gitlabApiClient := CreateApiClient()
-
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, fmt.Sprintf("projects/%v/repository/commits?with_stats=true", projectId), 100,
+	relativePath := fmt.Sprintf("projects/%v/repository/commits", projectId)
+	queryParams := &url.Values{}
+	queryParams.Set("with_stats", "true")
+	return gitlabApiClient.FetchWithPaginationAnts(scheduler, relativePath, queryParams, 100,
 		func(res *http.Response) error {
 
 			gitlabApiResponse := &ApiCommitResponse{}

--- a/plugins/gitlab/tasks/gitlab_merge_request_collector.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_collector.go
@@ -40,7 +40,7 @@ type ApiMergeRequestResponse []MergeRequestRes
 func CollectMergeRequests(projectId int, scheduler *utils.WorkerScheduler) error {
 	gitlabApiClient := CreateApiClient()
 
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, fmt.Sprintf("projects/%v/merge_requests", projectId), 100,
+	return gitlabApiClient.FetchWithPaginationAnts(scheduler, fmt.Sprintf("projects/%v/merge_requests", projectId), nil, 100,
 		func(res *http.Response) error {
 			gitlabApiResponse := &ApiMergeRequestResponse{}
 			err := core.UnmarshalResponse(res, gitlabApiResponse)

--- a/plugins/gitlab/tasks/gitlab_merge_request_commits.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_commits.go
@@ -37,7 +37,7 @@ func CollectMergeRequestCommits(projectId int, mr *models.GitlabMergeRequest) er
 	gitlabApiClient := CreateApiClient()
 
 	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/commits", projectId, mr.Iid)
-	return gitlabApiClient.FetchWithPagination(getUrl, 100,
+	return gitlabApiClient.FetchWithPagination(getUrl, nil, 100,
 		func(res *http.Response) error {
 			gitlabApiResponse := &ApiMergeRequestCommitResponse{}
 			err := core.UnmarshalResponse(res, gitlabApiResponse)

--- a/plugins/gitlab/tasks/gitlab_merge_request_note.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_note.go
@@ -71,7 +71,7 @@ func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest) erro
 	gitlabApiClient := CreateApiClient()
 
 	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/notes?system=false", projectId, mr.Iid)
-	return gitlabApiClient.FetchWithPagination(getUrl, 100,
+	return gitlabApiClient.FetchWithPagination(getUrl, nil, 100,
 		func(res *http.Response) error {
 
 			gitlabApiResponse := &ApiMergeRequestNoteResponse{}

--- a/plugins/gitlab/tasks/gitlab_pipeline_collector.go
+++ b/plugins/gitlab/tasks/gitlab_pipeline_collector.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
@@ -41,8 +42,13 @@ type ApiSinglePipelineResponse struct {
 
 func CollectAllPipelines(projectId int, scheduler *utils.WorkerScheduler) error {
 	gitlabApiClient := CreateApiClient()
-
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, fmt.Sprintf("projects/%v/pipelines?order_by=updated_at&sort=desc", projectId), 100,
+	queryParams := &url.Values{}
+	queryParams.Set("order_by", "updated_at")
+	queryParams.Set("sort", "desc")
+	return gitlabApiClient.FetchWithPaginationAnts(scheduler,
+		fmt.Sprintf("projects/%v/pipelines", projectId),
+		queryParams,
+		100,
 		func(res *http.Response) error {
 
 			apiPipelineResponse := &ApiPipelineResponse{}


### PR DESCRIPTION
### Description
This PR replaces our old method of putting together query strings with a more robust way that is less error prone. Now we are using the net/url package to resolve any inconsistencies for example with '/' at the end of the string or no '/'. This PR also includes:

- Unit testing for URI formatting
- GitHub plugin refactor to pass query params separate from relative path string
- GitLab plugin refactor for the same as GitHub

### Does this close any open issues?
https://github.com/merico-dev/lake/issues/804
