### PR TITLE
fix: jira - add /rest to relative paths ***IMPORTANT FIX - PLEASE READ***

### DIFF
--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -28,3 +28,13 @@ func TestGetURIStringPointer_WithNoSlash(t *testing.T) {
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, expected, *actual)
 }
+func TestGetURIStringPointer_WithRelativePath(t *testing.T) {
+	baseUrl := "http://my-site.com/rest"
+	relativePath := "api/stuff"
+	queryParams := &url.Values{}
+	queryParams.Set("id", "1")
+	expected := "http://my-site.com/api/stuff?id=1"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+}

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -100,6 +100,7 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 			"collectChangelogs": true,
 			"enrichIssues":      true,
 			"collectSprints":    true,
+			"collectUsers":      true,
 		}
 	}
 

--- a/plugins/jira/tasks/jira_board_collector.go
+++ b/plugins/jira/tasks/jira_board_collector.go
@@ -29,7 +29,7 @@ type JiraApiBoard struct {
 }
 
 func CollectBoard(jiraApiClient *JiraApiClient, source *models.JiraSource, boardId uint64) error {
-	res, err := jiraApiClient.Get(fmt.Sprintf("/agile/1.0/board/%v", boardId), nil, nil)
+	res, err := jiraApiClient.Get(fmt.Sprintf("rest/agile/1.0/board/%v", boardId), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/jira/tasks/jira_changelog_collector.go
+++ b/plugins/jira/tasks/jira_changelog_collector.go
@@ -128,7 +128,7 @@ func collectChangelogsByIssueId(
 	jiraApiClient *JiraApiClient,
 	issueId uint64,
 ) error {
-	return jiraApiClient.FetchPages(scheduler, fmt.Sprintf("/api/3/issue/%v/changelog", issueId), nil,
+	return jiraApiClient.FetchPages(scheduler, fmt.Sprintf("rest/api/3/issue/%v/changelog", issueId), nil,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiChangelogResponse := &JiraApiChangelogsResponse{}

--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -124,7 +124,7 @@ func CollectIssues(
 	}
 	defer scheduler.Release()
 
-	err = jiraApiClient.FetchPages(scheduler, fmt.Sprintf("/agile/1.0/board/%v/issue", boardId), query,
+	err = jiraApiClient.FetchPages(scheduler, fmt.Sprintf("rest/agile/1.0/board/%v/issue", boardId), query,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiIssuesResponse := &JiraApiIssuesResponse{}

--- a/plugins/jira/tasks/jira_project_collector.go
+++ b/plugins/jira/tasks/jira_project_collector.go
@@ -20,7 +20,7 @@ func CollectProjects(
 	jiraApiClient *JiraApiClient,
 	sourceId uint64,
 ) error {
-	res, err := jiraApiClient.Get("/api/3/project", nil, nil)
+	res, err := jiraApiClient.Get("rest/api/3/project", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/jira/tasks/jira_sprint_collector.go
+++ b/plugins/jira/tasks/jira_sprint_collector.go
@@ -31,7 +31,7 @@ type JiraApiSprintsResponse struct {
 }
 
 func CollectSprint(jiraApiClient *JiraApiClient, source *models.JiraSource, boardId uint64) error {
-	err := jiraApiClient.FetchWithoutPaginationHeaders(fmt.Sprintf("/agile/1.0/board/%v/sprint", boardId), nil, func(res *http.Response) (int, error) {
+	err := jiraApiClient.FetchWithoutPaginationHeaders(fmt.Sprintf("rest/agile/1.0/board/%v/sprint", boardId), nil, func(res *http.Response) (int, error) {
 		jiraApiSprints := &JiraApiSprintsResponse{}
 		err := core.UnmarshalResponse(res, jiraApiSprints)
 		if err != nil {

--- a/plugins/jira/tasks/jira_user_collector.go
+++ b/plugins/jira/tasks/jira_user_collector.go
@@ -28,7 +28,7 @@ func CollectUsers(jiraApiClient *JiraApiClient,
 	// The reason we use FetchWithoutPaginationHeaders is because this API endpoint does not
 	// return pagination info in it's headers the same way that other endpoints do.
 	// This method still uses pagination, but in a different way.
-	err := jiraApiClient.FetchWithoutPaginationHeaders("/api/3/users/search", nil,
+	err := jiraApiClient.FetchWithoutPaginationHeaders("rest/api/3/users/search", nil,
 		func(res *http.Response) (int, error) {
 			jiraApiUsersResponse := &JiraUserApiRes{}
 			err := core.UnmarshalResponse(res, jiraApiUsersResponse)


### PR DESCRIPTION
### Description
Due to recent changes with how our api client builds request URLs, we need to be conscious of supplying these distinct categories to the "Get" or "Do" method:
- baseUrl
- relativeUrl
- queryParams

Using Golang's net/url package, we can handle these three very well and very consistently. However, implementing this in #829 made our Jira collectors fail due to this problem: we stored part of the **relative path** in the DB as part of the **base url** as such: ```merico.atlassian.net/rest```

We cannot put "/rest" in the DB and still be compatible with the way the api client builds URLs. We need to store ONLY the base URL as ```merico.atlassian.net``` in the DB in the future, and add "/rest" instead to the **relative path** that the plugin supplies to the Fetch methods.

**Bottom Line** - If you are still storing "/rest" on the end of your base URL in your DB for Jira sources, please remove it.

### Does this close any open issues?
Related to #829