### PR TITLE
fix: handle / or no / on baseUrl

### DIFF
--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -95,7 +95,7 @@ const ProviderFormPlaceholders = {
   },
   jira: {
     name: 'Enter Instance Name',
-    endpoint: 'Enter Endpoint URL eg. https://your-domain.atlassian.net/rest/api',
+    endpoint: 'Enter Endpoint URL eg. https://your-domain.atlassian.net/rest/',
     token: 'Enter Auth Token eg. 8c06a7cc50b746bfab30',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'

--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -178,6 +179,7 @@ func UnmarshalResponse(res *http.Response, v interface{}) error {
 }
 
 func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.Values) (*string, error) {
+	AddMissingSlashToURL(&baseUrl)
 	base, err := url.Parse(baseUrl)
 	if err != nil {
 		return nil, err
@@ -195,4 +197,12 @@ func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.V
 	}
 	uri := base.ResolveReference(u).String()
 	return &uri, nil
+}
+
+func AddMissingSlashToURL(baseUrl *string) {
+	pattern := `\/$`
+	isMatch, _ := regexp.Match(pattern, []byte(*baseUrl))
+	if !isMatch {
+		*baseUrl += "/"
+	}
 }

--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -33,8 +33,30 @@ func TestGetURIStringPointer_WithRelativePath(t *testing.T) {
 	relativePath := "api/stuff"
 	queryParams := &url.Values{}
 	queryParams.Set("id", "1")
-	expected := "http://my-site.com/api/stuff?id=1"
+	expected := "http://my-site.com/rest/api/stuff?id=1"
 	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, expected, *actual)
+}
+func TestGetURIStringPointer_WithRelativePath2(t *testing.T) {
+	baseUrl := "https://my-site.com/api/v4/"
+	relativePath := "projects/stuff"
+	queryParams := &url.Values{}
+	queryParams.Set("id", "1")
+	expected := "https://my-site.com/api/v4/projects/stuff?id=1"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+}
+func TestAddMissingSlashToURL_NoSlash(t *testing.T) {
+	baseUrl := "http://my-site.com/rest"
+	expected := "http://my-site.com/rest/"
+	AddMissingSlashToURL(&baseUrl)
+	assert.Equal(t, expected, baseUrl)
+}
+func TestAddMissingSlashToURL_WithSlash(t *testing.T) {
+	baseUrl := "http://my-site.com/rest/"
+	expected := "http://my-site.com/rest/"
+	AddMissingSlashToURL(&baseUrl)
+	assert.Equal(t, expected, baseUrl)
 }

--- a/plugins/jira/tasks/jira_board_collector.go
+++ b/plugins/jira/tasks/jira_board_collector.go
@@ -29,7 +29,7 @@ type JiraApiBoard struct {
 }
 
 func CollectBoard(jiraApiClient *JiraApiClient, source *models.JiraSource, boardId uint64) error {
-	res, err := jiraApiClient.Get(fmt.Sprintf("rest/agile/1.0/board/%v", boardId), nil, nil)
+	res, err := jiraApiClient.Get(fmt.Sprintf("agile/1.0/board/%v", boardId), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/jira/tasks/jira_changelog_collector.go
+++ b/plugins/jira/tasks/jira_changelog_collector.go
@@ -128,7 +128,7 @@ func collectChangelogsByIssueId(
 	jiraApiClient *JiraApiClient,
 	issueId uint64,
 ) error {
-	return jiraApiClient.FetchPages(scheduler, fmt.Sprintf("rest/api/3/issue/%v/changelog", issueId), nil,
+	return jiraApiClient.FetchPages(scheduler, fmt.Sprintf("api/3/issue/%v/changelog", issueId), nil,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiChangelogResponse := &JiraApiChangelogsResponse{}

--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -124,7 +124,7 @@ func CollectIssues(
 	}
 	defer scheduler.Release()
 
-	err = jiraApiClient.FetchPages(scheduler, fmt.Sprintf("rest/agile/1.0/board/%v/issue", boardId), query,
+	err = jiraApiClient.FetchPages(scheduler, fmt.Sprintf("agile/1.0/board/%v/issue", boardId), query,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiIssuesResponse := &JiraApiIssuesResponse{}

--- a/plugins/jira/tasks/jira_project_collector.go
+++ b/plugins/jira/tasks/jira_project_collector.go
@@ -20,7 +20,7 @@ func CollectProjects(
 	jiraApiClient *JiraApiClient,
 	sourceId uint64,
 ) error {
-	res, err := jiraApiClient.Get("rest/api/3/project", nil, nil)
+	res, err := jiraApiClient.Get("api/3/project", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/plugins/jira/tasks/jira_sprint_collector.go
+++ b/plugins/jira/tasks/jira_sprint_collector.go
@@ -31,7 +31,7 @@ type JiraApiSprintsResponse struct {
 }
 
 func CollectSprint(jiraApiClient *JiraApiClient, source *models.JiraSource, boardId uint64) error {
-	err := jiraApiClient.FetchWithoutPaginationHeaders(fmt.Sprintf("rest/agile/1.0/board/%v/sprint", boardId), nil, func(res *http.Response) (int, error) {
+	err := jiraApiClient.FetchWithoutPaginationHeaders(fmt.Sprintf("agile/1.0/board/%v/sprint", boardId), nil, func(res *http.Response) (int, error) {
 		jiraApiSprints := &JiraApiSprintsResponse{}
 		err := core.UnmarshalResponse(res, jiraApiSprints)
 		if err != nil {

--- a/plugins/jira/tasks/jira_user_collector.go
+++ b/plugins/jira/tasks/jira_user_collector.go
@@ -28,7 +28,7 @@ func CollectUsers(jiraApiClient *JiraApiClient,
 	// The reason we use FetchWithoutPaginationHeaders is because this API endpoint does not
 	// return pagination info in it's headers the same way that other endpoints do.
 	// This method still uses pagination, but in a different way.
-	err := jiraApiClient.FetchWithoutPaginationHeaders("rest/api/3/users/search", nil,
+	err := jiraApiClient.FetchWithoutPaginationHeaders("api/3/users/search", nil,
 		func(res *http.Response) (int, error) {
 			jiraApiUsersResponse := &JiraUserApiRes{}
 			err := core.UnmarshalResponse(res, jiraApiUsersResponse)


### PR DESCRIPTION
### Description
This PR adds a method which allows ApiClient to handle base URLs with or without '/' at the end. It also adds unit tests to prove functionality. This means it is now OK to store endpoint URLs in the DB with or without relative paths attached (for example: ```mysite.com/rest``` or ```mysite.com``` are acceptable.

**Bottom Line** this reverts some changes to Jira plugin where ```rest/``` was added to relative paths. It is now fine to go back to the way we had it by storing ```/rest``` in the DB as the Jira endpoint. In fact, we will need ```/rest``` in the DB for Jira to work.

### Does this close any open issues?
related to #834 
related to #829 
completes #804 

### Current Behavior
If endpoint (from .env or DB) does not end with '/' then whatever is written after the last '/' will be removed from the endpoint. 

### New Behavior
If endpoint does not end with '/' then we will append a '/' on the end in order to keep what is written after the previous '/'

