### PR TITLE
feat: test connection

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -50,43 +50,44 @@ function useConnectionManager ({
   const [saveComplete, setSaveComplete] = useState(false)
   const [deleteComplete, setDeleteComplete] = useState(false)
 
-  const testConnection = (connection) => {
+  const testConnection = () => {
     setIsTesting(true)
     setShowError(false)
     ToastNotification.clear()
-    const testResponse = {
-      success: false,
-      connection: activeProvider,
-      errors: []
-    }
+    // TODO: run Save first
     const runTest = async () => {
-      let queryParams = ''
-      if (activeProvider.multiSource && connection.id){
-        queryParams += `?sourceId=${connection.id}`
+      let queryParams = ``
+      switch (activeProvider.id) {
+        case Providers.JENKINS:
+          queryParams = `?username=${username}&password=${password}&endpoint=${endpointUrl}`
+          break
+        case Providers.GITLAB:
+          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+          break
+        case Providers.GITHUB:
+          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+          break
+        case Providers.JIRA:
+          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+          break
       }
       let testUrl = `${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/test`
       let getUrl = testUrl + queryParams
       console.log('INFO >>> GET URL for testing: ', getUrl);
       let res = await request.get(getUrl)
-      if (res.data && res.status === 200) {
-        testResponse.success = true
-      } else {
-        testResponse.errors.push(new Error("Test failed. Please check provider configuration."))
-      }
-    }
-    runTest()
-    setTimeout(() => {
-      if (testResponse.success) {
+      console.log('res.data', res.data);
+      if (res?.data?.Success && res.status === 200) {
         setIsTesting(false)
         setTestStatus(1)
         ToastNotification.show({ message: 'Connection test OK.', intent: 'success', icon: 'small-tick' })
       } else {
         setIsTesting(false)
         setTestStatus(2)
-        ToastNotification.show({ message: 'Connection test FAILED.', intent: 'danger', icon: 'error' })
+        let errorMessage = 'Connection test FAILED. ' + res?.data?.Message
+        ToastNotification.show({ message: errorMessage, intent: 'danger', icon: 'error' })
       }
-      console.log('INFO >>> Test Response: ', testResponse)
-    }, 2000)
+    }
+    runTest()
   }
 
   const saveConnection = () => {

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -344,14 +344,14 @@ export default function ConnectionForm (props) {
           style={{ display: 'flex', marginTop: '30px', justifyContent: 'space-between' }}
         >
           <div style={{ display: 'flex' }}>
-            {/* <Button
+            <Button
               className='btn-test-connection'
               icon={getConnectionStatusIcon()}
               text='Test Connection'
               onClick={onTest}
               loading={isTesting}
               disabled={isTesting || isSaving || isLocked}
-            /> */}
+            />
           </div>
           <div style={{ display: 'flex' }}>
             <Button className='btn-cancel' icon='remove' text='Cancel' onClick={onCancel} disabled={isSaving || isTesting} />

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -315,7 +315,7 @@ export default function ManageIntegration () {
                                 <Icon icon='refresh' size={12} />
                                 Collect
                               </a> */}
-                              <a
+                              {/* <a
                                 href='#'
                                 data-provider={connection.id}
                                 className='table-action-link actions-link'
@@ -323,7 +323,7 @@ export default function ManageIntegration () {
                               >
                                 <Icon icon='data-connection' size={12} />
                                 Test
-                              </a>
+                              </a> */}
                             </td>
                           </tr>
                         ))}

--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -46,7 +46,8 @@ export default function ManageIntegration () {
     deleteConnection,
     fetchAllConnections,
     errors,
-    deleteComplete
+    deleteComplete,
+    testConnection
   } = useConnectionManager({
     activeProvider
   })
@@ -72,10 +73,6 @@ export default function ManageIntegration () {
     console.log('>> editing/modifying connection: ', id, endpoint)
   }
 
-  const testConnection = (connection) => {
-    const { id, endpoint } = connection
-    console.log('>> testing connection: ', id, endpoint)
-  }
 
   const runCollection = (connection) => {
     const { id, endpoint } = connection
@@ -317,7 +314,7 @@ export default function ManageIntegration () {
                               >
                                 <Icon icon='refresh' size={12} />
                                 Collect
-                              </a>
+                              </a> */}
                               <a
                                 href='#'
                                 data-provider={connection.id}
@@ -326,7 +323,7 @@ export default function ManageIntegration () {
                               >
                                 <Icon icon='data-connection' size={12} />
                                 Test
-                              </a> */}
+                              </a>
                             </td>
                           </tr>
                         ))}

--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -183,6 +183,7 @@ func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.V
 	if err != nil {
 		return nil, err
 	}
+	// TODO: if relative path starts with slash, shave it off.
 	u, err := url.Parse(relativePath)
 	if err != nil {
 		return nil, err

--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -59,6 +59,9 @@ func (apiClient *ApiClient) Setup(
 func (apiClient *ApiClient) SetEndpoint(endpoint string) {
 	apiClient.endpoint = endpoint
 }
+func (apiClient *ApiClient) GetEndpoint() string {
+	return apiClient.endpoint
+}
 
 func (ApiClient *ApiClient) SetTimeout(timeout time.Duration) {
 	ApiClient.client.Timeout = timeout
@@ -70,6 +73,9 @@ func (ApiClient *ApiClient) SetMaxRetry(maxRetry int) {
 
 func (apiClient *ApiClient) SetHeaders(headers map[string]string) {
 	apiClient.headers = headers
+}
+func (apiClient *ApiClient) GetHeaders() map[string]string {
+	return apiClient.headers
 }
 
 func (apiClient *ApiClient) SetBeforeFunction(callback ApiClientBeforeRequest) {

--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -48,6 +48,15 @@ func TestGetURIStringPointer_WithRelativePath2(t *testing.T) {
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, expected, *actual)
 }
+// TODO: this must pass
+func TestGetURIStringPointer_HandlesRelativePathStartingWithSlash(t *testing.T) {
+	baseUrl := "https://gitlab.com/api/v4/"
+	relativePath := "/user"
+	expected := "https://gitlab.com/api/v4/user"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, nil)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+}
 func TestAddMissingSlashToURL_NoSlash(t *testing.T) {
 	baseUrl := "http://my-site.com/rest"
 	expected := "http://my-site.com/rest/"

--- a/plugins/core/apiclient_test.go
+++ b/plugins/core/apiclient_test.go
@@ -48,24 +48,58 @@ func TestGetURIStringPointer_WithRelativePath2(t *testing.T) {
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, expected, *actual)
 }
-// TODO: this must pass
+
 func TestGetURIStringPointer_HandlesRelativePathStartingWithSlash(t *testing.T) {
-	baseUrl := "https://gitlab.com/api/v4/"
+	baseUrl := "https://my-site.com/api/v4/"
 	relativePath := "/user"
-	expected := "https://gitlab.com/api/v4/user"
+	expected := "https://my-site.com/api/v4/user"
 	actual, err := GetURIStringPointer(baseUrl, relativePath, nil)
 	assert.Equal(t, err == nil, true)
 	assert.Equal(t, expected, *actual)
 }
+
+func TestGetURIStringPointer_HandlesRelativePathStartingWithSlashWithParams(t *testing.T) {
+	baseUrl := "https://my-site.com/api/v4/"
+	relativePath := "/user"
+	queryParams := &url.Values{}
+	queryParams.Set("id", "1")
+	expected := "https://my-site.com/api/v4/user?id=1"
+	actual, err := GetURIStringPointer(baseUrl, relativePath, queryParams)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, expected, *actual)
+}
+
 func TestAddMissingSlashToURL_NoSlash(t *testing.T) {
 	baseUrl := "http://my-site.com/rest"
 	expected := "http://my-site.com/rest/"
 	AddMissingSlashToURL(&baseUrl)
 	assert.Equal(t, expected, baseUrl)
 }
+
 func TestAddMissingSlashToURL_WithSlash(t *testing.T) {
 	baseUrl := "http://my-site.com/rest/"
 	expected := "http://my-site.com/rest/"
 	AddMissingSlashToURL(&baseUrl)
 	assert.Equal(t, expected, baseUrl)
+}
+
+func TestRemoveStartingSlashFromPath(t *testing.T) {
+	testString := "/user/api"
+	expected := "user/api"
+	actual := RemoveStartingSlashFromPath(testString)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRemoveStartingSlashFromPath_EmptyString(t *testing.T) {
+	testString := ""
+	expected := ""
+	actual := RemoveStartingSlashFromPath(testString)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRemoveStartingSlashFromPath_NoStartingSlash(t *testing.T) {
+	testString := "user/api"
+	expected := "user/api"
+	actual := RemoveStartingSlashFromPath(testString)
+	assert.Equal(t, expected, actual)
 }

--- a/plugins/core/testConnection.go
+++ b/plugins/core/testConnection.go
@@ -1,0 +1,17 @@
+package core
+
+type TestResult struct {
+	Success bool
+	Message string
+}
+
+func (testResult *TestResult) Set(success bool, message string) {
+	testResult.Success = success
+	testResult.Message = message
+}
+
+const ReadError = "There was a problem reading source data."
+const SourceIdError = "Missing or Invalid sourceId"
+const InvalidConnectionError = "Your connection configuration is invalid."
+const UnsetConnectionError = "Your connection configuration is not set."
+const UnmarshallingError = "There was a problem unmarshalling the response"

--- a/plugins/core/testConnection.go
+++ b/plugins/core/testConnection.go
@@ -1,5 +1,7 @@
 package core
 
+import "fmt"
+
 type TestResult struct {
 	Success bool
 	Message string
@@ -10,7 +12,31 @@ func (testResult *TestResult) Set(success bool, message string) {
 	testResult.Message = message
 }
 
-const ReadError = "There was a problem reading source data."
+func ValidateParams(input *ApiResourceInput, requiredParams []string) *TestResult {
+	message := "Missing params: "
+	missingParams := []string{}
+	if len(input.Query) == 0 {
+		for _, param := range requiredParams {
+			message += fmt.Sprintf("%v,", param)
+		}
+		return &TestResult{Success: false, Message: message}
+	} else {
+		for _, param := range requiredParams {
+			if input.Query.Get(param) == "" {
+				missingParams = append(missingParams, param)
+			}
+		}
+		if len(missingParams) > 0 {
+			for _, param := range missingParams {
+				message += fmt.Sprintf("%v,", param)
+			}
+			return &TestResult{Success: false, Message: message}
+		} else {
+			return &TestResult{Success: true, Message: ""}
+		}
+	}
+}
+
 const SourceIdError = "Missing or Invalid sourceId"
 const InvalidConnectionError = "Your connection configuration is invalid."
 const UnsetConnectionError = "Your connection configuration is not set."

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/merico-dev/lake/config"
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/github/tasks"
+)
+
+type ApiMeResponse struct {
+	Name     string `json:"name"`
+	GithubId int    `json:"id"`
+	HTMLUrl  string `json:"html_url"`
+}
+
+/*
+GET /plugins/github/test
+*/
+func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	endpoint := config.V.GetString("GITHUB_ENDPOINT")
+	configTokensString := config.V.GetString("GITHUB_AUTH")
+	tokens := strings.Split(configTokensString, ",")
+	githubApiClient := tasks.CreateApiClient(endpoint, tokens)
+
+	res, err := githubApiClient.Get("/users/me", nil, nil)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return nil, err
+	}
+
+	githubApiResponse := &ApiMeResponse{}
+	err = core.UnmarshalResponse(res, githubApiResponse)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return nil, err
+	}
+
+	return &core.ApiResourceOutput{Body: githubApiResponse}, nil
+}

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -39,7 +38,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 			return nil, err
 		}
 		if res.StatusCode != 200 {
-			return nil, errors.New(fmt.Sprintf("Invalid token: %v. Please ensure your tokens are correct.", tokens[i]))
+			return nil, fmt.Errorf("Invalid token: %v. Please ensure your tokens are correct.", tokens[i])
 		}
 		githubApiResponse := &ApiUserPublicEmailResponse{}
 		err = core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -47,5 +47,5 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 			return nil, err
 		}
 	}
-	return &core.ApiResourceOutput{Body: "Tokens are valid!"}, nil
+	return &core.ApiResourceOutput{Body: true}, nil
 }

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -178,6 +178,9 @@ func (plugin Github) RootPkgPath() string {
 
 func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
+		"test": {
+			"GET": api.TestConnection,
+		},
 		"sources": {
 			"GET":  api.ListSources,
 			"POST": api.PutSource,

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -24,6 +24,7 @@ func CreateApiClient(endpoint string, tokens []string) *GithubApiClient {
 	githubApiClient := &GithubApiClient{}
 	githubApiClient.tokenIndex = 0
 	githubApiClient.tokens = tokens
+	// Rotates token on each request.
 	githubApiClient.SetBeforeFunction(func(req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", githubApiClient.tokens[githubApiClient.tokenIndex]))
 		// Set next token index

--- a/plugins/gitlab/api/gitlab_connections.go
+++ b/plugins/gitlab/api/gitlab_connections.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/gitlab/tasks"
+)
+
+// Using User because it requires authentication.
+type ApiUserResponse struct {
+	Id   int
+	Name string
+}
+
+/*
+GET /plugins/gitlab/test
+*/
+func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	gitlabApiClient := tasks.CreateApiClient()
+
+	res, err := gitlabApiClient.Get("user", nil, nil)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return nil, err
+	}
+	if res.StatusCode != 200 {
+		return nil, errors.New("Your token is invalid for this URL.")
+	}
+	fmt.Println("KEVIN >>> res.Status", res.Status)
+	gitlabApiResponse := &ApiUserResponse{}
+	err = core.UnmarshalResponse(res, gitlabApiResponse)
+	if err != nil {
+		logger.Error("Error: ", err)
+		return nil, err
+	}
+	fmt.Println("KEVIN >>> gitlabApiResponse.Name", gitlabApiResponse.Name)
+	return &core.ApiResourceOutput{Body: "Token is valid for the URL!"}, nil
+}

--- a/plugins/gitlab/api/gitlab_connections.go
+++ b/plugins/gitlab/api/gitlab_connections.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/merico-dev/lake/logger"
 	"github.com/merico-dev/lake/plugins/core"
@@ -29,13 +28,11 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	if res.StatusCode != 200 {
 		return nil, errors.New("Your token is invalid for this URL.")
 	}
-	fmt.Println("KEVIN >>> res.Status", res.Status)
 	gitlabApiResponse := &ApiUserResponse{}
 	err = core.UnmarshalResponse(res, gitlabApiResponse)
 	if err != nil {
 		logger.Error("Error: ", err)
 		return nil, err
 	}
-	fmt.Println("KEVIN >>> gitlabApiResponse.Name", gitlabApiResponse.Name)
 	return &core.ApiResourceOutput{Body: "Token is valid for the URL!"}, nil
 }

--- a/plugins/gitlab/api/gitlab_connections.go
+++ b/plugins/gitlab/api/gitlab_connections.go
@@ -34,5 +34,5 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		logger.Error("Error: ", err)
 		return nil, err
 	}
-	return &core.ApiResourceOutput{Body: "Token is valid for the URL!"}, nil
+	return &core.ApiResourceOutput{Body: true}, nil
 }

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -187,6 +187,9 @@ func (plugin Gitlab) RootPkgPath() string {
 
 func (plugin Gitlab) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
+		"test": {
+			"GET": api.TestConnection,
+		},
 		"sources": {
 			"GET":  api.ListSources,
 			"POST": api.PutSource,

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -20,6 +20,7 @@ type GitlabApiClient struct {
 
 func CreateApiClient() *GitlabApiClient {
 	gitlabApiClient := &GitlabApiClient{}
+	fmt.Println("KEVIN >>> endpoint", config.V.GetString("GITLAB_ENDPOINT"))
 	gitlabApiClient.Setup(
 		config.V.GetString("GITLAB_ENDPOINT"),
 		map[string]string{

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -20,7 +20,6 @@ type GitlabApiClient struct {
 
 func CreateApiClient() *GitlabApiClient {
 	gitlabApiClient := &GitlabApiClient{}
-	fmt.Println("KEVIN >>> endpoint", config.V.GetString("GITLAB_ENDPOINT"))
 	gitlabApiClient.Setup(
 		config.V.GetString("GITLAB_ENDPOINT"),
 		map[string]string{

--- a/plugins/jenkins/api/jenkins_connections.go
+++ b/plugins/jenkins/api/jenkins_connections.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/utils"
+)
+
+func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	jenkinsSource, err := GetSourceFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	encodedToken := utils.GetEncodedToken(jenkinsSource.Username, jenkinsSource.Password)
+	apiClient := &core.ApiClient{}
+	apiClient.Setup(
+		jenkinsSource.Endpoint,
+		map[string]string{
+			"Authorization": fmt.Sprintf("Basic %v", encodedToken),
+		},
+		10*time.Second,
+		3,
+	)
+	res, err := apiClient.Get("", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("Your connection configuration is invalid.")
+	}
+	return &core.ApiResourceOutput{Body: true}, nil
+}

--- a/plugins/jenkins/api/jenkins_connections.go
+++ b/plugins/jenkins/api/jenkins_connections.go
@@ -10,18 +10,15 @@ import (
 )
 
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
-	jenkinsSource, err := GetSourceFromEnv()
-	if err != nil {
-		logger.Error("Error: ", err)
-		return &core.ApiResourceOutput{Body: core.TestResult{Success: false, Message: core.ReadError}}, nil
+	ValidationResult := core.ValidateParams(input, []string{"username", "password", "endpoint"})
+	if !ValidationResult.Success {
+		return &core.ApiResourceOutput{Body: ValidationResult}, nil
 	}
-	if jenkinsSource.Username == "" || jenkinsSource.Password == "" || jenkinsSource.Endpoint == "" {
-		return &core.ApiResourceOutput{Body: core.TestResult{Success: false, Message: core.UnsetConnectionError}}, nil
-	}
-	encodedToken := utils.GetEncodedToken(jenkinsSource.Username, jenkinsSource.Password)
+
+	encodedToken := utils.GetEncodedToken(input.Query.Get("username"), input.Query.Get("password"))
 	apiClient := &core.ApiClient{}
 	apiClient.Setup(
-		jenkinsSource.Endpoint,
+		input.Query.Get("endpoint"),
 		map[string]string{
 			"Authorization": fmt.Sprintf("Basic %v", encodedToken),
 		},

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -55,7 +55,7 @@ func (j Jenkins) Execute(options map[string]interface{}, progress chan<- float32
 		return fmt.Errorf("Failed to decode options: %v", err)
 	}
 	j.CleanData()
-	var worker = tasks.NewJenkinsWorker(nil, tasks.NewDeafultJenkinsStorage(lakeModels.Db), op.Host, op.Username, op.Password)
+	var worker = tasks.NewJenkinsWorker(nil, tasks.NewDefaultJenkinsStorage(lakeModels.Db), op.Host, op.Username, op.Password)
 	err = worker.SyncJobs(progress)
 	if err != nil{
 		logger.Error("Fail to sync jobs", err)
@@ -80,6 +80,9 @@ func (plugin Jenkins) RootPkgPath() string {
 
 func (plugin Jenkins) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
+		"test": {
+			"GET": api.TestConnection,
+		},
 		"sources": {
 			"GET":  api.ListSources,
 			"POST": api.PostSource,

--- a/plugins/jenkins/tasks/storage.go
+++ b/plugins/jenkins/tasks/storage.go
@@ -13,7 +13,7 @@ type DefaultJenkinsStorage struct {
 	db *gorm.DB
 }
 
-func NewDeafultJenkinsStorage(db *gorm.DB) *DefaultJenkinsStorage {
+func NewDefaultJenkinsStorage(db *gorm.DB) *DefaultJenkinsStorage {
 	sqlDB, err := db.DB()
 	if err != nil {
 		logger.Error("failed to get sql db", err)

--- a/plugins/jira/api/jira_connections.go
+++ b/plugins/jira/api/jira_connections.go
@@ -20,6 +20,9 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	jiraApiClient := tasks.NewJiraApiClient(jiraSource.Endpoint, jiraSource.BasicAuthEncoded)
 
 	res, err := jiraApiClient.Get("api/3/myself", nil, nil)
+	if err != nil {
+		return nil, err
+	}
 	if res.StatusCode != 200 {
 		return nil, fmt.Errorf("Your connection configuration is invalid for this source: %v", jiraSource.Name)
 	}

--- a/plugins/jira/api/jira_connections.go
+++ b/plugins/jira/api/jira_connections.go
@@ -1,13 +1,33 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/jira/tasks"
 )
 
-func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
-	// Get the source ID from the input
-	// Get the source from the DB
-	// Use endpoint and auth to make a request to JIRA
+type ApiMyselfResponse struct {
+	AccountId   string
+	DisplayName string
+}
 
+func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	jiraSource, err := findSourceByInputQuery(input)
+	if err != nil {
+		return nil, err
+	}
+	jiraApiClient := tasks.NewJiraApiClient(jiraSource.Endpoint, jiraSource.BasicAuthEncoded)
+
+	res, err := jiraApiClient.Get("api/3/myself", nil, nil)
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("Your connection configuration is invalid for this source: %v", jiraSource.Name)
+	}
+	myselfFromApi := &ApiMyselfResponse{}
+
+	err = core.UnmarshalResponse(res, myselfFromApi)
+	if err != nil {
+		return nil, err
+	}
 	return &core.ApiResourceOutput{Body: true}, nil
 }

--- a/plugins/jira/api/jira_connections.go
+++ b/plugins/jira/api/jira_connections.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"github.com/merico-dev/lake/plugins/core"
+)
+
+func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	// Get the source ID from the input
+	// Get the source from the DB
+	// Use endpoint and auth to make a request to JIRA
+
+	return &core.ApiResourceOutput{Body: true}, nil
+}

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -21,14 +21,28 @@ func findSourceByInputParam(input *core.ApiResourceInput) (*models.JiraSource, e
 	if err != nil {
 		return nil, fmt.Errorf("invalid sourceId")
 	}
+	return getJiraSourceById(jiraSourceId)
+}
+func findSourceByInputQuery(input *core.ApiResourceInput) (*models.JiraSource, error) {
+	sourceId := input.Query["sourceId"][0]
+	if sourceId == "" {
+		return nil, fmt.Errorf("missing sourceid")
+	}
+	jiraSourceId, err := strconv.ParseUint(sourceId, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sourceId")
+	}
+	return getJiraSourceById(jiraSourceId)
+}
+
+func getJiraSourceById(id uint64) (*models.JiraSource, error) {
 	jiraSource := &models.JiraSource{}
-	err = lakeModels.Db.First(jiraSource, jiraSourceId).Error
+	err := lakeModels.Db.First(jiraSource, id).Error
 	if err != nil {
 		return nil, err
 	}
 	return jiraSource, nil
 }
-
 func mergeFieldsToJiraSource(jiraSource *models.JiraSource, sources ...map[string]interface{}) error {
 	// decode
 	for _, source := range sources {

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -24,7 +24,10 @@ func findSourceByInputParam(input *core.ApiResourceInput) (*models.JiraSource, e
 	return getJiraSourceById(jiraSourceId)
 }
 func findSourceByInputQuery(input *core.ApiResourceInput) (*models.JiraSource, error) {
-	sourceId := input.Query["sourceId"][0]
+	var sourceId string
+	if len(input.Query) > 0 {
+		sourceId = input.Query["sourceId"][0]
+	}
 	if sourceId == "" {
 		return nil, fmt.Errorf("missing sourceid")
 	}

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -26,7 +26,7 @@ func findSourceByInputParam(input *core.ApiResourceInput) (*models.JiraSource, e
 func findSourceByInputQuery(input *core.ApiResourceInput) (*models.JiraSource, error) {
 	var sourceId string
 	if len(input.Query) > 0 {
-		sourceId = input.Query["sourceId"][0]
+		sourceId = input.Query.Get("sourceId")
 	}
 	if sourceId == "" {
 		return nil, fmt.Errorf("missing sourceid")

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -23,20 +23,6 @@ func findSourceByInputParam(input *core.ApiResourceInput) (*models.JiraSource, e
 	}
 	return getJiraSourceById(jiraSourceId)
 }
-func findSourceByInputQuery(input *core.ApiResourceInput) (*models.JiraSource, error) {
-	var sourceId string
-	if len(input.Query) > 0 {
-		sourceId = input.Query.Get("sourceId")
-	}
-	if sourceId == "" {
-		return nil, fmt.Errorf("missing sourceid")
-	}
-	jiraSourceId, err := strconv.ParseUint(sourceId, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid sourceId")
-	}
-	return getJiraSourceById(jiraSourceId)
-}
 
 func getJiraSourceById(id uint64) (*models.JiraSource, error) {
 	jiraSource := &models.JiraSource{}

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -226,6 +226,9 @@ func (plugin Jira) RootPkgPath() string {
 
 func (plugin Jira) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
+		"test": {
+			"GET": api.TestConnection,
+		},
 		"echo": {
 			"POST": func(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 				return &core.ApiResourceOutput{Body: input.Body}, nil

--- a/utils/token.go
+++ b/utils/token.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+func GetEncodedToken(username string, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", username, password)))
+}


### PR DESCRIPTION
Fixes https://github.com/merico-dev/lake/issues/667

## Questions

So the first question here is: "Do we make it mandatory to include a /test route?"

1. Yes since every plugin needs it
2. No, just allow it to be added or not. Since the front end can still call this route and if a 404 comes back, the UI just disables the test connection button and gives a message to the user that says "Not implemented, please contact the plugin maintainer"

Can we enforce the plugin maintainer to make this route?

No. Since they can just write a route that always returns true to bypass this rule.

## Design

So I have decided that the only thing we need to do for this ticket is to simply add 

```
func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandler {
	return map[string]map[string]core.ApiResourceHandler{
		"test": {
			"GET": api.TestConnection,
		},
```

To all current plugins. @klesh says that the architecture may change anyway and this will solve the current problem. 