### PR TITLE
feat: only compile the plugins you want

### DIFF
--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -2,7 +2,9 @@
 # Change this if you only want to complile the plugin you are working on
 
 # If you want to use this, you neec to run `LOCAL=true make dev`
-PLUGIN_TO_COMPILE=merico-analysis-engine # this must be all or the name of the plugin
+# to compile all plugins `make dev`
+
+PLUGIN_TO_COMPILE=merico-analysis-engine # this must be the name of the plugin folder
 
 set -e
 
@@ -15,11 +17,6 @@ if [ "$LOCAL" == "true" ]; then
     NAME=$(basename $PLUG)
 
     if [ "$NAME" == "$PLUGIN_TO_COMPILE" ]; then
-        echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
-        go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
-    fi
-
-    if [ "$PLUGIN_TO_COMPILE" == "all" ]; then
         echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
         go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
     fi

--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -11,6 +11,8 @@ PLUGIN_OUTPUT_DIR=$SCRIPT_DIR/../bin/plugins
 for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
   NAME=$(basename $PLUG)
 
+  echo $NAME
+  echo $PLUGIN_TO_COMPILE
   if [ "$NAME" == "$PLUGIN_TO_COMPILE" ]; then
       echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
       go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go

--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Change this if you only want to complile the plugin you are working on
+PLUGIN_TO_COMPILE=all # this must be all or the name of the plugin
 
 set -e
 
@@ -6,9 +8,16 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 PLUGIN_SRC_DIR=$SCRIPT_DIR/../plugins
 PLUGIN_OUTPUT_DIR=$SCRIPT_DIR/../bin/plugins
 
-
 for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
   NAME=$(basename $PLUG)
-  echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
-  go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+
+  if [ "$NAME" == "$PLUGIN_TO_COMPILE" ]; then
+      echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
+      go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+  fi
+
+  if [ "$PLUGIN_TO_COMPILE" == "all" ]; then
+      echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
+      go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+  fi
 done

--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Change this if you only want to complile the plugin you are working on
-PLUGIN_TO_COMPILE=all # this must be all or the name of the plugin
+
+# If you want to use this, you neec to run `LOCAL=true make dev`
+PLUGIN_TO_COMPILE=merico-analysis-engine # this must be all or the name of the plugin
 
 set -e
 
@@ -8,18 +10,25 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 PLUGIN_SRC_DIR=$SCRIPT_DIR/../plugins
 PLUGIN_OUTPUT_DIR=$SCRIPT_DIR/../bin/plugins
 
-for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
-  NAME=$(basename $PLUG)
+if [ "$LOCAL" == "true" ]; then
+  for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
+    NAME=$(basename $PLUG)
 
-  echo $NAME
-  echo $PLUGIN_TO_COMPILE
-  if [ "$NAME" == "$PLUGIN_TO_COMPILE" ]; then
-      echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
-      go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
-  fi
+    if [ "$NAME" == "$PLUGIN_TO_COMPILE" ]; then
+        echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
+        go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+    fi
 
-  if [ "$PLUGIN_TO_COMPILE" == "all" ]; then
-      echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
-      go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
-  fi
-done
+    if [ "$PLUGIN_TO_COMPILE" == "all" ]; then
+        echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
+        go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+    fi
+  done
+else
+  for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
+    NAME=$(basename $PLUG)
+
+    echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so"
+    go build -buildmode=plugin "$@" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go
+  done
+fi


### PR DESCRIPTION
Fixes: https://github.com/merico-dev/lake/issues/487

## Problem

On my computer, it takes me a long time to compile all plugins. I need a faster way to develop. Most times I only work in one plugin at a time and the re-comilation takes up too much of my day.

## Solution 

Everything will work as before here. All you have to do is run `make dev`

However, if you are only working in one plugin, you can now update this line in `scripts/compile-plugins.sh`

`PLUGIN_TO_COMPILE=all` for all plugins as before

`PLUGIN_TO_COMPILE=github` for only github

<img width="763" alt="Screen Shot 2021-11-23 at 11 17 38 AM" src="https://user-images.githubusercontent.com/3011407/143051417-ad735660-b46a-4e07-ada9-2ef057b1d704.png">

