### PR TITLE
feat: pipeline api

### DIFF
--- a/api/pipelines/pipelines.go
+++ b/api/pipelines/pipelines.go
@@ -1,0 +1,112 @@
+package pipelines
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/services"
+)
+
+/*
+Create and run a new pipeline
+POST /pipelines
+{
+	"name": "name-of-pipeline",
+	"tasks": [
+		[ {"plugin": "gitlab", ...}, {"plugin": "jira"} ],
+		[ {"plugin": "gitlabdomain", ...}, {"plugin": "jiradomain"} ],
+	]
+}
+*/
+func Post(ctx *gin.Context) {
+	newPipeline := &models.NewPipeline{}
+
+	err := ctx.MustBindWith(newPipeline, binding.JSON)
+	if err != nil {
+		logger.Error("post /pipeline failed", err)
+		ctx.JSON(http.StatusBadRequest, err)
+		return
+	}
+
+	pipeline, err := services.CreatePipeline(newPipeline)
+	// Return all created tasks to the User
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, err)
+		return
+	}
+
+	go func() {
+		_ = services.RunPipeline(pipeline.ID)
+	}()
+	ctx.JSON(http.StatusCreated, pipeline)
+}
+
+/*
+Get list of pipelines
+GET /pipelines?status=TASK_RUNNING&pending=1&page=1&=pagesize=10
+{
+	"pipelines": [
+		{"id": 1, "name": "test-pipeline", ...}
+	],
+	"count": 5
+}
+*/
+func Index(ctx *gin.Context) {
+	var query services.PipelineQuery
+	err := ctx.BindQuery(&query)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	pipelines, count, err := services.GetPipelines(&query)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"pipelines": pipelines, "count": count})
+}
+
+/*
+Get detail of a pipeline
+GET /pipelines/:pipelineId
+{
+	"id": 1,
+	"name": "test-pipeline",
+	...
+}
+*/
+func Get(ctx *gin.Context) {
+	pipelineId := ctx.Param("pipelineId")
+	id, err := strconv.ParseUint(pipelineId, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, "invalid id")
+		return
+	}
+	pipeline, err := services.GetPipeline(id)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx.JSON(http.StatusOK, pipeline)
+}
+
+/*
+Cancel a pending pipeline
+DELETE /pipelines/:pipelineId
+*/
+func Delete(ctx *gin.Context) {
+	pipelineId := ctx.Param("pipelineId")
+	id, err := strconv.ParseUint(pipelineId, 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, "invalid id")
+		return
+	}
+	err = services.CancelPipeline(id)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, err.Error())
+	}
+}

--- a/api/router.go
+++ b/api/router.go
@@ -6,16 +6,18 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/merico-dev/lake/api/env"
+	"github.com/merico-dev/lake/api/pipelines"
 	"github.com/merico-dev/lake/api/task"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/services"
 )
 
 func RegisterRouter(r *gin.Engine) {
-	r.POST("/task", task.Post)
-	r.GET("/task", task.Get)
-	r.GET("/task/pending", task.GetPending)
-	r.DELETE("/task/:taskId", task.Delete)
+	r.GET("/pipelines", pipelines.Index)
+	r.GET("/pipelines/:pipelineId", pipelines.Get)
+	r.POST("/pipelines", pipelines.Post)
+	r.DELETE("/pipelines/:pipelineId", pipelines.Delete)
+	r.GET("/pipelines/:pipelineId/tasks", task.Index)
 	r.POST("/env", env.Set)
 	r.GET("/env", env.Get)
 

--- a/api/task/task.go
+++ b/api/task/task.go
@@ -5,64 +5,39 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
-	"github.com/merico-dev/lake/logger"
-	"github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/services"
 )
 
-func Post(ctx *gin.Context) {
-	// We use a 2D array because the request body must be an array of a set of tasks
-	// to be executed concurrently, while each set is to be executed sequentially.
-	var data [][]services.NewTask
-
-	err := ctx.MustBindWith(&data, binding.JSON)
-	if err != nil {
-		logger.Error("", err)
-		ctx.JSON(http.StatusBadRequest, "You must send down an array of objects")
-		return
-	}
-
-	tasks := services.CreateTasksInDBFromJSON(data)
-	// Return all created tasks to the User
-	ctx.JSON(http.StatusCreated, tasks)
-
-	go func() {
-		err := services.RunAllTasks(data, tasks)
-		if err != nil {
-			_ = ctx.AbortWithError(http.StatusInternalServerError, err)
-		}
-	}()
+/*
+Get list of pipelines
+GET /pipelines/pipeline:id/tasks?status=TASK_RUNNING&pending=1&page=1&=pagesize=10
+{
+	"tasks": [
+		{"id": 1, "plugin": "", ...}
+	],
+	"count": 5
 }
-
-func Get(ctx *gin.Context) {
+*/
+func Index(ctx *gin.Context) {
 	var query services.TaskQuery
 	err := ctx.BindQuery(&query)
 	if err != nil {
-		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		_ = ctx.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	err = ctx.BindUri(&query)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 	tasks, count, err := services.GetTasks(&query)
 	if err != nil {
-		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+		_ = ctx.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks, "count": count})
 }
-func GetPending(ctx *gin.Context) {
-	var query services.TaskQuery
-	err := ctx.BindQuery(&query)
-	if err != nil {
-		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
-	tasks, err := services.GetPendingTasks()
-	if err != nil {
-		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
-		return
-	}
-	ctx.JSON(http.StatusOK, gin.H{"tasks": tasks})
-}
+
 func Delete(ctx *gin.Context) {
 	taskId := ctx.Param("taskId")
 	id, err := strconv.ParseUint(taskId, 10, 64)
@@ -73,11 +48,5 @@ func Delete(ctx *gin.Context) {
 	err = services.CancelTask(id)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, err.Error())
-		return
-	} else {
-		err = models.Db.Model(&models.Task{}).Where("id = ?", id).Update("status", "CANCELLED").Error
-		if err != nil {
-			logger.Error("Could not upsert: ", err)
-		}
 	}
 }

--- a/cmd/lake-cli/README.md
+++ b/cmd/lake-cli/README.md
@@ -22,10 +22,10 @@ go install github.com/merico-dev/lake/cmd/lake-cli
 ```shell
 # trigger lake api
 # cron schedule defined at https://pkg.go.dev/github.com/robfig/cron#hdr-Predefined_schedules
-$ lake-cli api task -m POST --body "[[{\"plugin\":\"jira\", \"options\": {\"boardId\": 8}}]]" --cron "@hourly"
+$ lake-cli api pipeline -m POST --body "{\"name\":\"sync-hourly\", \"tasks\":[[{\"plugin\":\"jira\", \"options\": {\"boardId\": 8}}]]}" --cron "@hourly"
 
 # trigger lake api, and read request body from file
-$ lake-cli api task -m POST --body ./req.json
+$ lake-cli api pipeline -m POST --body ./req.json
 
 # create lake plugin (TODO)
 $ lake-cli plugin init -o ./plugin --name jenkins

--- a/cmd/lake-cli/api/client.go
+++ b/cmd/lake-cli/api/client.go
@@ -54,7 +54,7 @@ func (o *apiOptions) Validate(cmd *cobra.Command, args []string) error {
 		return errors.New("endpoint required, using like this: lake-cli api {endpoint}")
 	}
 	var supportedEndpoints = make(map[string]bool)
-	supportedEndpoints["task"] = true
+	supportedEndpoints["pipeline"] = true
 	var endpoint = args[0]
 	if support, ok := supportedEndpoints[endpoint]; !support || !ok {
 		return fmt.Errorf("unsupported endpoint %s", endpoint)

--- a/devops/sync/docker-compose.yml
+++ b/devops/sync/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     volumes:
       - ./req.json:/bin/app/req.json
     # This command will request task api every 60 mins 
-    command: lake-cli api task -m POST --cron "@every 60m" --body ./req.json 
+    command: lake-cli api pipeline -m POST --cron "@every 60m" --body ./req.json 
     network_mode: host

--- a/devops/sync/req.json
+++ b/devops/sync/req.json
@@ -1,28 +1,31 @@
-[
-  [
-    {
-      "plugin": "jira",
-      "Options": {
-        "boardId": 8,
-        "sourceId": 1
-      }
-    },
-    {
-      "plugin": "gitlab",
-      "Options": {
-        "projectId": 8967944
-      }
-    },
-    {
-      "plugin": "jenkins",
-      "Options": {}
-    },
-    {
-      "Plugin": "github",
-      "Options": {
-        "repositoryName": "lake",
-        "owner": "merico-dev"
-      }
-    }
-  ]
-]
+{
+    "name": "cron-sync",
+    "tasks": [
+        [
+            {
+                "plugin": "jira",
+                "Options": {
+                    "boardId": 8,
+                    "sourceId": 1
+                }
+            },
+            {
+                "plugin": "gitlab",
+                "Options": {
+                    "projectId": 8967944
+                }
+            },
+            {
+                "plugin": "jenkins",
+                "Options": {}
+            },
+            {
+                "Plugin": "github",
+                "Options": {
+                    "repositoryName": "lake",
+                    "owner": "merico-dev"
+                }
+            }
+        ]
+    ]
+}

--- a/models/domainlayer/domainlayer.go
+++ b/models/domainlayer/domainlayer.go
@@ -39,7 +39,6 @@ func (plugin DomainLayer) Description() string {
 }
 
 func (plugin DomainLayer) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	close(progress)
 	return nil
 }
 

--- a/models/domainlayer/okgen/originkey_generator_test.go
+++ b/models/domainlayer/okgen/originkey_generator_test.go
@@ -19,7 +19,6 @@ func (f *FooPlugin) Init() {
 }
 
 func (f *FooPlugin) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	close(progress)
 	return nil
 }
 

--- a/models/init.go
+++ b/models/init.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func migrateDB() {
-	err := Db.AutoMigrate(&Task{}, &Notification{})
+	err := Db.AutoMigrate(&Task{}, &Notification{}, &Pipeline{})
 	if err != nil {
 		panic(err)
 	}

--- a/models/notification.go
+++ b/models/notification.go
@@ -3,7 +3,7 @@ package models
 type NotificationType string
 
 const (
-	NotificationTaskSuccess NotificationType = "TaskSuccess"
+	NotificationPipelineStatusChanged NotificationType = "PipelineStatusChanged"
 )
 
 // Notification records notifications sent by lake

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/datatypes"
+)
+
+type Pipeline struct {
+	Model
+	Name          string         `json:"name" gorm:"index"`
+	Tasks         datatypes.JSON `json:"tasks"`
+	TotalTasks    int            `json:"totalTasks"`
+	FinishedTasks int            `json:"finishedTasks"`
+	BeganAt       *time.Time     `json:"beganAt"`
+	FinishedAt    *time.Time     `json:"finishedAt" gorm:"index"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	SpentSeconds  int            `json:"spentSeconds"`
+}
+
+// We use a 2D array because the request body must be an array of a set of tasks
+// to be executed concurrently, while each set is to be executed sequentially.
+type NewPipeline struct {
+	Name  string       `json:"name"`
+	Tasks [][]*NewTask `json:"tasks"`
+}

--- a/models/task.go
+++ b/models/task.go
@@ -1,15 +1,39 @@
 package models
 
 import (
+	"time"
+
 	"gorm.io/datatypes"
+)
+
+const (
+	TASK_CREATED   = "TASK_CREATED"
+	TASK_RUNNING   = "TASK_RUNNING"
+	TASK_COMPLETED = "TASK_COMPLETED"
+	TASK_FAILED    = "TASK_FAILED"
 )
 
 type Task struct {
 	Model
-	Plugin   string         `json:"plugin" gorm:"index"`
-	Options  datatypes.JSON `json:"options"`
-	Status   string         `json:"status"`
-	Message  string         `json:"message"`
-	Progress float32        `json:"progress"`
-	SourceId int64          `json:"source_id" gorm:"index"`
+	Plugin       string         `json:"plugin" gorm:"index"`
+	Options      datatypes.JSON `json:"options"`
+	Status       string         `json:"status"`
+	Message      string         `json:"message"`
+	Progress     float32        `json:"progress"`
+	PipelineId   uint64         `json:"pipelineId" gorm:"index"`
+	PipelineRow  int            `json:"pipelineRow"`
+	PipelineCol  int            `json:"pipelineCol"`
+	BeganAt      *time.Time     `json:"beganAt"`
+	FinishedAt   *time.Time     `json:"finishedAt" gorm:"index"`
+	SpentSeconds int            `json:"spentSeconds"`
+}
+
+type NewTask struct {
+	// Plugin name
+	Plugin string `json:"plugin" binding:"required"`
+	// Options for the plugin task to be triggered
+	Options     map[string]interface{} `json:"options"`
+	PipelineId  uint64                 `json:"-"`
+	PipelineRow int                    `json:"-"`
+	PipelineCol int                    `json:"-"`
 }

--- a/plugins/compound/compound.go
+++ b/plugins/compound/compound.go
@@ -73,7 +73,6 @@ func (plugin Compound) Description() string {
 }
 
 func (plugin Compound) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	close(progress)
 	return nil
 }
 

--- a/plugins/core/hub_test.go
+++ b/plugins/core/hub_test.go
@@ -17,7 +17,6 @@ func (f *Foo) Init() {
 }
 
 func (f *Foo) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	close(progress)
 	return nil
 }
 
@@ -39,7 +38,6 @@ func (b *Bar) Init() {
 }
 
 func (b *Bar) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	close(progress)
 	return nil
 }
 

--- a/plugins/github/README-zh-CN.md
+++ b/plugins/github/README-zh-CN.md
@@ -62,13 +62,18 @@
 ## 示例
 
 ```
-curl --location --request POST 'localhost:8080/task' \
+curl --location --request POST 'localhost:8080/pipelines' \
 --header 'Content-Type: application/json' \
---data-raw '[[{
-    "Plugin": "github",
-    "Options": {
-        "repositoryName": "lake",
-        "owner": "merico-dev"
-    }
-}]]'
+--data-raw '
+{
+    "name": "github 20211126",
+    "tasks": [[{
+        "plugin": "github",
+        "options": {
+            "repositoryName": "lake",
+            "owner": "merico-dev"
+        }
+    }]]
+}
+'
 ```

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -67,13 +67,18 @@ Click **Save Settings** to update additional settings.
 ## Sample Request
 
 ```
-curl --location --request POST 'localhost:8080/task' \
+curl --location --request POST 'localhost:8080/pipelines' \
 --header 'Content-Type: application/json' \
---data-raw '[[{
-    "Plugin": "github",
-    "Options": {
-        "repositoryName": "lake",
-        "owner": "merico-dev"
-    }
-}]]'
+--data-raw '
+{
+    "name": "github 20211126",
+    "tasks": [[{
+        "plugin": "github",
+        "options": {
+            "repositoryName": "lake",
+            "owner": "merico-dev"
+        }
+    }]]
+}
+'
 ```

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -169,9 +169,6 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	}
 
 	progress <- 1
-
-	close(progress)
-
 	return nil
 }
 

--- a/plugins/gitlab/README-zh-CN.md
+++ b/plugins/gitlab/README-zh-CN.md
@@ -63,18 +63,23 @@
 
 ## 收集数据
 
-你可以向 `/task` 发起一个POST请求来触发数据收集。
+你可以向 `/pipelines` 发起一个POST请求来触发数据收集。
 
-    ```
-    curl --location --request POST 'localhost:8080/task' \
-    --header 'Content-Type: application/json' \
-    --data-raw '[[{
-        "plugin": "gitlab",
+```
+curl --location --request POST 'localhost:8080/pipelines' \
+--header 'Content-Type: application/json' \
+--data-raw '
+{
+    "name": "gitlab 20211126",
+    "tasks": [[{
+        "plugin": "github",
         "options": {
             "projectId": <Your gitlab project id>
         }
-    }]]'
-    ```
+    }]]
+}
+'
+```
 
 ## 如何获取 Gitlab Project ID
 

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -62,18 +62,23 @@ Click **Save Settings** to update additional settings.
 
 ## Gathering Data with Gitlab
 
-To collect data, you can make a POST request to `/task`
+To collect data, you can make a POST request to `/pipelines`
 
-    ```
-    curl --location --request POST 'localhost:8080/task' \
-    --header 'Content-Type: application/json' \
-    --data-raw '[[{
-        "plugin": "gitlab",
+```
+curl --location --request POST 'localhost:8080/pipelines' \
+--header 'Content-Type: application/json' \
+--data-raw '
+{
+    "name": "gitlab 20211126",
+    "tasks": [[{
+        "plugin": "github",
         "options": {
             "projectId": <Your gitlab project id>
         }
-    }]]'
-    ```
+    }]]
+}
+'
+```
 
 ## Finding Project Id
 

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -130,7 +130,6 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 		}
 	}
 	progress <- 1
-	close(progress)
 	return nil
 }
 

--- a/plugins/jenkins/tasks/worker.go
+++ b/plugins/jenkins/tasks/worker.go
@@ -36,8 +36,6 @@ func (worker *JenkinsWorker) SyncJobs(progress chan<- float32) error {
 		}
 		progress <- float32((index + 1)) / float32(len(jobs))
 	}
-	close(progress)
-
 	return nil
 }
 

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -217,7 +217,6 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 
 	}
 	logger.Print("end jira plugin execution")
-	close(progress)
 	return nil
 }
 

--- a/plugins/jira/tasks/changelog_converter.go
+++ b/plugins/jira/tasks/changelog_converter.go
@@ -2,33 +2,53 @@ package tasks
 
 import (
 	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
 	"gorm.io/gorm/clause"
 )
 
+type ChangelogItemResult struct {
+	SourceId          uint64 `gorm:"primaryKey"`
+	ChangelogId       uint64 `gorm:"primaryKey"`
+	Field             string `gorm:"primaryKey"`
+	FieldType         string
+	FieldId           string
+	From              string
+	FromString        string
+	To                string
+	ToString          string
+	IssueId           uint64 `gorm:"index"`
+	AuthorAccountId   string
+	AuthorDisplayName string
+	Created           time.Time
+}
+
 func ConvertChangelogs(sourceId uint64, boardId uint64) error {
-
-	jiraChangelog := &jiraModels.JiraChangelog{}
-
-	var c1, c2 *sql.Rows
+	var cursor *sql.Rows
 	var err error
 	defer func() {
-		if c1 != nil {
-			c1.Close()
-		}
-		if c2 != nil {
-			c2.Close()
+		if cursor != nil {
+			cursor.Close()
 		}
 	}()
 	// select all changelogs belongs to the board
-	c1, err = lakeModels.Db.Model(jiraChangelog).
-		Select("jira_changelogs.*").
-		Joins(`left join jira_board_issues on (jira_board_issues.issue_id = jira_changelogs.issue_id)`).
-		Where("jira_board_issues.source_id = ? AND jira_board_issues.board_id = ?", sourceId, boardId).
+	cursor, err = lakeModels.Db.Table("jira_changelog_items").
+		Joins(`left join jira_changelogs on (
+			jira_changelogs.source_id = jira_changelog_items.source_id
+			AND jira_changelogs.changelog_id = jira_changelog_items.changelog_id
+		)`).
+		Joins(`left join jira_board_issues on (
+			jira_board_issues.source_id = jira_changelogs.source_id
+			AND jira_board_issues.issue_id = jira_changelogs.issue_id
+		)`).
+		Select("jira_changelog_items.*, jira_changelogs.*").
+		Where("jira_changelog_items.source_id = ? AND jira_board_issues.board_id = ?", sourceId, boardId).
 		Rows()
 	if err != nil {
 		return err
@@ -37,43 +57,54 @@ func ConvertChangelogs(sourceId uint64, boardId uint64) error {
 	issueOriginKeyGenerator := okgen.NewOriginKeyGenerator(&jiraModels.JiraIssue{})
 	changelogOriginKeyGenerator := okgen.NewOriginKeyGenerator(&jiraModels.JiraChangelogItem{})
 
+	// save in batch
+	size := 1000
+	i := 0
+	batch := make([]ticket.Changelog, size)
+	saveBatch := func() error {
+		err := lakeModels.Db.Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).CreateInBatches(batch[:i], size).Error
+		if err != nil {
+			println("err", err)
+			return err
+		}
+		logger.Info("convert changelog", fmt.Sprintf("%s .. %s", batch[0].OriginKey, batch[i-1].OriginKey))
+		return nil
+	}
+
+	row := &ChangelogItemResult{}
 	// iterate all rows
-	for c1.Next() {
-		err = lakeModels.Db.ScanRows(c1, jiraChangelog)
-		if err != nil {
-			return err
-		}
-
-		var items []jiraModels.JiraChangelogItem
-		err = lakeModels.Db.Where("changelog_id = ?", jiraChangelog.ChangelogId).Find(&items).Error
-		if err != nil {
-			return err
-		}
-		for _, jiraChangelogItem := range items {
+	for cursor.Next() {
+		if i >= size {
+			err = saveBatch()
 			if err != nil {
 				return err
 			}
-			changelog := &ticket.Changelog{
-				DomainEntity: base.DomainEntity{
-					OriginKey: changelogOriginKeyGenerator.Generate(
-						jiraChangelogItem.SourceId,
-						jiraChangelogItem.ChangelogId,
-						jiraChangelogItem.Field,
-					),
-				},
-				IssueOriginKey: issueOriginKeyGenerator.Generate(jiraChangelog.SourceId, jiraChangelog.IssueId),
-				AuthorName:     jiraChangelog.AuthorDisplayName,
-				FieldName:      jiraChangelogItem.Field,
-				From:           jiraChangelogItem.FromString,
-				To:             jiraChangelogItem.ToString,
-				CreatedDate:    jiraChangelog.Created,
-			}
-
-			err = lakeModels.Db.Clauses(clause.OnConflict{UpdateAll: true}).Create(changelog).Error
-			if err != nil {
-				println("err", err)
-				return err
-			}
+			i = 0
+		}
+		err = lakeModels.Db.ScanRows(cursor, row)
+		if err != nil {
+			return err
+		}
+		changelog := &batch[i]
+		changelog.DomainEntity.OriginKey = changelogOriginKeyGenerator.Generate(
+			row.SourceId,
+			row.ChangelogId,
+			row.Field,
+		)
+		changelog.IssueOriginKey = issueOriginKeyGenerator.Generate(row.SourceId, row.IssueId)
+		changelog.AuthorName = row.AuthorDisplayName
+		changelog.FieldName = row.Field
+		changelog.From = row.FromString
+		changelog.To = row.ToString
+		changelog.CreatedDate = row.Created
+		i++
+	}
+	if i > 0 {
+		err = saveBatch()
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -221,7 +221,7 @@ pipeline_new() {
                     }
                 },
                 {
-
+                    "plugin": "jenkins",
                     "options": {}
                 }
             ]

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -231,7 +231,7 @@ pipeline_new() {
 }
 
 pipelines() {
-    curl -v $LAKE_PIPELINE_URL | jq
+    curl -v $LAKE_PIPELINE_URL'?'$1 | jq
 }
 
 pipeline() {
@@ -326,10 +326,6 @@ truncate() {
     echo "SET FOREIGN_KEY_CHECKS=0;"
     echo 'show tables' | mycli local-lake | tail -n +2 | xargs -I{} -n 1 echo "truncate table {};"
     echo "SET FOREIGN_KEY_CHECKS=1;"
-}
-
-pipelines() {
-    curl -v $LAKE_PIPELINE_URL?status=$1 | jq
 }
 
 lint() {

--- a/scripts/pm.sh
+++ b/scripts/pm.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 LAKE_ENDPOINT=${LAKE_ENDPOINT-'http://localhost:8080'}
-LAKE_TASK_URL=$LAKE_ENDPOINT/task
+LAKE_PIPELINE_URL=$LAKE_ENDPOINT/pipelines
 
 debug() {
     $SCRIPT_DIR/compile-plugins.sh -gcflags=all="-N -l"
@@ -196,60 +196,6 @@ jira_statusmapping_list() {
     curl -v "$LAKE_ENDPOINT/plugins/jira/sources/$1/type-mappings/$2/status-mappings" | jq
 }
 
-jira() {
-    curl -v -XPOST $LAKE_TASK_URL --data '
-    [
-        [{
-            "plugin": "jira",
-            "options": {
-                "sourceId": '$1',
-                "boardId": '$2',
-                "tasks": ['"$3"']
-            }
-        }]
-    ]
-    ' | jq
-}
-
-tasks_2d() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON' | jq
-    [
-        [
-            {
-                "plugin": "jira",
-                "options": {
-                    "boardId": 8
-                }
-            },
-            {
-                "plugin": "jenkins",
-                "options": {}
-            }
-        ],
-        [
-            {
-                "plugin": "jenkinsdomain",
-                "options": {}
-            }
-        ]
-    ]
-    JSON
-}
-
-jira_enrich_issues() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
-    [
-        [{
-            "plugin": "jira",
-            "options": {
-                "boardId": 8,
-                "tasks": [ "enrichIssues" ]
-            }
-        }]
-    ]
-    JSON
-}
-
 jira_echo() {
     curl -v -XPOST "$LAKE_ENDPOINT/plugins/jira/echo" --data @- <<'    JSON' | jq
     {
@@ -261,66 +207,117 @@ jira_echo() {
     JSON
 }
 
-all() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
-    [
-            [{
-                "plugin": "gitlab",
-                "options": {
-                    "projectId": 8967944
+pipeline_new() {
+    curl -v -XPOST $LAKE_PIPELINE_URL --data @- <<'    JSON' | jq
+    {
+        "name": "test-all",
+        "tasks": [
+            [
+                {
+                    "plugin": "jira",
+                    "options": {
+                        "sourceId": 1,
+                        "boardId": 8
+                    }
+                },
+                {
+
+                    "options": {}
                 }
-            },
-            {
-                "plugin": "jira",
-                "options": {
-                    "boardId": 8
-                }
-            },
-            {
-                "plugin": "jenkins",
-                "options": {}
-            }]
-    ]
+            ]
+        ]
+    }
     JSON
 }
 
-gitlab() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
-    [
-            [{
-                "plugin": "gitlab",
-                "options": {
-                    "projectId": 8967944,
-                    "tasks": ["collectMrs"]
+pipelines() {
+    curl -v $LAKE_PIPELINE_URL | jq
+}
+
+pipeline() {
+    curl -v $LAKE_PIPELINE_URL/$1 | jq
+}
+
+pipeline_cancel() {
+    curl -v -XDELETE $LAKE_PIPELINE_URL/$1
+}
+
+pipeline_tasks() {
+    curl -v $LAKE_PIPELINE_URL/$1/tasks'?'$2 | jq
+}
+
+jira() {
+    curl -v -XPOST $LAKE_PIPELINE_URL --data '
+    {
+        "name": "test-jira",
+        "tasks": [
+            [
+                {
+                    "plugin": "jira",
+                    "options": {
+                        "sourceId": '$1',
+                        "boardId": '$2',
+                        "tasks": ['"$3"']
+                    }
                 }
-            }]
-    ]
+            ]
+        ]
+    }
+    ' | jq
+}
+
+gitlab() {
+    curl -v -XPOST $LAKE_PIPELINE_URL --data @- <<'    JSON'
+    {
+        "name": "test-gitlab",
+        "tasks": [
+            [
+                {
+                    "plugin": "gitlab",
+                    "options": {
+                        "projectId": 8967944,
+                        "tasks": ["collectMrs"]
+                    }
+                }
+            ]
+        ]
+    }
     JSON
 }
 
 github() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
-    [
-            [{
-                "plugin": "github",
-                "options": {
-                    "repositoryName": "lake",
-                    "owner": "merico-dev",
-                    "tasks": ["collectIssues"]
+    curl -v -XPOST $LAKE_PIPELINE_URL --data @- <<'    JSON'
+    {
+        "name": "test-github",
+        "tasks": [
+            [
+                {
+                    "plugin": "github",
+                    "options": {
+                        "repositoryName": "lake",
+                        "owner": "merico-dev",
+                        "tasks": ["collectIssues"]
+                    }
                 }
-            }]
-    ]
+            ]
+        ]
+    }
     JSON
 }
 
 jenkins() {
-    curl -v -XPOST $LAKE_TASK_URL --data @- <<'    JSON'
-    [
-            [{
-                "plugin": "jenkins",
-                "options": {}
-            }]
-    ]
+    curl -v -XPOST $LAKE_PIPELINE_URL --data @- <<'    JSON'
+    {
+        "name": "test-jenkins",
+        "tasks": [
+            [
+                {
+                    "plugin": "jenkins",
+                    "options": {}
+                }
+            ]
+        ]
+    }
     JSON
 }
 
@@ -331,8 +328,8 @@ truncate() {
     echo "SET FOREIGN_KEY_CHECKS=1;"
 }
 
-tasks() {
-    curl -v $LAKE_TASK_URL?status=$1 | jq
+pipelines() {
+    curl -v $LAKE_PIPELINE_URL?status=$1 | jq
 }
 
 lint() {

--- a/services/notification.go
+++ b/services/notification.go
@@ -30,15 +30,17 @@ func NewNotificationService(endpoint, secret string) *NotificationService {
 	}
 }
 
-type TaskSuccessNotification struct {
-	TaskID     uint64
-	PluginName string
+type PipelineNotification struct {
+	PipelineID uint64
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+	BeganAt    *time.Time
+	FinishedAt *time.Time
+	Status     string
 }
 
-func (n *NotificationService) TaskSuccess(params TaskSuccessNotification) error {
-	return n.sendNotification(models.NotificationTaskSuccess, params)
+func (n *NotificationService) PipelineStatusChanged(params PipelineNotification) error {
+	return n.sendNotification(models.NotificationPipelineStatusChanged, params)
 }
 
 func (n *NotificationService) sendNotification(notificationType models.NotificationType, data interface{}) error {

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -1,0 +1,257 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/merico-dev/lake/config"
+	"github.com/merico-dev/lake/errors"
+	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/models"
+)
+
+var notificationService *NotificationService
+
+type PipelineQuery struct {
+	Status   string `form:"status"`
+	Pending  int    `form:"pending"`
+	Page     int    `form:"page"`
+	PageSize int    `form:"page_size"`
+}
+
+func init() {
+	var notificationEndpoint = config.V.GetString("NOTIFICATION_ENDPOINT")
+	var notificationSecret = config.V.GetString("NOTIFICATION_SECRET")
+	if strings.TrimSpace(notificationEndpoint) != "" {
+		notificationService = NewNotificationService(notificationEndpoint, notificationSecret)
+	}
+	models.Db.Model(&models.Pipeline{}).Where("status = ?", models.TASK_RUNNING).Update("status", models.TASK_FAILED)
+}
+
+func CreatePipeline(newPipeline *models.NewPipeline) (*models.Pipeline, error) {
+	// create pipeline object from posted data
+	pipeline := &models.Pipeline{
+		Name:          newPipeline.Name,
+		FinishedTasks: 0,
+		Status:        models.TASK_CREATED,
+		Message:       "",
+		SpentSeconds:  0,
+	}
+
+	// save pipeline to database
+	err := models.Db.Create(&pipeline).Error
+	if err != nil {
+		logger.Error("create pipline failed", err)
+		return nil, errors.InternalError
+	}
+
+	// create tasks accordingly
+	for i := range newPipeline.Tasks {
+		for j := range newPipeline.Tasks[i] {
+			newTask := newPipeline.Tasks[i][j]
+			newTask.PipelineId = pipeline.ID
+			newTask.PipelineRow = i + 1
+			newTask.PipelineCol = j + 1
+			_, err := CreateTask(newTask)
+			if err != nil {
+				logger.Error("create task for pipeline failed", err)
+				return nil, err
+			}
+			// sync task state back to pipeline
+			pipeline.TotalTasks += 1
+		}
+	}
+	if err != nil {
+		logger.Error("save tasks for pipeline failed", err)
+		return nil, errors.InternalError
+	}
+	if pipeline.TotalTasks == 0 {
+		return nil, fmt.Errorf("no task to run")
+	}
+
+	// update tasks state
+	pipeline.Tasks, err = json.Marshal(newPipeline.Tasks)
+	if err != nil {
+		return nil, err
+	}
+	err = models.Db.Model(pipeline).Updates(map[string]interface{}{
+		"total_tasks": pipeline.TotalTasks,
+		"tasks":       pipeline.Tasks,
+	}).Error
+	if err != nil {
+		logger.Error("update pipline state failed", err)
+		return nil, errors.InternalError
+	}
+
+	return pipeline, nil
+}
+
+func GetPipelines(query *PipelineQuery) ([]*models.Pipeline, int64, error) {
+	pipelines := make([]*models.Pipeline, 0)
+	db := models.Db.Model(pipelines).Order("id DESC")
+	if query.Status != "" {
+		db = db.Where("status = ?", query.Status)
+	}
+	if query.Pending > 0 {
+		db = db.Where("finished_at is null")
+	}
+	var count int64
+	err := db.Count(&count).Error
+	if err != nil {
+		return nil, 0, err
+	}
+	if query.Page > 0 && query.PageSize > 0 {
+		offset := query.PageSize * (query.Page - 1)
+		db = db.Limit(query.PageSize).Offset(offset)
+	}
+	err = db.Find(&pipelines).Error
+	if err != nil {
+		return nil, count, err
+	}
+	return pipelines, count, nil
+}
+
+func GetPipeline(pipelineId uint64) (*models.Pipeline, error) {
+	pipeline := &models.Pipeline{}
+	err := models.Db.Find(pipeline, pipelineId).Error
+	if err != nil {
+		return nil, err
+	}
+	return pipeline, nil
+}
+
+func RunPipeline(pipelineId uint64) error {
+	pipeline, err := GetPipeline(pipelineId)
+	if err != nil {
+		return err
+	}
+	// load tasks for pipeline
+	var tasks []*models.Task
+	err = models.Db.Where("pipeline_id = ?", pipeline.ID).Order("pipeline_row, pipeline_col").Find(&tasks).Error
+	if err != nil {
+		return err
+	}
+	// convert to 2d array
+	taskIds := make([][]uint64, 0)
+	for _, task := range tasks {
+		if len(taskIds) < task.PipelineRow {
+			taskIds = append(taskIds, make([]uint64, 0))
+		}
+		taskIds[task.PipelineRow-1] = append(taskIds[task.PipelineRow-1], task.ID)
+	}
+
+	beganAt := time.Now()
+	err = models.Db.Model(pipeline).Updates(map[string]interface{}{
+		"status":   models.TASK_RUNNING,
+		"message":  "",
+		"began_at": beganAt,
+	}).Error
+	if err != nil {
+		return err
+	}
+	// This double for loop executes each set of tasks sequentially while
+	// executing the set of tasks concurrently.
+	finishedTasks := 0
+	rowResults := make(chan error)
+	rowErrors := make([]string, 0)
+	for _, row := range taskIds {
+		rowFinished := 0
+		for _, taskId := range row {
+			taskId := taskId
+			go func() {
+				logger.Info("run task in background ", taskId)
+				rowResults <- RunTask(taskId)
+			}()
+		}
+		for err = range rowResults {
+			finishedTasks++
+			rowFinished++
+			if err != nil {
+				logger.Error("pipeline task failed", err)
+				rowErrors = append(rowErrors, err.Error())
+			}
+			err = models.Db.Model(pipeline).Updates(map[string]interface{}{
+				"status":         models.TASK_RUNNING,
+				"finished_tasks": finishedTasks,
+			}).Error
+			if err != nil {
+				logger.Error("update pipeline state failed", err)
+				rowErrors = append(rowErrors, err.Error())
+			}
+			if rowFinished == len(row) {
+				break
+			}
+		}
+		if len(rowErrors) > 0 {
+			err = fmt.Errorf(strings.Join(rowErrors, "\n"))
+			break
+		}
+	}
+	close(rowResults)
+
+	logger.Info("pipeline finished:", err == nil)
+	// finished, update database
+	finishedAt := time.Now()
+	spentSeconds := finishedAt.Unix() - beganAt.Unix()
+	if err != nil {
+		err = models.Db.Model(pipeline).Updates(map[string]interface{}{
+			"status":        models.TASK_FAILED,
+			"message":       err.Error(),
+			"finished_at":   finishedAt,
+			"spent_seconds": spentSeconds,
+		}).Error
+	} else {
+		err = models.Db.Model(pipeline).Updates(map[string]interface{}{
+			"status":        models.TASK_COMPLETED,
+			"message":       "",
+			"finished_at":   finishedAt,
+			"spent_seconds": spentSeconds,
+		}).Error
+	}
+	if err != nil {
+		return err
+	}
+
+	// notify external webhook
+	return NotifyExternal(pipelineId)
+}
+
+func NotifyExternal(pipelineId uint64) error {
+	if notificationService == nil {
+		return nil
+	}
+	// send notification to an external web endpoint
+	pipeline, err := GetPipeline(pipelineId)
+	if err != nil {
+		return err
+	}
+	err = notificationService.PipelineStatusChanged(PipelineNotification{
+		PipelineID: pipeline.ID,
+		CreatedAt:  pipeline.CreatedAt,
+		UpdatedAt:  pipeline.UpdatedAt,
+		BeganAt:    pipeline.BeganAt,
+		FinishedAt: pipeline.FinishedAt,
+		Status:     pipeline.Status,
+	})
+	if err != nil {
+		logger.Error("Failed to send notification", err)
+		return err
+	}
+	return nil
+}
+
+func CancelPipeline(pipelineId uint64) error {
+	pendingTasks, count, err := GetTasks(&TaskQuery{PipelineId: pipelineId, Pending: 1, PageSize: -1})
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return nil
+	}
+	for _, pendingTask := range pendingTasks {
+		_ = CancelTask(pendingTask.ID)
+	}
+	return err
+}

--- a/services/task.go
+++ b/services/task.go
@@ -4,153 +4,53 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"time"
 
-	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/errors"
 	"github.com/merico-dev/lake/logger"
 	"github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins"
 )
 
-const (
-	TASK_CREATED   = "TASK_CREATED"
-	TASK_COMPLETED = "TASK_COMPLETED"
-	TASK_FAILED    = "TASK_FAILED"
-)
-
-// FIXME: don't use notification service here
-// move it to controller
-var notificationService *NotificationService
 var runningTasks map[uint64]context.CancelFunc
 
-type NewTask struct {
-	// Plugin name
-	Plugin string `json:"plugin" binding:"required"`
-	// Options for the plugin task to be triggered
-	Options map[string]interface{} `json:"options" binding:"required"`
-}
-
 type TaskQuery struct {
-	Status   string `form:"status"`
-	Page     int    `form:"page"`
-	PageSize int    `form:"page_size"`
-	Plugin   string `form:"plugin"`
-	SourceId int64  `form:"source_id"`
+	Status     string `form:"status"`
+	Page       int    `form:"page"`
+	PageSize   int    `form:"page_size"`
+	Plugin     string `form:"plugin"`
+	PipelineId uint64 `form:"pipelineId" uri:"pipelineId"`
+	Pending    int    `form:"pending"`
 }
 
 func init() {
-	var notificationEndpoint = config.V.GetString("NOTIFICATION_ENDPOINT")
-	var notificationSecret = config.V.GetString("NOTIFICATION_SECRET")
-	if strings.TrimSpace(notificationEndpoint) != "" {
-		notificationService = NewNotificationService(notificationEndpoint, notificationSecret)
-	}
-	// FIXME: don't cancel tasks here
-	models.Db.Model(&models.Task{}).Where("status != ?", TASK_COMPLETED).Update("status", TASK_FAILED)
+	// set all previous unfinished tasks to status failed
+	models.Db.Model(&models.Task{}).Where("status = ?", models.TASK_RUNNING).Update("status", models.TASK_FAILED)
 	runningTasks = make(map[uint64]context.CancelFunc)
 }
 
-func CreateTaskInDB(data NewTask) (*models.Task, error) {
-	var sourceId int64
-	if source, ok := data.Options["sourceId"].(float64); ok {
-		sourceId = int64(source)
-		if sourceId == 0 {
-			return nil, fmt.Errorf("invalid sourceId: %d", sourceId)
-		}
-	}
-
-	b, err := json.Marshal(data.Options)
+func CreateTask(newTask *models.NewTask) (*models.Task, error) {
+	b, err := json.Marshal(newTask.Options)
 	if err != nil {
 		return nil, err
 	}
 	task := models.Task{
-		Plugin:   data.Plugin,
-		Options:  b,
-		Status:   TASK_CREATED,
-		Message:  "",
-		SourceId: sourceId,
+		Plugin:      newTask.Plugin,
+		Options:     b,
+		Status:      models.TASK_CREATED,
+		Message:     "",
+		PipelineId:  newTask.PipelineId,
+		PipelineRow: newTask.PipelineRow,
+		PipelineCol: newTask.PipelineCol,
 	}
 	err = models.Db.Save(&task).Error
 	if err != nil {
-		logger.Error("Database error", err)
+		logger.Error("save task failed", err)
 		return nil, errors.InternalError
 	}
 	return &task, nil
 }
 
-func RunTask(task models.Task, data NewTask, taskComplete chan bool) (models.Task, error) {
-	// trigger plugins
-	data.Options["ID"] = task.ID
-	ctx, cancel := context.WithCancel(context.Background())
-	runningTasks[task.ID] = cancel
-	go func() {
-		logger.Info("run task ", task)
-		progress := make(chan float32)
-		go func() {
-			err := plugins.RunPlugin(task.Plugin, data.Options, progress, ctx)
-			if err != nil {
-				logger.Error("Task error", err)
-				task.Status = TASK_FAILED
-				task.Message = err.Error()
-			}
-			err = models.Db.Save(&task).Error
-			if err != nil {
-				logger.Error("Database error", err)
-			}
-		}()
-
-		for p := range progress {
-			task.Progress = p
-			logger.Info("running plugin progress", task)
-			err := models.Db.Save(&task).Error
-			if err != nil {
-				logger.Error("Database error", err)
-			}
-		}
-		task.Status = TASK_COMPLETED
-		err := models.Db.Save(&task).Error
-		if err != nil {
-			logger.Error("Database error", err)
-		}
-		delete(runningTasks, task.ID)
-		// TODO: send notification
-		if notificationService != nil {
-			err = notificationService.TaskSuccess(TaskSuccessNotification{
-				TaskID:     task.ID,
-				PluginName: task.Plugin,
-				CreatedAt:  task.CreatedAt,
-				UpdatedAt:  task.UpdatedAt,
-			})
-			if err != nil {
-				logger.Error("Failed to send notification", err)
-			}
-		}
-		taskComplete <- true
-	}()
-	return task, nil
-}
-
-func CancelTask(taskId uint64) error {
-	if cancel, ok := runningTasks[taskId]; ok {
-		logger.Info("cancel task ", taskId)
-		cancel()
-		delete(runningTasks, taskId)
-	} else {
-		return fmt.Errorf("unable to cancel task %v", taskId)
-	}
-	return nil
-}
-
-func GetPendingTasks() ([]models.Task, error) {
-	tasks := make([]models.Task, 0)
-	whereClause := "progress < 1 AND status != 'TASK_COMPLETED'"
-	db := models.Db.Model(&models.Task{}).Where(whereClause).Order("id DESC")
-	err := db.Debug().Find(&tasks)
-	if err != nil {
-		return tasks, nil
-	}
-	return tasks, nil
-}
 func GetTasks(query *TaskQuery) ([]models.Task, int64, error) {
 	db := models.Db.Model(&models.Task{}).Order("id DESC")
 	if query.Status != "" {
@@ -159,8 +59,11 @@ func GetTasks(query *TaskQuery) ([]models.Task, int64, error) {
 	if query.Plugin != "" {
 		db = db.Where("plugin = ?", query.Plugin)
 	}
-	if query.SourceId != 0 {
-		db = db.Where("source_id = ?", query.SourceId)
+	if query.PipelineId > 0 {
+		db = db.Where("pipeline_id = ?", query.PipelineId)
+	}
+	if query.Pending > 0 {
+		db = db.Where("finished_at is null")
 	}
 	var count int64
 	err := db.Count(&count).Error
@@ -179,43 +82,104 @@ func GetTasks(query *TaskQuery) ([]models.Task, int64, error) {
 	return tasks, count, nil
 }
 
-func CreateTasksInDBFromJSON(data [][]NewTask) [][]models.Task {
-	// create all the tasks in the db without running the tasks
-	var tasks [][]models.Task
-
-	for i := 0; i < len(data); i++ {
-		var tasksToAppend []models.Task
-		for j := 0; j < len(data[i]); j++ {
-			task, _ := CreateTaskInDB(data[i][j])
-			tasksToAppend = append(tasksToAppend, *task)
-		}
-		tasks = append(tasks, tasksToAppend)
+func GetTask(taskId uint64) (*models.Task, error) {
+	task := &models.Task{}
+	err := models.Db.Find(task, taskId).Error
+	if err != nil {
+		return nil, err
 	}
-
-	return tasks
+	return task, nil
 }
 
-func RunAllTasks(data [][]NewTask, tasks [][]models.Task) (err error) {
-	// This double for loop executes each set of tasks sequentially while
-	// executing the set of tasks concurrently.
-	// for _, array := range data {
-	for i := 0; i < len(data); i++ {
+// RunTask guarantees database is update even if it panicked, and the error will be returned to caller
+func RunTask(taskId uint64) error {
+	task, err := GetTask(taskId)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("task: %v", task)
+	if task.Status != models.TASK_CREATED {
+		return fmt.Errorf("invalid task status")
+	}
 
-		taskComplete := make(chan bool)
-		count := 0
-		// for _, taskFromRequest := range array {
-		for j := 0; j < len(data[i]); j++ {
-			_, err := RunTask(tasks[i][j], data[i][j], taskComplete)
+	// for task cancelling
+	ctx, cancel := context.WithCancel(context.Background())
+	runningTasks[taskId] = cancel
+
+	progress := make(chan float32)
+	var options map[string]interface{}
+	err = json.Unmarshal(task.Options, &options)
+	if err != nil {
+		return err
+	}
+
+	// run in new thread so we can track progress asynchronously
+	go func() {
+		beganAt := time.Now()
+		// make sure task status always correct even if it panicked
+		defer func() {
+			delete(runningTasks, task.ID)
+			close(progress)
+			if r := recover(); r != nil {
+				var ok bool
+				if err, ok = r.(error); !ok {
+					err = fmt.Errorf("run task failed: %v", r)
+				}
+			}
+			finishedAt := time.Now()
+			spentSeconds := finishedAt.Unix() - beganAt.Unix()
 			if err != nil {
-				return err
+				err = models.Db.Model(task).Updates(map[string]interface{}{
+					"status":        models.TASK_FAILED,
+					"message":       err.Error(),
+					"finished_at":   finishedAt,
+					"spent_seconds": spentSeconds,
+				}).Error
+			} else {
+				err = models.Db.Model(task).Updates(map[string]interface{}{
+					"status":        models.TASK_COMPLETED,
+					"message":       "",
+					"finished_at":   finishedAt,
+					"spent_seconds": spentSeconds,
+				}).Error
 			}
+		}()
+		// start execution
+		logger.Info("start executing task ", task.ID)
+		err = models.Db.Model(task).Updates(map[string]interface{}{
+			"status":   models.TASK_RUNNING,
+			"message":  "",
+			"began_at": beganAt,
+		}).Error
+		if err != nil {
+			logger.Error("update task state failed", err)
+			return
 		}
-		for range taskComplete {
-			count++
-			if count == len(data[i]) {
-				close(taskComplete)
-			}
+		err = plugins.RunPlugin(task.Plugin, options, progress, ctx)
+	}()
+
+	// read progress from working thread and save into database
+	for p := range progress {
+		logger.Info("running plugin progress", fmt.Sprintf(" %d %s %f%%", task.ID, task.Plugin, p*100))
+		err = models.Db.Model(task).Updates(map[string]interface{}{
+			"progress": p,
+		}).Error
+		if err != nil {
+			logger.Error("save task progress failed", err)
+			return err
 		}
+	}
+
+	return err
+}
+
+func CancelTask(taskId uint64) error {
+	if cancel, ok := runningTasks[taskId]; ok {
+		logger.Info("cancel task ", taskId)
+		cancel()
+		delete(runningTasks, taskId)
+	} else {
+		return fmt.Errorf("unable to cancel task %v", taskId)
 	}
 	return nil
 }

--- a/test/api/task/task_test.go
+++ b/test/api/task/task_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,7 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/magiconair/properties/assert"
 	"github.com/merico-dev/lake/api"
-	"github.com/merico-dev/lake/utils"
+	"github.com/merico-dev/lake/models"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -26,16 +27,24 @@ func TestNewTask(t *testing.T) {
 	testObj.On("CreateTask").Return(true, nil)
 
 	w := httptest.NewRecorder()
-	params := strings.NewReader(`[[{ "plugin": "jira", "options": { "host": "www.jira.com" } }]]`)
-	req, _ := http.NewRequest("POST", "/task", params)
+	params := strings.NewReader(`{"name": "hello", "tasks": [[{ "plugin": "jira", "options": { "host": "www.jira.com" } }]]}`)
+	req, _ := http.NewRequest("POST", "/pipelines", params)
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, w.Code, http.StatusCreated)
 	resp := w.Body.String()
-	tasks, err := utils.JsonToMap(resp)
+	var pipeline models.Pipeline
+	err := json.Unmarshal([]byte(resp), &pipeline)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, tasks[0][0]["plugin"], "jira")
+	assert.Equal(t, pipeline.Name, "hello")
+
+	var tasks [][]*models.NewTask
+	err = json.Unmarshal(pipeline.Tasks, &tasks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, tasks[0][0].Plugin, "jira")
 }

--- a/utils/json.go
+++ b/utils/json.go
@@ -1,9 +1,0 @@
-package utils
-
-import "encoding/json"
-
-func JsonToMap(jsonString string) ([][]map[string]interface{}, error) {
-	m := make([][]map[string]interface{}, 999)
-	err := json.Unmarshal([]byte(jsonString), &m)
-	return m, err
-}


### PR DESCRIPTION
# Summary

- [x] Coding
- [x] Documentation
- [x] config-ui triggers page updation
- [x] `lake-cli` updation

# Step to verify:

**Too many files were involved, you may like to review by commit**

1. create a pipeline `scripts/pm.sh pipeline_new` , this is expected to fail. because `gitlabdomain` doesn't exist
2. list pipelines `scripts/pm.sh pipelines`
3. get pipeline detail `scripts/pm.sh pipeline <id>`
4. cancel pipeline `scripts/pm.sh pipeline_cancel <id>`
5. list tasks of a pipeline `scripts/pm.sh pipeline_tasks <pipeline_id> [querystring]`

### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

### Description
Conceptual:

  1. pipeline represent a user trigger request, which contains multiple
  tasks, it is responsible for task scheduling, to make sure
  sequential/parallel semantics are handled correctly
  2. task represent a plugin execution, it is responsible for task
  execution, to make sure used resources are handled properly, and task
  status is alway right even when `plugin.Execute` panicked.

Breaking Changes:
  1. `close(progress)` was moved to `RunTask` to avoid plugin failed to
  do so.
  2. most of `/task` APIs were deleted, all trigger/tracking should
  adopt new `pipeline` API
  3. `notification` message was redesigned to a more general way, and
  guarantees to post notification even if `pipeline` failed
  4. `services/task.go` was refactored for simplicity


### Does this close any open issues?
Closes #824, #532 
