### PR TITLE
refactor: migrate db just in one place

### DIFF
--- a/models/common/base.go
+++ b/models/common/base.go
@@ -1,4 +1,4 @@
-package models
+package common
 
 import (
 	"regexp"

--- a/models/domainlayer/base/base.go
+++ b/models/domainlayer/base/base.go
@@ -1,8 +1,0 @@
-package base
-
-import "github.com/merico-dev/lake/models"
-
-type DomainEntity struct {
-	OriginKey string `json:"originKey" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
-	models.NoPKModel
-}

--- a/models/domainlayer/code/commit.go
+++ b/models/domainlayer/code/commit.go
@@ -1,12 +1,13 @@
 package code
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Commit struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	RepoId         uint64 `gorm:"index;comment:References the repo the commit belongs to."`
 	Sha            string `gorm:"comment:commit hash"`
 	Additions      int    `gorm:"comment:Added lines of code"`

--- a/models/domainlayer/code/note.go
+++ b/models/domainlayer/code/note.go
@@ -1,14 +1,15 @@
 package code
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Note struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	PrId        uint64 `gorm:"index;comment:References the pull request for this note"`
-	Type        string 
+	Type        string
 	Author      string
 	Body        string
 	Resolvable  bool `gorm:"comment:Is or is not a review comment"`

--- a/models/domainlayer/code/pr.go
+++ b/models/domainlayer/code/pr.go
@@ -1,12 +1,13 @@
 package code
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Pr struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	RepoId      uint64 `gorm:"index"`
 	State       string `gorm:"comment:open/closed or other"`
 	Title       string

--- a/models/domainlayer/code/repo.go
+++ b/models/domainlayer/code/repo.go
@@ -1,11 +1,11 @@
 package code
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Repo struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	Name string `json:"name"`
 	Url  string `json:"url"`
 }

--- a/models/domainlayer/devops/build.go
+++ b/models/domainlayer/devops/build.go
@@ -1,12 +1,13 @@
 package devops
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Build struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	JobOriginKey string `gorm:"index"`
 	Name         string
 	CommitSha    string

--- a/models/domainlayer/devops/job.go
+++ b/models/domainlayer/devops/job.go
@@ -1,10 +1,10 @@
 package devops
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Job struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	Name string
 }

--- a/models/domainlayer/domainlayer.go
+++ b/models/domainlayer/domainlayer.go
@@ -1,54 +1,10 @@
-package main // must be main for plugin entry point
+package domainlayer
 
 import (
-	"context"
-	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/devops"
-	"github.com/merico-dev/lake/models/domainlayer/ticket"
-	"github.com/merico-dev/lake/models/domainlayer/user"
-	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/models/common"
 )
 
-// plugin interface
-type DomainLayer string
-
-func (plugin DomainLayer) Init() {
-	err := lakeModels.Db.AutoMigrate(
-		&user.User{},
-		&code.Repo{},
-		&code.Commit{},
-		&code.Pr{},
-		&code.Note{},
-		&ticket.Board{},
-		&ticket.Issue{},
-		&ticket.Changelog{},
-		&ticket.Sprint{},
-		&ticket.SprintIssue{},
-		&devops.Job{},
-		&devops.Build{},
-		&ticket.Worklog{},
-	)
-	if err != nil {
-		panic(err)
-	}
+type DomainEntity struct {
+	OriginKey string `json:"originKey" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	common.NoPKModel
 }
-
-func (plugin DomainLayer) Description() string {
-	return "Domain Layer"
-}
-
-func (plugin DomainLayer) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	return nil
-}
-
-func (plugin DomainLayer) RootPkgPath() string {
-	return "github.com/merico-dev/lake/plugins/domainlayer"
-}
-
-func (plugin DomainLayer) ApiResources() map[string]map[string]core.ApiResourceHandler {
-	return make(map[string]map[string]core.ApiResourceHandler)
-}
-
-// Export a variable named PluginEntry for Framework to search and load
-var PluginEntry DomainLayer //nolint

--- a/models/domainlayer/ticket/board.go
+++ b/models/domainlayer/ticket/board.go
@@ -1,11 +1,11 @@
 package ticket
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Board struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	Name string
 	Url  string
 }

--- a/models/domainlayer/ticket/changelog.go
+++ b/models/domainlayer/ticket/changelog.go
@@ -1,12 +1,13 @@
 package ticket
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Changelog struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 
 	// collected fields
 	IssueOriginKey string `gorm:"index"`

--- a/models/domainlayer/ticket/issue.go
+++ b/models/domainlayer/ticket/issue.go
@@ -1,12 +1,13 @@
 package ticket
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Issue struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 
 	// collected fields
 	BoardOriginKey           string `gorm:"index"`

--- a/models/domainlayer/ticket/sprint.go
+++ b/models/domainlayer/ticket/sprint.go
@@ -1,12 +1,13 @@
 package ticket
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Sprint struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 
 	// collected fields
 	BoardOriginKey string `gorm:"index"`

--- a/models/domainlayer/ticket/worklog.go
+++ b/models/domainlayer/ticket/worklog.go
@@ -1,12 +1,13 @@
 package ticket
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
 	"time"
+
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type Worklog struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	IssueOriginKey   string `gorm:"index"`
 	BoardOriginKey   string `gorm:"index"`
 	AuthorId         string

--- a/models/domainlayer/user/user.go
+++ b/models/domainlayer/user/user.go
@@ -1,11 +1,11 @@
 package user
 
 import (
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 )
 
 type User struct {
-	base.DomainEntity
+	domainlayer.DomainEntity
 	Name      string
 	Email     string
 	AvatarUrl string

--- a/models/init.go
+++ b/models/init.go
@@ -7,6 +7,10 @@ import (
 	"time"
 
 	"github.com/merico-dev/lake/config"
+	"github.com/merico-dev/lake/models/domainlayer/code"
+	"github.com/merico-dev/lake/models/domainlayer/devops"
+	"github.com/merico-dev/lake/models/domainlayer/ticket"
+	"github.com/merico-dev/lake/models/domainlayer/user"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -39,7 +43,24 @@ func init() {
 }
 
 func migrateDB() {
-	err := Db.AutoMigrate(&Task{}, &Notification{}, &Pipeline{})
+	err := Db.AutoMigrate(
+		&Task{},
+		&Notification{},
+		&Pipeline{},
+		&user.User{},
+		&code.Repo{},
+		&code.Commit{},
+		&code.Pr{},
+		&code.Note{},
+		&ticket.Board{},
+		&ticket.Issue{},
+		&ticket.Changelog{},
+		&ticket.Sprint{},
+		&ticket.SprintIssue{},
+		&devops.Job{},
+		&devops.Build{},
+		&ticket.Worklog{},
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/models/notification.go
+++ b/models/notification.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/merico-dev/lake/models/common"
+
 type NotificationType string
 
 const (
@@ -8,7 +10,7 @@ const (
 
 // Notification records notifications sent by lake
 type Notification struct {
-	Model
+	common.Model
 	Type         NotificationType
 	Endpoint     string
 	Nonce        string

--- a/models/pipeline.go
+++ b/models/pipeline.go
@@ -3,11 +3,12 @@ package models
 import (
 	"time"
 
+	"github.com/merico-dev/lake/models/common"
 	"gorm.io/datatypes"
 )
 
 type Pipeline struct {
-	Model
+	common.Model
 	Name          string         `json:"name" gorm:"index"`
 	Tasks         datatypes.JSON `json:"tasks"`
 	TotalTasks    int            `json:"totalTasks"`

--- a/models/task.go
+++ b/models/task.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/merico-dev/lake/models/common"
 	"gorm.io/datatypes"
 )
 
@@ -14,7 +15,7 @@ const (
 )
 
 type Task struct {
-	Model
+	common.Model
 	Plugin       string         `json:"plugin" gorm:"index"`
 	Options      datatypes.JSON `json:"options"`
 	Status       string         `json:"status"`

--- a/plugins/github/models/github_commit.go
+++ b/plugins/github/models/github_commit.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubCommit struct {
@@ -20,5 +19,5 @@ type GithubCommit struct {
 	Additions      int `gorm:"comment:Added lines of code"`
 	Deletions      int `gorm:"comment:Deleted lines of code"`
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_issue.go
+++ b/plugins/github/models/github_issue.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubIssue struct {
@@ -21,5 +20,5 @@ type GithubIssue struct {
 	GithubCreatedAt time.Time
 	GithubUpdatedAt time.Time
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_issue_comment.go
+++ b/plugins/github/models/github_issue_comment.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubIssueComment struct {
@@ -13,5 +12,5 @@ type GithubIssueComment struct {
 	AuthorUsername  string
 	GithubCreatedAt time.Time
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_issue_event.go
+++ b/plugins/github/models/github_issue_event.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubIssueEvent struct {
@@ -13,5 +12,5 @@ type GithubIssueEvent struct {
 	AuthorUsername  string
 	GithubCreatedAt time.Time
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_issue_label.go
+++ b/plugins/github/models/github_issue_label.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/merico-dev/lake/models"
+import (
+	"github.com/merico-dev/lake/models/common"
+)
 
 // Please note that Issue Labels can also apply to Pull Requests.
 // Pull Requests are considered Issues in GitHub.
@@ -11,5 +13,5 @@ type GithubIssueLabel struct {
 	Description string
 	Color       string
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_issue_label_issue.go
+++ b/plugins/github/models/github_issue_label_issue.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 // This Model is intended to be an association table between issue labels and issues.
@@ -14,5 +14,5 @@ import (
 type GithubIssueLabelIssue struct {
 	IssueLabelId int `gorm:"index"`
 	IssueId      int `gorm:"index"`
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request.go
+++ b/plugins/github/models/github_pull_request.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubPullRequest struct {
@@ -23,5 +22,5 @@ type GithubPullRequest struct {
 	Merged         bool
 	MergedAt       *time.Time
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request_comment.go
+++ b/plugins/github/models/github_pull_request_comment.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubPullRequestComment struct {
@@ -13,5 +12,5 @@ type GithubPullRequestComment struct {
 	AuthorUsername  string
 	GithubCreatedAt time.Time
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request_commit.go
+++ b/plugins/github/models/github_pull_request_commit.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GithubPullRequestCommit struct {
@@ -18,5 +17,5 @@ type GithubPullRequestCommit struct {
 	Message        string
 	Url            string
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request_commit_pull_request.go
+++ b/plugins/github/models/github_pull_request_commit_pull_request.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 // This Model is intended to be an association table between pull request commits and pull requests.
@@ -11,5 +11,5 @@ import (
 type GithubPullRequestCommitPullRequest struct {
 	PullRequestCommitSha string `gorm:"index"`
 	PullRequestId       int    `gorm:"index"`
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_repository.go
+++ b/plugins/github/models/github_repository.go
@@ -1,11 +1,13 @@
 package models
 
-import "github.com/merico-dev/lake/models"
+import (
+	"github.com/merico-dev/lake/models/common"
+)
 
 type GithubRepository struct {
 	GithubId int `gorm:"primaryKey"`
 	Name     string
 	HTMLUrl  string
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/models/github_reviewer.go
+++ b/plugins/github/models/github_reviewer.go
@@ -1,11 +1,13 @@
 package models
 
-import "github.com/merico-dev/lake/models"
+import (
+	"github.com/merico-dev/lake/models/common"
+)
 
 type GithubReviewer struct {
 	GithubId      int `gorm:"primaryKey"`
 	Login         string
 	PullRequestId int
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/github/tasks/commit_converter.go
+++ b/plugins/github/tasks/commit_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
@@ -26,7 +26,7 @@ func ConvertCommits() error {
 }
 func convertToCommitModel(commit *githubModels.GithubCommit) *code.Commit {
 	domainCommit := &code.Commit{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(commit).Generate(commit.Sha),
 		},
 		Sha:            commit.Sha,

--- a/plugins/github/tasks/issue_converter.go
+++ b/plugins/github/tasks/issue_converter.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"fmt"
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
@@ -37,7 +37,7 @@ func convertStateToStatus(state string) string {
 
 func convertToIssueModel(issue *githubModels.GithubIssue) *ticket.Issue {
 	domainIssue := &ticket.Issue{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(issue).Generate(issue.GithubId),
 		},
 		Key:               fmt.Sprint(issue.GithubId),

--- a/plugins/github/tasks/note_converter.go
+++ b/plugins/github/tasks/note_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
@@ -26,7 +26,7 @@ func ConvertNotes() error {
 }
 func convertToNoteModel(note *githubModels.GithubPullRequestComment) *code.Note {
 	domainNote := &code.Note{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(note).Generate(note.GithubId),
 		},
 		PrId:        uint64(note.PullRequestId),

--- a/plugins/github/tasks/pull_request_converter.go
+++ b/plugins/github/tasks/pull_request_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
@@ -26,7 +26,7 @@ func ConvertPullRequests() error {
 }
 func convertToPullRequestModel(pr *githubModels.GithubPullRequest) *code.Pr {
 	domainPr := &code.Pr{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(pr).Generate(pr.GithubId),
 		},
 		RepoId:      uint64(pr.RepositoryId),

--- a/plugins/github/tasks/repo_converter.go
+++ b/plugins/github/tasks/repo_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
@@ -26,7 +26,7 @@ func ConvertRepos() error {
 }
 func convertToRepositoryModel(repository *githubModels.GithubRepository) *code.Repo {
 	domainRepository := &code.Repo{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(repository).Generate(repository.GithubId),
 		},
 		Name: repository.Name,

--- a/plugins/gitlab/models/gitlab_commit.go
+++ b/plugins/gitlab/models/gitlab_commit.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GitlabCommit struct {
@@ -22,5 +21,5 @@ type GitlabCommit struct {
 	Additions      int `gorm:"comment:Added lines of code"`
 	Deletions      int `gorm:"comment:Deleted lines of code"`
 	Total          int `gorm:"comment:Sum of added/deleted lines of code"`
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GitlabMergeRequest struct {
@@ -25,5 +24,5 @@ type GitlabMergeRequest struct {
 	FirstCommentTime *time.Time `gorm:"comment:Time when the first comment occurred"`
 	ReviewRounds     int        `gorm:"comment:How many rounds of review this MR went through"`
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_commit.go
+++ b/plugins/gitlab/models/gitlab_merge_request_commit.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 // This Model is intended to save commits that are associated to a merge request
@@ -27,5 +26,5 @@ type GitlabMergeRequestCommit struct {
 	Additions      int `gorm:"comment:Added lines of code"`
 	Deletions      int `gorm:"comment:Deleted lines of code"`
 	Total          int `gorm:"comment:Sum of added/deleted lines of code"`
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_commit_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request_commit_merge_request.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 // This Model is intended to be an association table between merge request commits and merge requests.
@@ -11,5 +11,5 @@ import (
 type GitlabMergeRequestCommitMergeRequest struct {
 	MergeRequestCommitId string `gorm:"index"`
 	MergeRequestId       int    `gorm:"index"`
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_note.go
+++ b/plugins/gitlab/models/gitlab_merge_request_note.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GitlabMergeRequestNote struct {
@@ -18,5 +17,5 @@ type GitlabMergeRequestNote struct {
 	Resolvable      bool `gorm:"comment:Is or is not review comment"`
 	System          bool `gorm:"comment:Is or is not auto-generated vs. human generated"`
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_pipeline.go
+++ b/plugins/gitlab/models/gitlab_pipeline.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type GitlabPipeline struct {
@@ -18,5 +17,5 @@ type GitlabPipeline struct {
 	StartedAt       *time.Time
 	FinishedAt      *time.Time
 	Coverage        string
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_project.go
+++ b/plugins/gitlab/models/gitlab_project.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/merico-dev/lake/models"
+import (
+	"github.com/merico-dev/lake/models/common"
+)
 
 type GitlabProject struct {
 	GitlabId          int `gorm:"primaryKey"`
@@ -11,5 +13,5 @@ type GitlabProject struct {
 	OpenIssuesCount   int
 	StarCount         int
 
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_reviewer.go
+++ b/plugins/gitlab/models/gitlab_reviewer.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 type GitlabReviewer struct {
@@ -13,5 +13,5 @@ type GitlabReviewer struct {
 	State          string
 	AvatarUrl      string
 	WebUrl         string
-	models.NoPKModel
+	common.NoPKModel
 }

--- a/plugins/gitlab/tasks/commits_converter.go
+++ b/plugins/gitlab/tasks/commits_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
@@ -26,7 +26,7 @@ func ConvertCommits() error {
 }
 func convertToCommitModel(commit *gitlabModels.GitlabCommit) *code.Commit {
 	domainCommit := &code.Commit{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(commit).Generate(commit.GitlabId),
 		},
 		Sha:            commit.GitlabId,

--- a/plugins/gitlab/tasks/note_converter.go
+++ b/plugins/gitlab/tasks/note_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
@@ -26,7 +26,7 @@ func ConvertNotes() error {
 }
 func convertToNoteModel(note *gitlabModels.GitlabMergeRequestNote) *code.Note {
 	domainNote := &code.Note{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(note).Generate(note.GitlabId),
 		},
 		PrId:        uint64(note.MergeRequestId),

--- a/plugins/gitlab/tasks/pr_converter.go
+++ b/plugins/gitlab/tasks/pr_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
@@ -26,7 +26,7 @@ func ConvertPrs() error {
 }
 func convertToPrModel(mr *gitlabModels.GitlabMergeRequest) *code.Pr {
 	domainPr := &code.Pr{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(mr).Generate(mr.GitlabId),
 		},
 		RepoId:      uint64(mr.ProjectId),

--- a/plugins/gitlab/tasks/repo_converter.go
+++ b/plugins/gitlab/tasks/repo_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
@@ -26,7 +26,7 @@ func ConvertRepos() error {
 }
 func convertToRepositoryModel(project *gitlabModels.GitlabProject) *code.Repo {
 	domainRepository := &code.Repo{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(project).Generate(project.GitlabId),
 		},
 		Name: project.Name,

--- a/plugins/jenkins/models/jenkins_build.go
+++ b/plugins/jenkins/models/jenkins_build.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 // JenkinsBuildProps current used jenkins build props
@@ -19,7 +18,7 @@ type JenkinsBuildProps struct {
 
 // JenkinsBuild db entity for jenkins build
 type JenkinsBuild struct {
-	models.Model
+	common.Model
 	JenkinsBuildProps
 	JobID uint64
 }

--- a/plugins/jenkins/models/jenkins_job.go
+++ b/plugins/jenkins/models/jenkins_job.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/merico-dev/lake/models"
+import (
+	"github.com/merico-dev/lake/models/common"
+)
 
 // JenkinsJobProps current used jenkins job props
 type JenkinsJobProps struct {
@@ -11,6 +13,6 @@ type JenkinsJobProps struct {
 
 // JenkinsJob db entity for jenkins job
 type JenkinsJob struct {
-	models.Model
+	common.Model
 	JenkinsJobProps
 }

--- a/plugins/jenkins/tasks/buildconverter.go
+++ b/plugins/jenkins/tasks/buildconverter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/devops"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	jenkinsModels "github.com/merico-dev/lake/plugins/jenkins/models"
@@ -28,7 +28,7 @@ func ConvertBuilds() error {
 			return err
 		}
 		build := &devops.Build{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: buildOriginkeyGenerator.Generate(jenkinsBuild.ID),
 			},
 			JobOriginKey: jobOriginkeyGenerator.Generate(jenkinsBuild.JobID),

--- a/plugins/jenkins/tasks/jobconverter.go
+++ b/plugins/jenkins/tasks/jobconverter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/devops"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	jenkinsModels "github.com/merico-dev/lake/plugins/jenkins/models"
@@ -27,7 +27,7 @@ func ConvertJobs() error {
 			return err
 		}
 		job := &devops.Job{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: jobOriginkeyGenerator.Generate(jenkinsJob.ID),
 			},
 			Name: jenkinsJob.Name,

--- a/plugins/jira/api/jira_issue_status_mapping.go
+++ b/plugins/jira/api/jira_issue_status_mapping.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/merico-dev/lake/models/common"
 	"net/http"
 
 	"github.com/go-playground/validator/v10"
@@ -58,7 +59,7 @@ func mergeFieldsToJiraStatusMapping(
 }
 
 func wrapIssueStatusDuplicateErr(err error) error {
-	if lakeModels.IsDuplicateError(err) {
+	if common.IsDuplicateError(err) {
 		return fmt.Errorf("jira issue status mapping already exists")
 	}
 	return err

--- a/plugins/jira/api/jira_issue_type_mapping.go
+++ b/plugins/jira/api/jira_issue_type_mapping.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/merico-dev/lake/models/common"
 	"net/http"
 
 	"github.com/go-playground/validator/v10"
@@ -53,7 +54,7 @@ func mergeFieldsToJiraTypeMapping(
 }
 
 func wrapIssueTypeDuplicateErr(err error) error {
-	if lakeModels.IsDuplicateError(err) {
+	if common.IsDuplicateError(err) {
 		return fmt.Errorf("jira issue type mapping already exists")
 	}
 	return err

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/merico-dev/lake/models/common"
 	"net/http"
 	"strconv"
 
@@ -73,7 +74,7 @@ func refreshAndSaveJiraSource(jiraSource *models.JiraSource, data map[string]int
 		err = tx.Create(jiraSource).Error
 	}
 	if err != nil {
-		if lakeModels.IsDuplicateError(err) {
+		if common.IsDuplicateError(err) {
 			return fmt.Errorf("jira source with name %s already exists", jiraSource.Name)
 		}
 		return err

--- a/plugins/jira/models/jira_board.go
+++ b/plugins/jira/models/jira_board.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 type JiraBoard struct {
-	models.NoPKModel
+	common.NoPKModel
 	SourceId  uint64 `gorm:"primaryKey"`
 	BoardId   uint64 `gorm:"primaryKey"`
 	ProjectId uint

--- a/plugins/jira/models/jira_changelog.go
+++ b/plugins/jira/models/jira_changelog.go
@@ -1,13 +1,12 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type JiraChangelog struct {
-	models.NoPKModel
+	common.NoPKModel
 
 	// collected fields
 	SourceId          uint64 `gorm:"primaryKey"`
@@ -20,7 +19,7 @@ type JiraChangelog struct {
 }
 
 type JiraChangelogItem struct {
-	models.NoPKModel
+	common.NoPKModel
 
 	// collected fields
 	SourceId    uint64 `gorm:"primaryKey"`

--- a/plugins/jira/models/jira_issue.go
+++ b/plugins/jira/models/jira_issue.go
@@ -1,13 +1,12 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type JiraIssue struct {
-	models.NoPKModel
+	common.NoPKModel
 
 	// collected fields
 	SourceId                 uint64 `gorm:"primaryKey"`

--- a/plugins/jira/models/jira_project.go
+++ b/plugins/jira/models/jira_project.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 type JiraProject struct {
-	models.NoPKModel
+	common.NoPKModel
 
 	// collected fields
 	SourceId uint64 `gorm:"primarykey"`

--- a/plugins/jira/models/jira_source.go
+++ b/plugins/jira/models/jira_source.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 type JiraSource struct {
-	models.Model
+	common.Model
 	Name             string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
 	Endpoint         string `json:"endpoint" validate:"required"`
 	BasicAuthEncoded string `json:"basicAuthEncoded" validate:"required"`

--- a/plugins/jira/models/jira_user.go
+++ b/plugins/jira/models/jira_user.go
@@ -1,11 +1,11 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/models/common"
 )
 
 type JiraUser struct {
-	models.NoPKModel
+	common.NoPKModel
 
 	// collected fields
 	SourceId    uint64 `gorm:"primarykey"`

--- a/plugins/jira/models/jira_worklog.go
+++ b/plugins/jira/models/jira_worklog.go
@@ -1,13 +1,12 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type JiraWorklog struct {
-	models.NoPKModel
+	common.NoPKModel
 	SourceId         uint64 `gorm:"primaryKey"`
 	IssueId          uint64 `gorm:"primarykey"`
 	WorklogId        string `gorm:"primarykey"`

--- a/plugins/jira/models/jiras_print.go
+++ b/plugins/jira/models/jiras_print.go
@@ -1,13 +1,12 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/models/common"
 	"time"
-
-	"github.com/merico-dev/lake/models"
 )
 
 type JiraSprint struct {
-	models.NoPKModel
+	common.NoPKModel
 	SourceId      uint64 `gorm:"primaryKey"`
 	SprintId      uint64 `gorm:"primaryKey"`
 	Self          string

--- a/plugins/jira/tasks/board_converter.go
+++ b/plugins/jira/tasks/board_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
@@ -18,7 +18,7 @@ func ConvertBoard(sourceId uint64, boardId uint64) error {
 	}
 
 	board := &ticket.Board{
-		DomainEntity: base.DomainEntity{
+		DomainEntity: domainlayer.DomainEntity{
 			OriginKey: okgen.NewOriginKeyGenerator(jiraBoard).Generate(jiraBoard.SourceId, boardId),
 		},
 		Name: jiraBoard.Name,

--- a/plugins/jira/tasks/issue_converter.go
+++ b/plugins/jira/tasks/issue_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
@@ -35,7 +35,7 @@ func ConvertIssues(sourceId uint64, boardId uint64) error {
 			return err
 		}
 		issue := &ticket.Issue{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: issueOriginKeyGenerator.Generate(jiraIssue.SourceId, jiraIssue.IssueId),
 			},
 			BoardOriginKey:           boardOriginKey,

--- a/plugins/jira/tasks/sprint_converter.go
+++ b/plugins/jira/tasks/sprint_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
@@ -33,7 +33,7 @@ func ConvertSprint(sourceId uint64, boardId uint64) error {
 			return err
 		}
 		sprint := &ticket.Sprint{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: sprintOriginKeyGenerator.Generate(jiraSprint.SourceId, jiraSprint.SprintId),
 			},
 			BoardOriginKey: boardOriginKey,

--- a/plugins/jira/tasks/user_converter.go
+++ b/plugins/jira/tasks/user_converter.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/user"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
@@ -22,7 +22,7 @@ func ConvertUsers(sourceId uint64) error {
 
 	for _, jiraUser := range jiraUserRows {
 		user := &user.User{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: userOriginKeyGenerator.Generate(jiraUser.SourceId, jiraUser.AccountId),
 			},
 			Name:      jiraUser.Name,

--- a/plugins/jira/tasks/worklog_converter.go
+++ b/plugins/jira/tasks/worklog_converter.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/models/domainlayer/base"
+	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/okgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
@@ -35,7 +35,7 @@ func ConvertWorklog(sourceId uint64, boardId uint64) error {
 			return err
 		}
 		worklog := &ticket.Worklog{
-			DomainEntity: base.DomainEntity{
+			DomainEntity: domainlayer.DomainEntity{
 				OriginKey: worklogOriginKeyGenerator.Generate(jiraWorklog.SourceId, jiraWorklog.IssueId, jiraWorklog.WorklogId),
 			},
 			IssueOriginKey:   issueOriginKeyGenerator.Generate(jiraWorklog.SourceId, jiraWorklog.IssueId),


### PR DESCRIPTION
# Summary
Put  migrations of `domainlayer` tables  and framework tables in the same file(`models/init.go`)

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
