### PR TITLE
fix: add npm install to make configure-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ configure:
 	docker-compose up config-ui
 
 configure-dev:
-	cd config-ui; npm start;
+	cd config-ui; npm install; npm start;
 
 compose:
 	docker-compose up grafana


### PR DESCRIPTION
# Summary

`make configure-dev` needs to run `npm install` first before `npm start`.