### PR TITLE
fix: duplicate data fix gitlab / github

### DIFF
--- a/plugins/github/models/github_issue_label_issue.go
+++ b/plugins/github/models/github_issue_label_issue.go
@@ -12,7 +12,7 @@ import (
 // an Issue Id can be considered a Pull Request Id also.
 
 type GithubIssueLabelIssue struct {
-	IssueLabelId int `gorm:"index"`
-	IssueId      int `gorm:"index"`
+	IssueLabelId int `gorm:"primaryKey;autoIncrement:false"`
+	IssueId      int `gorm:"primaryKey;autoIncrement:false"`
 	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request_commit_pull_request.go
+++ b/plugins/github/models/github_pull_request_commit_pull_request.go
@@ -9,7 +9,7 @@ import (
 // (which are commits associated to a pull request) and pull requests.
 
 type GithubPullRequestCommitPullRequest struct {
-	PullRequestCommitSha string `gorm:"index"`
-	PullRequestId       int    `gorm:"index"`
+	PullRequestCommitSha string `gorm:"primaryKey"`
+	PullRequestId        int    `gorm:"primaryKey;autoIncrement:false"`
 	common.NoPKModel
 }

--- a/plugins/gitlab/models/gitlab_merge_request_commit_merge_request.go
+++ b/plugins/gitlab/models/gitlab_merge_request_commit_merge_request.go
@@ -9,7 +9,7 @@ import (
 // (which are commits associated to a merge request) and merge requests.
 
 type GitlabMergeRequestCommitMergeRequest struct {
-	MergeRequestCommitId string `gorm:"index"`
-	MergeRequestId       int    `gorm:"index"`
+	MergeRequestCommitId string `gorm:"primaryKey"`
+	MergeRequestId       int    `gorm:"primaryKey;autoIncrement:false"`
 	common.NoPKModel
 }


### PR DESCRIPTION
### Description
The issue raised in #916 is due to the fact that GORM updates records on conflict, but because the models in question were not declared as composite primary keys, there was no conflict, hence it defaulted to Create new records, causing duplicates. Changing ```gorm:"index"``` to ```gorm:"primaryKey"``` on the necessary columns causes the conflict, thus no longer creates duplicates. I've tested this out and believe that it solves the issue.

### Does this close any open issues?
Closes #916 

### Current Behavior
Duplicate records are stored on 3 tables because of their model definition.

### New Behavior
No more duplicate records are stored on these tables.

### Screenshots
After consecutive collections:
This shows there are no duplicate records with the same two "id" fields:
![image](https://user-images.githubusercontent.com/27032263/144312103-f7a368d0-f3fe-4a18-b282-a2ce04de30f7.png)

This shows the example row in the issue #916 has only one row:
![image](https://user-images.githubusercontent.com/27032263/144312415-f03ce365-321c-4225-9f5c-9ee1b3e2bdf1.png)

### Additional context
Thanks to @likyh for raising the issue.