### PR TITLE
fix: remove `wait` so offline page can show its charm

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -1,10 +1,10 @@
 FROM nginx:latest
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
-RUN chmod +x /wait
+#ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
+#RUN chmod +x /wait
 RUN rm /etc/nginx/conf.d/default.conf
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf.tpl
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY ./dist/* ./
 EXPOSE 80 443
-CMD /wait && envsubst '${DEVLAKE_ENDPOINT} ${GRAFANA_ENDPOINT}' < /etc/nginx/conf.d/default.conf.tpl > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'
+CMD envsubst '${DEVLAKE_ENDPOINT} ${GRAFANA_ENDPOINT}' < /etc/nginx/conf.d/default.conf.tpl > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'

--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -1,6 +1,3 @@
-upstream devlake {
-    server ${DEVLAKE_ENDPOINT} fail_timeout=5s max_fails=5;
-}
 server {
   listen 80;
   server_name localhost;
@@ -11,8 +8,13 @@ server {
   }
 
   location /api/ {
+    resolver 127.0.0.11 valid=300s;
+    resolver_timeout 1s;
+    set $target "${DEVLAKE_ENDPOINT}";
     rewrite /api/(.*) /$1  break;
-    proxy_pass http://devlake;
+    proxy_send_timeout 2s;
+    proxy_read_timeout 2s;
+    proxy_pass http://$target;
   }
 
   location /grafana {

--- a/config-ui/src/hooks/useNetworkOfflineMode.jsx
+++ b/config-ui/src/hooks/useNetworkOfflineMode.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 
-function useNetworkOfflineMode (offlineStatus = 504, offlineRoute = '/offline') {
+function useNetworkOfflineMode (offlineStatuses = [502, 504], offlineRoute = '/offline') {
   const history = useHistory()
   const [status, setStatus] = useState()
   const [response, setResponse] = useState()
@@ -12,10 +12,10 @@ function useNetworkOfflineMode (offlineStatus = 504, offlineRoute = '/offline') 
   }, [])
 
   useEffect(() => {
-    if (status && response && status === offlineStatus) {
+    if (status && response && offlineStatuses.includes(status)) {
       history.push(offlineRoute)
     }
-  }, [status, response, offlineStatus, offlineRoute, history])
+  }, [status, response, offlineStatuses, offlineRoute, history])
 
   return {
     handleOfflineMode,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,7 @@ services:
     volumes:
       - ./.env:/app/.env
     depends_on:
-      - grafana
-    environment:
-      WAIT_HOSTS: mysql:3306, grafana:3000   
+      - mysql
   config-ui:
     image: mericodev/config-ui:0.4.0
     ports:
@@ -46,8 +44,8 @@ services:
       - ./.env
     depends_on:
       - devlake
-    environment:
-      WAIT_HOSTS: mysql:3306, grafana:3000, devlake:8080
+    #environment:
+      #- WAIT_HOSTS: mysql:3306, grafana:3000, devlake:8080
 volumes:
   mysql-storage:
   grafana-storage:


### PR DESCRIPTION
# Summary

  `wait` will block nginx, so user wont be able to open `config-ui`,
  thus, user may never see the `/offline` page at all. this fixes the
  problem by removing the `wait` and make nginx be able to start even
  `devlake` is not ready.

# Step to verify
I have already push the latest build to dockhub. so you can verify it by:

1. chage `config-ui` image tag to latest and remove `depends_on` devlake part for `docker-compose.yml`,
2. stop all by `docker-compose down` and launch `config-ui` only by `docker-compose up -d config-ui`
3. open `config-ui` on browser, config-ui should pop up, and click into plugin, wait a few seconds `offline` page should be pop up
4. better to show `offline` page even if user didn't do anything, we can do this on next iter if @e2corporation think this is a good idea.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
