### PR TITLE
feat: remove old binaries when running make dev

### DIFF
--- a/scripts/compile-plugins.sh
+++ b/scripts/compile-plugins.sh
@@ -19,6 +19,9 @@ if [ ! -z "$PLUGIN" ]; then
     fi
   done
 else
+  # When rebuilding from all plugins, clean out old binaries first
+  rm -rf bin/plugins/*
+
   for PLUG in $(find $PLUGIN_SRC_DIR/* -maxdepth 0 -type d -not -name core -not -empty); do
     NAME=$(basename $PLUG)
 


### PR DESCRIPTION
Fixes https://github.com/merico-dev/lake/issues/883

This simply allows users to run `make dev` and clear out old binaries. 

This solves the problem where a user built binaries on a plugin before such as `jiradomain` and now that plugin no longer exists.

This is safe to always run