### PR TITLE
chore: rm extra columns on mrCommits

### DIFF
--- a/plugins/gitlab/models/gitlab_merge_request_commit.go
+++ b/plugins/gitlab/models/gitlab_merge_request_commit.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/merico-dev/lake/models/common"
 	"time"
+
+	"github.com/merico-dev/lake/models/common"
 )
 
 // This Model is intended to save commits that are associated to a merge request
@@ -23,8 +24,5 @@ type GitlabMergeRequestCommit struct {
 	CommitterEmail string
 	CommittedDate  time.Time
 	WebUrl         string
-	Additions      int `gorm:"comment:Added lines of code"`
-	Deletions      int `gorm:"comment:Deleted lines of code"`
-	Total          int `gorm:"comment:Sum of added/deleted lines of code"`
 	common.NoPKModel
 }

--- a/plugins/gitlab/tasks/gitlab_merge_request_commits.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_commits.go
@@ -26,11 +26,6 @@ type GitlabMergeRequestCommit struct {
 	CommitterEmail string           `json:"committer_email"`
 	CommittedDate  core.Iso8601Time `json:"committed_date"`
 	WebUrl         string           `json:"web_url"`
-	Stats          struct {
-		Additions int
-		Deletions int
-		Total     int
-	}
 }
 
 func CollectMergeRequestCommits(projectId int, mr *models.GitlabMergeRequest) error {
@@ -88,9 +83,6 @@ func convertMergeRequestCommit(commit *GitlabMergeRequestCommit) (*models.Gitlab
 		CommitterEmail: commit.CommitterEmail,
 		CommittedDate:  commit.CommittedDate.ToTime(),
 		WebUrl:         commit.WebUrl,
-		Additions:      commit.Stats.Additions,
-		Deletions:      commit.Stats.Deletions,
-		Total:          commit.Stats.Total,
 	}
 	return gitlabMergeRequestCommit, nil
 }


### PR DESCRIPTION
### Description
Just removes unneeded columns from DB model, since we don't get Additions/Deletions from GitLab API on Merge Request _Commits_

### Does this close any open issues?
Closes https://github.com/merico-dev/lake/issues/866
