### PR TITLE
fix: more specific error msg for unauthorized

### DIFF
--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -82,6 +82,10 @@ func (apiClient *ApiClient) SetBeforeFunction(callback ApiClientBeforeRequest) {
 	apiClient.beforeRequest = callback
 }
 
+func (apiClient *ApiClient) SetAfterFunction(callback ApiClientAfterResponse) {
+	apiClient.afterReponse = callback
+}
+
 func (apiClient *ApiClient) SetProxy(proxyUrl string) error {
 	pu, err := url.Parse(proxyUrl)
 	if err != nil {
@@ -149,10 +153,13 @@ func (apiClient *ApiClient) Do(
 				retry += 1
 				continue
 			}
-			return nil, err
 		} else {
 			break
 		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	// after recieve
@@ -163,7 +170,7 @@ func (apiClient *ApiClient) Do(
 		}
 	}
 
-	return res, nil
+	return res, err
 }
 
 func (apiClient *ApiClient) Get(

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -29,6 +29,12 @@ func NewJiraApiClient(endpoint string, auth string) *JiraApiClient {
 		10*time.Second,
 		3,
 	)
+	jiraApiClient.SetAfterFunction(func(res *http.Response) error {
+		if res.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("authentication failed, please check your Basic Auth Token")
+		}
+		return nil
+	})
 	return jiraApiClient
 }
 


### PR DESCRIPTION
# Summary

To provide more specific message for jira api request authentication failure

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description

 jira plugin now report specific msg for unauthorized error instead of msg like #868

### Does this close any open issues?
Related to #868 , Closes #878

### Current Behavior
authentication failure would exhibition message like #868 

### New Behavior
Show authentication fail message for http status 404 from jira api server

### Screenshots
![jira-auth-fail-msg](https://user-images.githubusercontent.com/61080/145391251-876812d0-047c-44a3-a9f6-bedd46dd25bb.png)

