### PR TITLE
feat: disable auth in grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -4,3 +4,8 @@ COPY ./provisioning/datasources /etc/grafana/provisioning/datasources
 COPY ./dashboards /etc/grafana/dashboards
 COPY ./img/grafana_icon.svg /usr/share/grafana/public/img/grafana_icon.svg
 COPY ./img /usr/share/grafana/public/img/lake
+
+# These three lines disable login pages
+ENV GF_AUTH_ANONYMOUS_ENABLED=true
+ENV GF_AUTH_ORG_ROLE=viewer
+ENV GF_AUTH_DISABLE_LOGIN_FORM=true

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,9 @@
+# Grafana for Lake
+
+## How to build this image
+
+`docker build -t mericodev/grafana:x.x.x-test .`
+
+then...
+
+`docker run -d -p 3002:3000 mericodev/grafana:x.x.x-test`


### PR DESCRIPTION
No one has asked for this but I stumbled upon this solution while I was working on something else.

Right now, we always ask users to log into grafana. However since they are hosting it, we don't really care. If they want login, they can enable it.

This allows users to go to grafana directly without login.

I want this in the code but its up to @Startrekzky and @hezyin 