### PR TITLE
feat: ae supports canceling

### DIFF
--- a/plugins/ae/ae.go
+++ b/plugins/ae/ae.go
@@ -40,19 +40,19 @@ func (plugin AE) Execute(options map[string]interface{}, progress chan<- float32
 	}
 
 	progress <- 0.1
-	if err := tasks.CollectProject(projectIdInt); err != nil {
+	if err := tasks.CollectProject(projectIdInt, ctx); err != nil {
 		return fmt.Errorf("could not collect project: %v", err)
 	}
 
 	progress <- 0.25
 
-	if err := tasks.CollectCommits(projectIdInt); err != nil {
+	if err := tasks.CollectCommits(projectIdInt, ctx); err != nil {
 		return fmt.Errorf("could not collect commits: %v", err)
 	}
 
 	progress <- 0.75
 
-	if err := tasks.SetDevEqOnCommits(); err != nil {
+	if err := tasks.SetDevEqOnCommits(ctx); err != nil {
 		return fmt.Errorf("could not enhance commits with AE dev equivalent: %v", err)
 	}
 

--- a/plugins/ae/tasks/ae_commit_collector.go
+++ b/plugins/ae/tasks/ae_commit_collector.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -20,8 +21,8 @@ type AEApiCommit struct {
 	DevEq       int    `json:"dev_eq"`
 }
 
-func CollectCommits(projectId int) error {
-	aeApiClient := CreateApiClient()
+func CollectCommits(projectId int, ctx context.Context) error {
+	aeApiClient := CreateApiClient(ctx)
 	relativePath := fmt.Sprintf("projects/%v/commits", projectId)
 	pageSize := 2000
 	return aeApiClient.FetchWithPagination(relativePath, pageSize,

--- a/plugins/ae/tasks/ae_commit_converter.go
+++ b/plugins/ae/tasks/ae_commit_converter.go
@@ -1,35 +1,45 @@
 package tasks
 
 import (
+	"context"
+
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	aeModels "github.com/merico-dev/lake/plugins/ae/models"
+	"github.com/merico-dev/lake/plugins/core"
 )
 
 // NOTE: This only works on Commits in the Domain layer. You need to run Github or Gitlab collection and Domain layer enrichemnt first.
-func SetDevEqOnCommits() error {
-	var commits []code.Commit
+func SetDevEqOnCommits(ctx context.Context) error {
+	commit := &code.Commit{}
+	aeCommit := &aeModels.AECommit{}
 
 	// Get all the commits from the domain layer
-	err := lakeModels.Db.Find(&commits).Error
+	cursor, err := lakeModels.Db.Model(aeCommit).Rows()
 	if err != nil {
 		return err
 	}
+	defer cursor.Close()
 
 	// Loop over them
-	for _, commit := range commits {
+	for cursor.Next() {
+		// we do a non-blocking checking, this should be applied to all converters from all plugins
+		select {
+		case <-ctx.Done():
+			return core.TaskCanceled
+		default:
+		}
+		// uncomment following line if you want to test out canceling feature for this task
+		//time.Sleep(1 * time.Second)
 
-		// see if there is a match between Commit and AECommit
-		var aeCommit aeModels.AECommit
-		results := lakeModels.Db.Where("hex_sha = ?", commit.Sha).First(&aeCommit)
+		err = lakeModels.Db.ScanRows(cursor, aeCommit)
+		if err != nil {
+			return err
+		}
 
-		// Check to see if a record was found
-		if results.RowsAffected > 0 {
-			commit.DevEq = aeCommit.DevEq
-			err := lakeModels.Db.Save(&commit).Error
-			if err != nil {
-				return err
-			}
+		err := lakeModels.Db.Model(commit).Where("sha = ?", aeCommit.HexSha).Update("dev_eq", aeCommit.DevEq).Error
+		if err != nil {
+			return err
 		}
 	}
 

--- a/plugins/ae/tasks/ae_project_collector.go
+++ b/plugins/ae/tasks/ae_project_collector.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -20,8 +21,8 @@ type ApiProjectResponse struct {
 	AEUpdateTime *time.Time `json:"update_time"`
 }
 
-func CollectProject(projectId int) error {
-	aeApiClient := CreateApiClient()
+func CollectProject(projectId int, ctx context.Context) error {
+	aeApiClient := CreateApiClient(ctx)
 
 	res, err := aeApiClient.Get(fmt.Sprintf("/projects/%v", projectId), nil, nil)
 	if err != nil {

--- a/plugins/core/errors.go
+++ b/plugins/core/errors.go
@@ -1,0 +1,5 @@
+package core
+
+import "fmt"
+
+var TaskCanceled = fmt.Errorf("task got canceled")


### PR DESCRIPTION
# Summary

Make ae plugin supports canceling, both collector and converter.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
The idea is simple:
1. make `api client` supports cancel, so before/after each request, task can be canceled right away as long as `ctx.Context` got passed into `api client` by `SetContext` method correctly.
2. add `cancel checking` in the begining of each loop, so conversion task can be canceled.

![image](https://user-images.githubusercontent.com/61080/145581902-19450d96-787c-4f89-94f0-0a53906eb965.png)

