### PR TITLE
Rename `originkey` to `id`

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:
       DB_DATABASE: lake
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
     - name: setup mysql
       run: |
-        sudo /etc/init.d/mysql start
+        sudo systemctl start mysql.service
         mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
     - name: setup redis
       uses: shogo82148/actions-setup-redis@v1

--- a/api/push/README.md
+++ b/api/push/README.md
@@ -8,7 +8,7 @@ This is a generic API service that gives our users the ability to inject data di
 
 POST to ```localhost:8080/push/:tableName```
 
-Where "tableName" is the name of the table you wish to insert into 
+Where "tableName" is the name of the table you wish to insert into
 For example, "commits" would be ```/push/commits```
 
 ## The JSON body
@@ -16,14 +16,14 @@ For example, "commits" would be ```/push/commits```
 Include a JSON body that consists of an array of objects you wish to insert.
 Please Note: You must know the schema you are inserting into (column names, types, etc.)
 ```
-	[
-		{
-			"origin_key": "gitlab...etc",
-			"sha": "osidjfoawehfwh08",
-      "additions": 89,
-      ...
-		}
-	]
+[
+    {
+        "id": "gitlab...etc",
+        "sha": "osidjfoawehfwh08",
+        "additions": 89,
+        ...
+    }
+]
 ```
 
 

--- a/config-ui/src/pages/triggers/index.jsx
+++ b/config-ui/src/pages/triggers/index.jsx
@@ -12,7 +12,7 @@ import Sidebar from '@/components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '@/components/Content'
 import request from '@/utils/request'
-import { GRAFANA_URL } from '@/utils/config.js'
+import { DEVLAKE_ENDPOINT, GRAFANA_URL } from '@/utils/config.js'
 import TriggersUtil  from '@/utils/triggersUtil'
 import SourcesUtil from '@/utils/sourcesUtil'
 

--- a/models/domainlayer/README.md
+++ b/models/domainlayer/README.md
@@ -25,13 +25,22 @@ The following rules make sure Domain Layer Entities serve its purpose
 
 ## Domain Layer Entity
 
-- Each **Domain Entity** has a `OriginKey` describe its origin record in format `<Plugin>:<Entity>:<PK0>:<PK1>`
+- Each **Domain Entity** has a `Id` with type `string` describe its origin record in format
+  `<Plugin>:<Entity>:<PK0>:<PK1>`, because:
+  1. Different platforms might choice different types as their Primary Key, i.e. `AutoIncremental Integer` or `uuid`
+  2. Platform might or might not use `composite primary keys`
+  3. Primary key might overlay between entities, and multiple entities most likely will be combined into one table
+  4. Different plugins might use same entity name, even they can not co-exists at the same time, so plugin name must be
+     included for distinction
+  5. This format is deterministic, each of every entity can be converted independently in parallel, and data could be
+     rebuilt arbitrary time with same output, which mean you can truncate any table at any time, and data integrity
+     will be restored on next run. (this is not possible for `AutoIncremental Integer` or `uuid`)
 - Each **Domain Entity** must contains enough fields needed for all metric calculations
 
 ## Data Conversion
 
 - Read data from platform specific table, convert and store record into one(or multiple) domain table(s)
-- Generate its own `OriginKey` accordingly
+- Generate its own `Id` accordingly
 - Generate foreign key accordlingly
 - Fields conversion
 
@@ -40,14 +49,14 @@ Sample code:
 ```go
 
 type Issue struct {
-    OriginKey       string  `gorm:"primaryKey"`
-    BoardOriginKey  string  `gorm:"index"`
+    Id       string  `gorm:"primaryKey"`
+    BoardId  string  `gorm:"index"`
     ...
 }
 
 issue := Issue {
-    OriginKey: "jira:JiraIssues:1:10",
-    BoardOriginKey: "jira:JiraBoard:1:10"
+    Id:         "jira:JiraIssues:1:10",
+    BoardId:    "jira:JiraBoard:1:10"
     ...
 }
 

--- a/models/domainlayer/devops/build.go
+++ b/models/domainlayer/devops/build.go
@@ -8,10 +8,10 @@ import (
 
 type Build struct {
 	domainlayer.DomainEntity
-	JobOriginKey string `gorm:"index"`
-	Name         string
-	CommitSha    string
-	DurationSec  uint64
-	Status       string
-	StartedDate  time.Time
+	JobId       string `gorm:"index"`
+	Name        string
+	CommitSha   string
+	DurationSec uint64
+	Status      string
+	StartedDate time.Time
 }

--- a/models/domainlayer/didgen/domain_id_generator.go
+++ b/models/domainlayer/didgen/domain_id_generator.go
@@ -64,7 +64,7 @@ func NewDomainIdGenerator(entityPtr interface{}) *DomainIdGenerator {
 }
 
 func (g *DomainIdGenerator) Generate(pkValues ...interface{}) string {
-	originKey := g.prefix
+	id := g.prefix
 	for i, pkValue := range pkValues {
 		// type checking
 		if reflect.ValueOf(pkValue).Type() != g.pkTypes[i] {
@@ -74,7 +74,7 @@ func (g *DomainIdGenerator) Generate(pkValues ...interface{}) string {
 			))
 		}
 		// append pk
-		originKey += ":" + fmt.Sprintf("%v", pkValue)
+		id += ":" + fmt.Sprintf("%v", pkValue)
 	}
-	return originKey
+	return id
 }

--- a/models/domainlayer/didgen/domain_id_generator.go
+++ b/models/domainlayer/didgen/domain_id_generator.go
@@ -1,4 +1,4 @@
-package okgen
+package didgen
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/merico-dev/lake/plugins/core"
 )
 
-type OriginKeyGenerator struct {
+type DomainIdGenerator struct {
 	prefix  string
 	pkNames []string
 	pkTypes []reflect.Type
@@ -31,7 +31,7 @@ func walkFields(t reflect.Type, pkNames *[]string, pkTypes *[]reflect.Type) {
 	}
 }
 
-func NewOriginKeyGenerator(entityPtr interface{}) *OriginKeyGenerator {
+func NewDomainIdGenerator(entityPtr interface{}) *DomainIdGenerator {
 	v := reflect.ValueOf(entityPtr)
 	if v.Kind() != reflect.Ptr {
 		panic("entityPtr is not a pointer")
@@ -56,14 +56,14 @@ func NewOriginKeyGenerator(entityPtr interface{}) *OriginKeyGenerator {
 		panic(fmt.Errorf("no primary key found for %s:%s", pluginName, structName))
 	}
 
-	return &OriginKeyGenerator{
+	return &DomainIdGenerator{
 		prefix:  fmt.Sprintf("%s:%s", pluginName, structName),
 		pkNames: pkNames,
 		pkTypes: pkTypes,
 	}
 }
 
-func (g *OriginKeyGenerator) Generate(pkValues ...interface{}) string {
+func (g *DomainIdGenerator) Generate(pkValues ...interface{}) string {
 	originKey := g.prefix
 	for i, pkValue := range pkValues {
 		// type checking

--- a/models/domainlayer/didgen/domain_id_generator_test.go
+++ b/models/domainlayer/didgen/domain_id_generator_test.go
@@ -1,4 +1,4 @@
-package okgen
+package didgen
 
 import (
 	"context"
@@ -38,14 +38,14 @@ func TestOriginKeyGenerator(t *testing.T) {
 	var foo FooPlugin
 	assert.Nil(t, core.RegisterPlugin("fooplugin", &foo))
 
-	g := NewOriginKeyGenerator(&FooModel{})
+	g := NewDomainIdGenerator(&FooModel{})
 	assert.Equal(t, g.prefix, "fooplugin:FooModel")
 
 	originKey := g.Generate(uint(2))
 	assert.Equal(t, "fooplugin:FooModel:2", originKey)
 
 	assert.Panics(t, func() {
-		NewOriginKeyGenerator(&foo)
+		NewDomainIdGenerator(&foo)
 	})
 
 	assert.Panics(t, func() {

--- a/models/domainlayer/domainlayer.go
+++ b/models/domainlayer/domainlayer.go
@@ -5,6 +5,7 @@ import (
 )
 
 type DomainEntity struct {
-	OriginKey string `json:"originKey" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	Id string `json:"originKey" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
 	common.NoPKModel
 }
+

--- a/models/domainlayer/domainlayer.go
+++ b/models/domainlayer/domainlayer.go
@@ -5,7 +5,6 @@ import (
 )
 
 type DomainEntity struct {
-	Id string `json:"originKey" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	Id string `json:"id" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
 	common.NoPKModel
 }
-

--- a/models/domainlayer/ticket/changelog.go
+++ b/models/domainlayer/ticket/changelog.go
@@ -10,12 +10,12 @@ type Changelog struct {
 	domainlayer.DomainEntity
 
 	// collected fields
-	IssueOriginKey string `gorm:"index"`
-	AuthorId       string
-	AuthorName     string
-	FieldId        string
-	FieldName      string
-	From           string
-	To             string
-	CreatedDate    time.Time
+	IssueId     string `gorm:"index"`
+	AuthorId    string
+	AuthorName  string
+	FieldId     string
+	FieldName   string
+	From        string
+	To          string
+	CreatedDate time.Time
 }

--- a/models/domainlayer/ticket/issue.go
+++ b/models/domainlayer/ticket/issue.go
@@ -10,7 +10,7 @@ type Issue struct {
 	domainlayer.DomainEntity
 
 	// collected fields
-	BoardOriginKey           string `gorm:"index"`
+	BoardId                  string `gorm:"index"`
 	Url                      string
 	Key                      string
 	Title                    string
@@ -22,12 +22,12 @@ type Issue struct {
 	OriginalEstimateMinutes  int64 // user input?
 	AggregateEstimateMinutes int64 // sum up of all subtasks?
 	RemainingEstimateMinutes int64 // could it be negative value?
-	CreatorOriginKey         string
-	AssigneeOriginKey        string
+	CreatorId                string
+	AssigneeId               string
 	ResolutionDate           *time.Time
 	Priority                 string // not sure how to deal with it yet, copy the name for now
-	ParentOriginKey          string
-	SprintOriginKey          string
+	ParentId                 string
+	SprintId                 string
 	CreatedDate              time.Time
 	UpdatedDate              time.Time
 	SpentMinutes             int64

--- a/models/domainlayer/ticket/sprint.go
+++ b/models/domainlayer/ticket/sprint.go
@@ -10,16 +10,16 @@ type Sprint struct {
 	domainlayer.DomainEntity
 
 	// collected fields
-	BoardOriginKey string `gorm:"index"`
-	Url            string
-	State          string
-	Name           string
-	StartDate      *time.Time
-	EndDate        *time.Time
-	CompleteDate   *time.Time
+	BoardId      string `gorm:"index"`
+	Url          string
+	State        string
+	Name         string
+	StartDate    *time.Time
+	EndDate      *time.Time
+	CompleteDate *time.Time
 }
 
 type SprintIssue struct {
-	SprintOriginKey string `gorm:"primaryKey"`
-	IssueOriginKey  string `gorm:"primaryKey"`
+	SprintId string `gorm:"primaryKey"`
+	IssueId  string `gorm:"primaryKey"`
 }

--- a/models/domainlayer/ticket/worklog.go
+++ b/models/domainlayer/ticket/worklog.go
@@ -8,8 +8,8 @@ import (
 
 type Worklog struct {
 	domainlayer.DomainEntity
-	IssueOriginKey   string `gorm:"index"`
-	BoardOriginKey   string `gorm:"index"`
+	IssueId          string `gorm:"index"`
+	BoardId          string `gorm:"index"`
 	AuthorId         string
 	UpdateAuthorId   string
 	TimeSpent        string

--- a/plugins/github/tasks/github_commit_converter.go
+++ b/plugins/github/tasks/github_commit_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertCommits() error {
 func convertToCommitModel(commit *githubModels.GithubCommit) *code.Commit {
 	domainCommit := &code.Commit{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(commit).Generate(commit.Sha),
+			Id: didgen.NewDomainIdGenerator(commit).Generate(commit.Sha),
 		},
 		Sha:            commit.Sha,
 		RepoId:         uint64(commit.RepositoryId),

--- a/plugins/github/tasks/github_issue_converter.go
+++ b/plugins/github/tasks/github_issue_converter.go
@@ -2,9 +2,10 @@ package tasks
 
 import (
 	"fmt"
+
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
@@ -38,19 +39,19 @@ func convertStateToStatus(state string) string {
 func convertToIssueModel(issue *githubModels.GithubIssue) *ticket.Issue {
 	domainIssue := &ticket.Issue{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(issue).Generate(issue.GithubId),
+			Id: didgen.NewDomainIdGenerator(issue).Generate(issue.GithubId),
 		},
-		Key:               fmt.Sprint(issue.GithubId),
-		Title:             issue.Title,
-		Summary:           issue.Body,
-		Status:            convertStateToStatus(issue.State),
-		Priority:          issue.Priority,
-		Type:              issue.Type,
-		AssigneeOriginKey: issue.Assignee,
-		LeadTimeMinutes:   issue.LeadTimeMinutes,
-		CreatedDate:       issue.GithubCreatedAt,
-		UpdatedDate:       issue.GithubUpdatedAt,
-		ResolutionDate:    issue.ClosedAt,
+		Key:             fmt.Sprint(issue.GithubId),
+		Title:           issue.Title,
+		Summary:         issue.Body,
+		Status:          convertStateToStatus(issue.State),
+		Priority:        issue.Priority,
+		Type:            issue.Type,
+		AssigneeId:      issue.Assignee,
+		LeadTimeMinutes: issue.LeadTimeMinutes,
+		CreatedDate:     issue.GithubCreatedAt,
+		UpdatedDate:     issue.GithubUpdatedAt,
+		ResolutionDate:  issue.ClosedAt,
 	}
 	return domainIssue
 }

--- a/plugins/github/tasks/github_note_converter.go
+++ b/plugins/github/tasks/github_note_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertNotes() error {
 func convertToNoteModel(note *githubModels.GithubPullRequestComment) *code.Note {
 	domainNote := &code.Note{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(note).Generate(note.GithubId),
+			Id: didgen.NewDomainIdGenerator(note).Generate(note.GithubId),
 		},
 		PrId:        uint64(note.PullRequestId),
 		Author:      note.AuthorUsername,

--- a/plugins/github/tasks/github_pull_request_converter.go
+++ b/plugins/github/tasks/github_pull_request_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertPullRequests() error {
 func convertToPullRequestModel(pr *githubModels.GithubPullRequest) *code.Pr {
 	domainPr := &code.Pr{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(pr).Generate(pr.GithubId),
+			Id: didgen.NewDomainIdGenerator(pr).Generate(pr.GithubId),
 		},
 		RepoId:      uint64(pr.RepositoryId),
 		State:       pr.State,

--- a/plugins/github/tasks/github_repo_converter.go
+++ b/plugins/github/tasks/github_repo_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertRepos() error {
 func convertToRepositoryModel(repository *githubModels.GithubRepository) *code.Repo {
 	domainRepository := &code.Repo{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(repository).Generate(repository.GithubId),
+			Id: didgen.NewDomainIdGenerator(repository).Generate(repository.GithubId),
 		},
 		Name: repository.Name,
 		Url:  repository.HTMLUrl,

--- a/plugins/gitlab/tasks/gitlab_commits_converter.go
+++ b/plugins/gitlab/tasks/gitlab_commits_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertCommits() error {
 func convertToCommitModel(commit *gitlabModels.GitlabCommit) *code.Commit {
 	domainCommit := &code.Commit{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(commit).Generate(commit.GitlabId),
+			Id: didgen.NewDomainIdGenerator(commit).Generate(commit.GitlabId),
 		},
 		Sha:            commit.GitlabId,
 		RepoId:         uint64(commit.ProjectId),

--- a/plugins/gitlab/tasks/gitlab_note_converter.go
+++ b/plugins/gitlab/tasks/gitlab_note_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertNotes() error {
 func convertToNoteModel(note *gitlabModels.GitlabMergeRequestNote) *code.Note {
 	domainNote := &code.Note{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(note).Generate(note.GitlabId),
+			Id: didgen.NewDomainIdGenerator(note).Generate(note.GitlabId),
 		},
 		PrId:        uint64(note.MergeRequestId),
 		Type:        note.NoteableType,

--- a/plugins/gitlab/tasks/gitlab_pr_converter.go
+++ b/plugins/gitlab/tasks/gitlab_pr_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertPrs() error {
 func convertToPrModel(mr *gitlabModels.GitlabMergeRequest) *code.Pr {
 	domainPr := &code.Pr{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(mr).Generate(mr.GitlabId),
+			Id: didgen.NewDomainIdGenerator(mr).Generate(mr.GitlabId),
 		},
 		RepoId:      uint64(mr.ProjectId),
 		State:       mr.State,

--- a/plugins/gitlab/tasks/gitlab_repo_converter.go
+++ b/plugins/gitlab/tasks/gitlab_repo_converter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertRepos() error {
 func convertToRepositoryModel(project *gitlabModels.GitlabProject) *code.Repo {
 	domainRepository := &code.Repo{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(project).Generate(project.GitlabId),
+			Id: didgen.NewDomainIdGenerator(project).Generate(project.GitlabId),
 		},
 		Name: project.Name,
 		Url:  project.WebUrl,

--- a/plugins/jenkins/tasks/jobconverter.go
+++ b/plugins/jenkins/tasks/jobconverter.go
@@ -4,7 +4,7 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/devops"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	jenkinsModels "github.com/merico-dev/lake/plugins/jenkins/models"
 	"gorm.io/gorm/clause"
 )
@@ -18,7 +18,7 @@ func ConvertJobs() error {
 	}
 	defer cursor.Close()
 
-	jobOriginkeyGenerator := okgen.NewOriginKeyGenerator(jenkinsJob)
+	jobIdGen := didgen.NewDomainIdGenerator(jenkinsJob)
 
 	// iterate all rows
 	for cursor.Next() {
@@ -28,7 +28,7 @@ func ConvertJobs() error {
 		}
 		job := &devops.Job{
 			DomainEntity: domainlayer.DomainEntity{
-				OriginKey: jobOriginkeyGenerator.Generate(jenkinsJob.ID),
+				Id: jobIdGen.Generate(jenkinsJob.ID),
 			},
 			Name: jenkinsJob.Name,
 		}

--- a/plugins/jira/tasks/jira_board_converter.go
+++ b/plugins/jira/tasks/jira_board_converter.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
 	"gorm.io/gorm/clause"
@@ -19,7 +19,7 @@ func ConvertBoard(sourceId uint64, boardId uint64) error {
 
 	board := &ticket.Board{
 		DomainEntity: domainlayer.DomainEntity{
-			OriginKey: okgen.NewOriginKeyGenerator(jiraBoard).Generate(jiraBoard.SourceId, boardId),
+			Id: didgen.NewDomainIdGenerator(jiraBoard).Generate(jiraBoard.SourceId, boardId),
 		},
 		Name: jiraBoard.Name,
 		Url:  jiraBoard.Self,

--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -253,7 +253,7 @@ func convertIssue(source *models.JiraSource, jiraApiIssue *JiraApiIssue) (jiraIs
 		jiraIssue.AggregateEstimateMinutes = fields.AggregateTimeEstimate / 60
 		jiraIssue.RemainingEstimateMinutes = fields.TimeTracking.RemainingEstimatSeconds / 60
 	}
-	// this would never be true if we collect issues by board
+	// depend on board settings, subtasks may or may not be collected.
 	if fields.Parent != nil {
 		parentId, err := strconv.ParseUint(fields.Parent.Id, 10, 64)
 		if err != nil {

--- a/plugins/jira/tasks/jira_user_converter.go
+++ b/plugins/jira/tasks/jira_user_converter.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
-	"github.com/merico-dev/lake/models/domainlayer/okgen"
+	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/user"
 	jiraModels "github.com/merico-dev/lake/plugins/jira/models"
 	"gorm.io/gorm/clause"
@@ -18,12 +18,12 @@ func ConvertUsers(sourceId uint64) error {
 		return err
 	}
 
-	userOriginKeyGenerator := okgen.NewOriginKeyGenerator(&jiraModels.JiraUser{})
+	userIdGen := didgen.NewDomainIdGenerator(&jiraModels.JiraUser{})
 
 	for _, jiraUser := range jiraUserRows {
 		user := &user.User{
 			DomainEntity: domainlayer.DomainEntity{
-				OriginKey: userOriginKeyGenerator.Generate(jiraUser.SourceId, jiraUser.AccountId),
+				Id: userIdGen.Generate(jiraUser.SourceId, jiraUser.AccountId),
 			},
 			Name:      jiraUser.Name,
 			Email:     jiraUser.Email,


### PR DESCRIPTION
# Summary

Renamed `OriginKey` to `Id`
Fixed "Trigger Collection" button stop working from Triggers page 
Renamed tasks filenames with plugin prefix for all plugins

### Key Points

- [x] This is a breaking change
- [x] New or existing documentation is updated

### Description
Keep in mind this primary key changing will break existing user database.
 
![rename-originkey-need-db-migration-support](https://user-images.githubusercontent.com/61080/145781401-be329867-afc8-4c56-bad1-25f0669803eb.png)

We have two solutions for this change:
1. ask existing users to drop all domain layer tables like we always did.
2. implement DB Migration feature, and make sure db got migrated autmatically.

### Does this close any open issues?
Closes #945 

