### PR TITLE
Jira issue commits relationship

### DIFF
--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -35,6 +35,8 @@ func (plugin Jira) Init() {
 		&models.JiraBoardIssue{},
 		&models.JiraChangelog{},
 		&models.JiraChangelogItem{},
+		&models.JiraRemotelink{},
+		&models.JiraIssueCommit{},
 		&models.JiraSource{},
 		&models.JiraIssueTypeMapping{},
 		&models.JiraIssueStatusMapping{},
@@ -95,19 +97,21 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 	}
 	if len(tasksToRun) == 0 {
 		tasksToRun = map[string]bool{
-			"collectBoard":      true,
-			"collectProjects":   true,
-			"collectIssues":     true,
-			"collectChangelogs": true,
-			"enrichIssues":      true,
-			"collectSprints":    true,
-			"collectUsers":      true,
-			"convertBoard":      true,
-			"convertIssues":     true,
-			"convertWorklogs":   true,
-			"convertChangelogs": true,
-			"convertUsers":      true,
-			"convertSprints":    true,
+			"collectBoard":       true,
+			"collectProjects":    true,
+			"collectIssues":      true,
+			"collectChangelogs":  true,
+			"collectRemotelinks": true,
+			"enrichIssues":       true,
+			"enrichRemotelinks":  true,
+			"collectSprints":     true,
+			"collectUsers":       true,
+			"convertBoard":       true,
+			"convertIssues":      true,
+			"convertWorklogs":    true,
+			"convertChangelogs":  true,
+			"convertUsers":       true,
+			"convertSprints":     true,
 		}
 	}
 
@@ -156,9 +160,21 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 				return err
 			}
 		}
+		if tasksToRun["collectRemotelinks"] {
+			err = tasks.CollectRemoteLinks(jiraApiClient, source, boardId, ctx)
+			if err != nil {
+				return err
+			}
+		}
 		setBoardProgress(i, 0.2)
 		if tasksToRun["enrichIssues"] {
 			err = tasks.EnrichIssues(source, boardId)
+			if err != nil {
+				return err
+			}
+		}
+		if tasksToRun["enrichRemotelinks"] {
+			err = tasks.EnrichRemotelinks(source, boardId)
 			if err != nil {
 				return err
 			}

--- a/plugins/jira/models/jira_issue.go
+++ b/plugins/jira/models/jira_issue.go
@@ -1,9 +1,10 @@
 package models
 
 import (
+	"time"
+
 	"github.com/merico-dev/lake/models/common"
 	"gorm.io/datatypes"
-	"time"
 )
 
 type JiraIssue struct {
@@ -55,5 +56,6 @@ type JiraIssue struct {
 	AllFields       datatypes.JSONMap
 
 	// internal status tracking
-	ChangelogUpdated *time.Time
+	ChangelogUpdated  *time.Time
+	RemotelinkUpdated *time.Time
 }

--- a/plugins/jira/models/jira_issue_commit.go
+++ b/plugins/jira/models/jira_issue_commit.go
@@ -1,0 +1,7 @@
+package models
+
+type JiraIssueCommit struct {
+	SourceId  uint64 `gorm:"primaryKey"`
+	IssueId   uint64 `gorm:"primaryKey"`
+	CommitSha string `gorm:"primaryKey;type:char(40)"`
+}

--- a/plugins/jira/models/jira_remotelink.go
+++ b/plugins/jira/models/jira_remotelink.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"github.com/merico-dev/lake/models/common"
+	"gorm.io/datatypes"
+)
+
+type JiraRemotelink struct {
+	common.NoPKModel
+
+	// collected fields
+	SourceId     uint64 `gorm:"primaryKey"`
+	RemotelinkId uint64 `gorm:"primarykey"`
+	IssueId      uint64 `gorm:"index"`
+	RawJson      datatypes.JSON
+	Self         string
+	Title        string
+	Url          string
+}

--- a/plugins/jira/models/jira_source.go
+++ b/plugins/jira/models/jira_source.go
@@ -6,11 +6,12 @@ import (
 
 type JiraSource struct {
 	common.Model
-	Name             string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
-	Endpoint         string `json:"endpoint" validate:"required"`
-	BasicAuthEncoded string `json:"basicAuthEncoded" validate:"required"`
-	EpicKeyField     string `gorm:"type:varchar(50);" json:"epicKeyField"`
-	StoryPointField  string `gorm:"type:varchar(50);" json:"storyPointField"`
+	Name                       string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
+	Endpoint                   string `json:"endpoint" validate:"required"`
+	BasicAuthEncoded           string `json:"basicAuthEncoded" validate:"required"`
+	EpicKeyField               string `gorm:"type:varchar(50);" json:"epicKeyField"`
+	StoryPointField            string `gorm:"type:varchar(50);" json:"storyPointField"`
+	RemotelinkCommitShaPattern string `gorm:"type:varchar(255);comment='golang regexp, the first group will be recognized as commit sha, ref https://github.com/google/re2/wiki/Syntax'" json:"remotelinkCommitShaPattern"`
 }
 
 type JiraIssueTypeMapping struct {

--- a/plugins/jira/tasks/jira_changelog_collector.go
+++ b/plugins/jira/tasks/jira_changelog_collector.go
@@ -85,11 +85,11 @@ func CollectChangelogs(
 	if err != nil {
 		return err
 	}
+	defer changelogScheduler.Release()
 	issueScheduler, err := utils.NewWorkerScheduler(10, 50, ctx)
 	if err != nil {
 		return err
 	}
-	defer changelogScheduler.Release()
 	defer issueScheduler.Release()
 
 	// iterate all rows

--- a/plugins/jira/tasks/jira_issue_enricher.go
+++ b/plugins/jira/tasks/jira_issue_enricher.go
@@ -53,7 +53,7 @@ func EnrichIssues(source *models.JiraSource, boardId uint64) (err error) {
 	cursor, err := lakeModels.Db.Model(jiraIssue).
 		Select("jira_issues.*").
 		Joins("left join jira_board_issues on jira_board_issues.issue_id = jira_issues.issue_id").
-		Where("jira_board_issues.board_id = ?", boardId).
+		Where("jira_board_issues.board_id = ? AND jira_board_issues.source_id = ?", boardId, source.ID).
 		Rows()
 	if err != nil {
 		return err

--- a/plugins/jira/tasks/jira_remotelink_collector.go
+++ b/plugins/jira/tasks/jira_remotelink_collector.go
@@ -1,0 +1,140 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/merico-dev/lake/utils"
+	"gorm.io/datatypes"
+	"gorm.io/gorm/clause"
+
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/jira/models"
+)
+
+type JiraApiRemotelink struct {
+	Id           uint64
+	Self         string
+	Application  json.RawMessage
+	Relationship string
+	Object       struct {
+		Url    string
+		Title  string
+		Icon   json.RawMessage
+		Status json.RawMessage
+	}
+}
+
+// need to store a origin json body into RawJson, by this approach, we dont need to Marshal it back to bytes
+type JiraApiRemotelinksResponse []json.RawMessage
+
+func CollectRemoteLinks(
+	jiraApiClient *JiraApiClient,
+	source *models.JiraSource,
+	boardId uint64,
+	ctx context.Context,
+) error {
+	jiraIssue := &models.JiraIssue{}
+
+	/*
+		`CollectIssues` will take into account of `since` option and set the `updated` field for issues that have
+		updates, So when it comes to collecting remotelinks, we only need to compare an issue's `updated` field with its
+		`remotelink_updated` field. If `remotelink_updated` is older, then we'll collect remotelinks for this issue and
+		set its `remotelink_updated` to `updated` at the end.
+	*/
+	cursor, err := lakeModels.Db.Model(jiraIssue).
+		Select("jira_issues.issue_id", "jira_issues.updated").
+		Joins(`LEFT JOIN jira_board_issues ON (
+			jira_board_issues.source_id = jira_issues.source_id AND
+			jira_board_issues.issue_id = jira_issues.issue_id
+		)`).
+		Where(`
+			jira_board_issues.source_id = ? AND
+			jira_board_issues.board_id = ? AND
+			(jira_issues.remotelink_updated IS NULL OR jira_issues.remotelink_updated < jira_issues.updated)
+			`,
+			source.ID,
+			boardId,
+		).
+		Rows()
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	issueScheduler, err := utils.NewWorkerScheduler(10, 50, ctx)
+	if err != nil {
+		return err
+	}
+	defer issueScheduler.Release()
+
+	// iterate all rows
+	for cursor.Next() {
+		err = lakeModels.Db.ScanRows(cursor, jiraIssue)
+		if err != nil {
+			return err
+		}
+		issueId := jiraIssue.IssueId
+		updated := jiraIssue.Updated
+		err = issueScheduler.Submit(func() error {
+			err = collectRemotelinksByIssueId(source, jiraApiClient, issueId)
+			if err != nil {
+				return err
+			}
+			issue := &models.JiraIssue{SourceId: source.ID, IssueId: issueId}
+			err = lakeModels.Db.Model(issue).Update("remotelink_updated", updated).Error
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	issueScheduler.WaitUntilFinish()
+
+	return nil
+}
+
+func collectRemotelinksByIssueId(
+	source *models.JiraSource,
+	jiraApiClient *JiraApiClient,
+	issueId uint64,
+) error {
+	res, err := jiraApiClient.Get(fmt.Sprintf("api/3/issue/%v/remotelink", issueId), nil, nil)
+	if err != nil {
+		return err
+	}
+	apiRemotelinks := &JiraApiRemotelinksResponse{}
+	err = core.UnmarshalResponse(res, apiRemotelinks)
+	if err != nil {
+		return err
+	}
+
+	apiRemotelink := &JiraApiRemotelink{}
+	for _, apiRemotelinkRaw := range *apiRemotelinks {
+		// unmarshal to fetch id for primary key
+		err = json.Unmarshal(apiRemotelinkRaw, apiRemotelink)
+		if err != nil {
+			return err
+		}
+		// create a empty record with pk only
+		remotelink := &models.JiraRemotelink{
+			SourceId:     source.ID,
+			IssueId:      issueId,
+			RemotelinkId: apiRemotelink.Id,
+			RawJson:      datatypes.JSON(apiRemotelinkRaw),
+		}
+		// save raw response, delay feilds extraction to enrich stage
+		err = lakeModels.Db.Clauses(clause.OnConflict{
+			DoUpdates: clause.AssignmentColumns([]string{"raw_json"}),
+		}).Create(remotelink).Error
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/plugins/jira/tasks/jira_remotelink_enricher.go
+++ b/plugins/jira/tasks/jira_remotelink_enricher.go
@@ -1,0 +1,122 @@
+package tasks
+
+import (
+	"encoding/json"
+	"regexp"
+
+	lakeModels "github.com/merico-dev/lake/models"
+	"github.com/merico-dev/lake/plugins/jira/models"
+	"gorm.io/gorm/clause"
+)
+
+func EnrichRemotelinks(source *models.JiraSource, boardId uint64) (err error) {
+	// prepare for issue_commits enrichment
+	var commitShaRegex *regexp.Regexp
+	if source.RemotelinkCommitShaPattern != "" {
+		commitShaRegex = regexp.MustCompile(source.RemotelinkCommitShaPattern)
+	}
+	// clean up issue_commits relationship for board
+	lakeModels.Db.Exec(`
+	DELETE ic
+	FROM jira_issue_commits ic
+	LEFT JOIN jira_board_issues bi ON (bi.source_id = ic.source_id AND bi.issue_id = ic.issue_id)
+	WHERE ic.source_id = ? AND bi.board_id = ?
+	`, source.ID, boardId)
+
+	var remotelink *models.JiraRemotelink
+	var issueCommit *models.JiraIssueCommit
+	// select all remotelinks belongs to the board, cursor is important for low memory footprint
+	cursor, err := lakeModels.Db.Model(&models.JiraRemotelink{}).
+		Select("jira_remotelinks.*").
+		Joins("left join jira_board_issues on jira_board_issues.issue_id = jira_remotelinks.issue_id").
+		Where("jira_board_issues.board_id = ? AND jira_board_issues.source_id = ?", boardId, source.ID).
+		Rows()
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	// save in batch, this could improvement performance dramatically
+	size := 1000
+	i := 0
+	j := 0
+	batch := make([]models.JiraRemotelink, size)
+	icBatch := make([]models.JiraIssueCommit, size)
+	saveBatch := func() error {
+		err := lakeModels.Db.Clauses(clause.OnConflict{
+			UpdateAll: true,
+		}).CreateInBatches(batch[:i], size).Error
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	saveIcBatch := func() error {
+		err := lakeModels.Db.Clauses(clause.OnConflict{
+			DoNothing: true,
+		}).CreateInBatches(icBatch[:j], size).Error
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	apiRemotelink := &JiraApiRemotelink{}
+	// iterate all rows
+	for cursor.Next() {
+		if i >= size {
+			err = saveBatch()
+			if err != nil {
+				return err
+			}
+			i = 0
+		}
+		if j >= size {
+			err = saveIcBatch()
+			if err != nil {
+				return err
+			}
+			j = 0
+		}
+
+		remotelink = &batch[i]
+		err = lakeModels.Db.ScanRows(cursor, remotelink)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(remotelink.RawJson, apiRemotelink)
+		if err != nil {
+			return err
+		}
+		remotelink.Self = apiRemotelink.Self
+		remotelink.Url = apiRemotelink.Object.Url
+		remotelink.Title = apiRemotelink.Object.Title
+
+		// issue commit relationship
+		if commitShaRegex != nil {
+			groups := commitShaRegex.FindStringSubmatch(remotelink.Url)
+			if len(groups) > 1 {
+				issueCommit = &icBatch[j]
+				issueCommit.SourceId = source.ID
+				issueCommit.IssueId = remotelink.IssueId
+				issueCommit.CommitSha = groups[1]
+				j++
+			}
+		}
+
+		i++
+	}
+	if i > 0 {
+		err = saveBatch()
+		if err != nil {
+			return err
+		}
+	}
+	if j > 0 {
+		err = saveIcBatch()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Summary

1. jira issue remotelinks collection
2. create jira issue / git commit sha relationship based on remotelink url pattern

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description

Lately, we received some usabiltiy issues:
1. User have to recollect all data if they set a wrong value for customfield, #575 
2. Conversion takes so long if table was too big


By developing this feature, I also try to solve these issues:
1. Collection stage store only primary key and `RawJson`, and extract needed field on Enrichment stage. So, for customfield, users don't have to recollection if they set it wrong. This is similar to previous js POC implementation.
2. Adopt `Pre Allocated Array` and `Batch Insert` for Conversion tasks which introduced by @mindlesscloud , this technique reduced conversion time dramatically.

I would like everybody @mindlesscloud  @hezyin @joncodo @kevin-kline to take a close look at this PR, and post your thought regarding the approach, and we may gradually refactor all our tasks if we all concured this is a better way to go.

### Does this close any open issues?
Closes #490 
