### PR TITLE
`feat` #965 pipelines: show pipeline activity & details

### DIFF
--- a/config-ui/package-lock.json
+++ b/config-ui/package-lock.json
@@ -13,6 +13,7 @@
         "@blueprintjs/select": "^3.18.10",
         "axios": "^0.21.4",
         "babel-plugin-module-resolver": "^4.1.0",
+        "dayjs": "^1.10.7",
         "dotenv": "^10.0.0",
         "dotenv-webpack": "^7.0.3",
         "react": "17.0.2",
@@ -6654,6 +6655,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -26965,6 +26971,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
       "version": "4.3.2",

--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -15,6 +15,7 @@
     "@blueprintjs/select": "^3.18.10",
     "axios": "^0.21.4",
     "babel-plugin-module-resolver": "^4.1.0",
+    "dayjs": "^1.10.7",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
     "react": "17.0.2",

--- a/config-ui/src/App.js
+++ b/config-ui/src/App.js
@@ -22,7 +22,7 @@ import Offline from '@/pages/offline/index'
 // #963 Create Pipelines
 import CreatePipeline from '@/pages/pipelines/create'
 // #965 Pipeline Activity
-// import PipelineActivity from '@/pages/pipelines/activity'
+import PipelineActivity from '@/pages/pipelines/activity'
 
 function App () {
   return (
@@ -55,9 +55,12 @@ function App () {
       {/* #964 <Route exact path='/pipelines'>
         <Pipelines />
       </Route> */}
-      {/* #965 <Route exact path='/pipelines/activity/:id'>
+      <Route exact path='/pipelines/activity'>
         <PipelineActivity />
-      </Route> */}
+      </Route>
+      <Route exact path='/pipelines/activity/:pId'>
+        <PipelineActivity />
+      </Route>
       <Route exact path='/lake/api/configuration'>
         <Configure />
       </Route>

--- a/config-ui/src/components/pipelines/CodeInspector.jsx
+++ b/config-ui/src/components/pipelines/CodeInspector.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+// import { CSSTransition } from 'react-transition-group'
+import {
+  Classes,
+  Drawer,
+  DrawerSize,
+  Card,
+  Elevation,
+  Position,
+} from '@blueprintjs/core'
+
+const CodeInspector = (props) => {
+  const { activePipeline, isOpen, onClose } = props
+
+  return (
+    <Drawer
+      className='drawer-json-inspector'
+      icon='code'
+      onClose={() => onClose(false)}
+      title={`Inspect RUN #${activePipeline.ID}`}
+      position={Position.RIGHT}
+      size={DrawerSize.SMALL}
+      autoFocus
+      canEscapeKeyClose
+      canOutsideClickClose
+      enforceFocus
+      hasBackdrop
+      isOpen={isOpen}
+      usePortal
+    >
+      <div className={Classes.DRAWER_BODY}>
+        <div className={Classes.DIALOG_BODY}>
+          <h3 style={{ margin: 0, padding: '8px 0' }}>
+            <span style={{ float: 'right', fontSize: '9px', color: '#aaaaaa' }}>application/json</span> JSON RESPONSE
+          </h3>
+          <p>
+            If you are submitting a
+            <strong> Bug-Report</strong> regarding a Pipeline Run, include the output below for better debugging.
+          </p>
+          <div className='formContainer'>
+            <Card
+              interactive={false}
+              elevation={Elevation.ZERO}
+              style={{ padding: '6px 12px', minWidth: '320px', width: '100%', maxWidth: '601px', marginBottom: '20px', overflow: 'auto' }}
+            >
+
+              <code>
+                <pre style={{ fontSize: '10px' }}>
+                  {JSON.stringify(activePipeline, null, '  ')}
+                </pre>
+              </code>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </Drawer>
+
+  )
+}
+
+export default CodeInspector

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -143,7 +143,7 @@ const ProviderSettings = (props) => {
             <InputGroup
               id='owner'
               disabled={isRunning || !isEnabled(providerId)}
-              placeholder='eg. merio-dev'
+              placeholder='eg. merico-dev'
               value={owner}
               onChange={(e) => setOwner(e.target.value)}
               className='input-owner'

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -39,7 +39,7 @@ const StagePanel = (props) => {
 
           <ButtonGroup style={{ backgroundColor: 'transparent' }}>
             <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
-              <h3 style={{ margin: 0, fontSize: '20px', display: 'flex' }}>
+              <h3 className='stage-panel-stage-name' style={{ margin: 0, fontSize: '18px', display: 'flex' }}>
                 {/* Stage 1 */}
                 {(() => {
                   let statusIcon = null
@@ -122,13 +122,14 @@ const StagePanel = (props) => {
                       sIdx !== (Object.keys(stages).length - 1)
                         ? (
                           <Button
+                            className='stage-panel-stage-separator'
                             minimal style={{
                               backgroundColor: '#eeeeee',
                               color: '#cccccc',
                               fontSize: '35px',
-                              lineHeight: '20px',
+                              lineHeight: '100%',
                               padding: 0,
-                              margin: 0,
+                              margin: 'auto 0 auto 0',
                               position: 'absolute',
                               right: 0,
                               fontWeight: 100,
@@ -139,14 +140,17 @@ const StagePanel = (props) => {
                         : null
                     }
                   >
-                    <h3 style={{ margin: 0, fontSize: '20px', color: activeStageId === (sIdx + 1) ? Colors.BLACK : Colors.GRAY3 }}>
+                    <h3
+                      className='stage-panel-stage-name'
+                      style={{ margin: 0, fontSize: '18px', color: activeStageId === (sIdx + 1) ? Colors.BLACK : Colors.GRAY3 }}
+                    >
                       Stage {sIdx + 1}
                     </h3>
                   </Button>
                 ))}
 
                 <Button
-                  className='btn-stage-endcap'
+                  className='stage-panel-stage-endcap'
                   minimal
                   style={{
                     marginLeft: '1px',

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -1,21 +1,12 @@
 import React from 'react'
 import { CSSTransition } from 'react-transition-group'
 import {
-  // Classes,
   Card,
-  Button, Icon, Intent, Switch,
-  // H2, Card, Elevation, Tag,
-  // Menu,
-  FormGroup,
+  Button, Icon,
   ButtonGroup,
   Elevation,
-  InputGroup,
-  Popover,
-  Tooltip,
-  Position,
-  // Spinner,
   Colors,
-  // Alignment
+  // Alignment, Classes, Spinner
 } from '@blueprintjs/core'
 import { ReactComponent as PipelineRunningIcon } from '@/images/synchronize.svg'
 import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.svg'
@@ -53,7 +44,13 @@ const StagePanel = (props) => {
                     case 'TASK_COMPLETED':
                       statusIcon = (
                         <Icon
-                          icon={<PipelineCompleteIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          icon={<PipelineCompleteIcon
+                            width={24} height={24} style={{
+                              margin: '0 0 0 10px',
+                              display: 'flex',
+                              alignSelf: 'center'
+                            }}
+                                />}
                           size={24}
                         />
                       )
@@ -61,7 +58,14 @@ const StagePanel = (props) => {
                     case 'TASK_FAILED':
                       statusIcon = (
                         <Icon
-                          icon={<PipelineFailedIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          icon={<PipelineFailedIcon
+                            width={24}
+                            height={24} style={{
+                              margin: '0 0 0 10px',
+                              display: 'flex',
+                              alignSelf: 'center'
+                            }}
+                                />}
                           size={24}
                         />
                       )
@@ -70,7 +74,14 @@ const StagePanel = (props) => {
                     default:
                       statusIcon = (
                         <Icon
-                          icon={<PipelineRunningIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          icon={<PipelineRunningIcon
+                            width={24}
+                            height={24} style={{
+                              margin: '0 0 0 10px',
+                              display: 'flex',
+                              alignSelf: 'center'
+                            }}
+                                />}
                           size={24}
                         />
                       )
@@ -80,6 +91,7 @@ const StagePanel = (props) => {
                 })()}
               </h3>
             </Button>
+            {/* @todo: re-active "stage" ux in a future release */}
             {/* <Button
               minimal style={{
                 backgroundColor: '#eeeeee',

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -13,7 +13,7 @@ import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.sv
 import { ReactComponent as PipelineCompleteIcon } from '@/images/check-circle.svg'
 
 const StagePanel = (props) => {
-  const { activePipeline, pipelineReady = false } = props
+  const { activePipeline, pipelineReady = false, stages, activeStageId = 1 } = props
 
   return (
     <>
@@ -30,14 +30,17 @@ const StagePanel = (props) => {
             justifySelf: 'flex-start',
             marginBottom: '8px',
             padding: 0,
-            backgroundColor: activePipeline.status === 'TASK_COMPLETED' ? 'rgba(245, 255, 250, 0.99)' : 'inherit'
+            backgroundColor: activePipeline.status === 'TASK_COMPLETED' ? 'rgba(245, 255, 250, 0.99)' : 'inherit',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis'
           }}
         >
 
           <ButtonGroup style={{ backgroundColor: 'transparent' }}>
             <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
               <h3 style={{ margin: 0, fontSize: '20px', display: 'flex' }}>
-                Stage 1
+                {/* Stage 1 */}
                 {(() => {
                   let statusIcon = null
                   switch (activePipeline.status) {
@@ -92,37 +95,72 @@ const StagePanel = (props) => {
               </h3>
             </Button>
             {/* @todo: re-active "stage" ux in a future release */}
-            {/* <Button
-              minimal style={{
-                backgroundColor: '#eeeeee',
-                color: '#cccccc',
-                fontSize: '35px',
-                lineHeight: '20px',
-                padding: 0,
-                fontWeight: 100,
-              }}
-            >/
-            </Button> */}
-            {/* <Button
-              disabled style={{
-                backgroundColor: '#eeeeee',
-              }}
-            ><h3 style={{ margin: 0, fontSize: '20px' }}>Stage 2</h3>
-            </Button> */}
-            <Button
-              className='btn-stage-endcap'
-              minimal
-              style={{
-                marginLeft: '1px',
-                background: '#ffffff!!important',
-                width: 0,
-                height: 0,
-                borderTop: '16px solid transparent',
-                borderBottom: '16px solid transparent',
-                borderLeft: '16px solid #eeeeee',
-                pointerEvents: 'none'
-              }}
-            />
+            {Object.keys(stages).length > 0 && (
+              <>
+                {Object.keys(stages).map((s, sIdx) => (
+                  // <Button
+                  //   minimal style={{
+                  //     backgroundColor: '#eeeeee',
+                  //     color: '#cccccc',
+                  //     fontSize: '35px',
+                  //     lineHeight: '20px',
+                  //     padding: 0,
+                  //     fontWeight: 100,
+                  //   }}
+                  // >/
+                  // </Button>
+                  <Button
+                    key={`stage-btn-key${sIdx}`}
+                    disabled={activeStageId !== (sIdx + 1)}
+                    minimal
+                    style={{
+                      position: 'relative',
+                      backgroundColor: '#eeeeee',
+                      paddingRight: '50px',
+                    }}
+                    rightIcon={
+                      sIdx !== (Object.keys(stages).length - 1)
+                        ? (
+                          <Button
+                            minimal style={{
+                              backgroundColor: '#eeeeee',
+                              color: '#cccccc',
+                              fontSize: '35px',
+                              lineHeight: '20px',
+                              padding: 0,
+                              margin: 0,
+                              position: 'absolute',
+                              right: 0,
+                              fontWeight: 100,
+                            }}
+                          >/
+                          </Button>
+                          )
+                        : null
+                    }
+                  >
+                    <h3 style={{ margin: 0, fontSize: '20px', color: activeStageId === (sIdx + 1) ? Colors.BLACK : Colors.GRAY3 }}>
+                      Stage {sIdx + 1}
+                    </h3>
+                  </Button>
+                ))}
+
+                <Button
+                  className='btn-stage-endcap'
+                  minimal
+                  style={{
+                    marginLeft: '1px',
+                    background: '#ffffff!!important',
+                    width: 0,
+                    height: 0,
+                    borderTop: '16px solid transparent',
+                    borderBottom: '16px solid transparent',
+                    borderLeft: '16px solid #eeeeee',
+                    pointerEvents: 'none'
+                  }}
+                />
+              </>
+            )}
           </ButtonGroup>
           <h3 style={{
             textTransform: 'uppercase',

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -144,9 +144,9 @@ const StagePanel = (props) => {
                     rightIcon={
                       sIdx !== (Object.keys(stages).length - 1)
                         ? (
-                          <Button
+                          <span
                             className='stage-panel-stage-separator'
-                            minimal style={{
+                            style={{
                               backgroundColor: '#eeeeee',
                               color: '#cccccc',
                               fontSize: '35px',
@@ -158,7 +158,7 @@ const StagePanel = (props) => {
                               fontWeight: 100,
                             }}
                           >/
-                          </Button>
+                          </span>
                           )
                         : null
                     }

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -6,6 +6,8 @@ import {
   ButtonGroup,
   Elevation,
   Colors,
+  Spinner,
+  Intent
   // Alignment, Classes, Spinner
 } from '@blueprintjs/core'
 import { ReactComponent as PipelineRunningIcon } from '@/images/synchronize.svg'
@@ -13,7 +15,7 @@ import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.sv
 import { ReactComponent as PipelineCompleteIcon } from '@/images/check-circle.svg'
 
 const StagePanel = (props) => {
-  const { activePipeline, pipelineReady = false, stages, activeStageId = 1 } = props
+  const { activePipeline, pipelineReady = false, stages, activeStageId = 1, isLoading = false } = props
 
   return (
     <>
@@ -38,9 +40,28 @@ const StagePanel = (props) => {
         >
 
           <ButtonGroup style={{ backgroundColor: 'transparent' }}>
-            <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
-              <h3 className='stage-panel-stage-name' style={{ margin: 0, fontSize: '18px', display: 'flex' }}>
-                {/* Stage 1 */}
+            <Button minimal active style={{ width: '32px', backgroundColor: '#eeeeee', padding: 0 }}>
+              <div style={{
+                margin: 0,
+                display: 'flex',
+                position: 'relative',
+                justifyContent: 'center',
+                alignItems: 'center',
+                alignContent: 'center'
+              }}
+              >
+                {isLoading && (
+                  <span style={{
+                    position: 'absolute',
+                    width: '24px',
+                    height: '24px',
+                    marginLeft: '4px',
+                    display: 'flex',
+                    justifyContent: 'center'
+                  }}
+                  >
+                    <Spinner size={20} intent={Intent.PRIMARY} />
+                  </span>)}
                 {(() => {
                   let statusIcon = null
                   switch (activePipeline.status) {
@@ -49,7 +70,7 @@ const StagePanel = (props) => {
                         <Icon
                           icon={<PipelineCompleteIcon
                             width={24} height={24} style={{
-                              margin: '0 0 0 10px',
+                              margin: '0 0 0 0',
                               display: 'flex',
                               alignSelf: 'center'
                             }}
@@ -64,7 +85,7 @@ const StagePanel = (props) => {
                           icon={<PipelineFailedIcon
                             width={24}
                             height={24} style={{
-                              margin: '0 0 0 10px',
+                              margin: '0 0 0 0',
                               display: 'flex',
                               alignSelf: 'center'
                             }}
@@ -77,11 +98,13 @@ const StagePanel = (props) => {
                     default:
                       statusIcon = (
                         <Icon
+                          style={{ margin: 0, padding: 0, float: 'left' }}
                           icon={<PipelineRunningIcon
                             width={24}
                             height={24} style={{
-                              margin: '0 0 0 10px',
-                              display: 'flex',
+                              margin: '0 0 0 0',
+                              padding: 0,
+                              display: 'inline',
                               alignSelf: 'center'
                             }}
                                 />}
@@ -90,11 +113,11 @@ const StagePanel = (props) => {
                       )
                       break
                   }
-                  return statusIcon
+                  return !isLoading && (<span style={{ position: 'absolute', marginLeft: '3px', width: '24px', height: '24px' }}>{statusIcon}</span>)
                 })()}
-              </h3>
+              </div>
             </Button>
-            {/* @todo: re-active "stage" ux in a future release */}
+            {/* @todo: re-activate "stage" ux in a future release */}
             {Object.keys(stages).length > 0 && (
               <>
                 {Object.keys(stages).map((s, sIdx) => (
@@ -166,20 +189,24 @@ const StagePanel = (props) => {
               </>
             )}
           </ButtonGroup>
-          <h3 style={{
-            textTransform: 'uppercase',
-            lineHeight: '33px',
-            margin: 0,
-            fontFamily: 'Montserrat',
-            fontWeight: 800,
-            letterSpacing: '2px'
-          }}
-          >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
-            <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
-          </h3>
-          <div style={{ display: 'flex', fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px', padding: '0 10px' }}>
-
-            {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}%
+          <div style={{ display: 'flex', marginLeft: 'auto', padding: '0 10px' }}>
+            <h3
+              className='h3-finished-tasks-indicator'
+              style={{
+                textTransform: 'uppercase',
+                lineHeight: '33px',
+                margin: 0,
+                fontFamily: 'Montserrat',
+                fontWeight: 800,
+                fontSize: '13px',
+                letterSpacing: '2px',
+                justifySelf: 'flex-end'
+              }}
+            >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
+              <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
+            </h3>
+            {/* <span style={{fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px'}} /> */}
+            {/* {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}% */}
           </div>
         </Card>
       </CSSTransition>

--- a/config-ui/src/components/pipelines/StagePanel.jsx
+++ b/config-ui/src/components/pipelines/StagePanel.jsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { CSSTransition } from 'react-transition-group'
+import {
+  // Classes,
+  Card,
+  Button, Icon, Intent, Switch,
+  // H2, Card, Elevation, Tag,
+  // Menu,
+  FormGroup,
+  ButtonGroup,
+  Elevation,
+  InputGroup,
+  Popover,
+  Tooltip,
+  Position,
+  // Spinner,
+  Colors,
+  // Alignment
+} from '@blueprintjs/core'
+import { ReactComponent as PipelineRunningIcon } from '@/images/synchronize.svg'
+import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.svg'
+import { ReactComponent as PipelineCompleteIcon } from '@/images/check-circle.svg'
+
+const StagePanel = (props) => {
+  const { activePipeline, pipelineReady = false } = props
+
+  return (
+    <>
+      <CSSTransition
+        in={pipelineReady}
+        timeout={350}
+        classNames='activity-panel'
+      >
+        <Card
+          elevation={Elevation.TWO}
+          style={{
+            display: 'flex',
+            width: '100%',
+            justifySelf: 'flex-start',
+            marginBottom: '8px',
+            padding: 0,
+            backgroundColor: activePipeline.status === 'TASK_COMPLETED' ? 'rgba(245, 255, 250, 0.99)' : 'inherit'
+          }}
+        >
+
+          <ButtonGroup style={{ backgroundColor: 'transparent' }}>
+            <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
+              <h3 style={{ margin: 0, fontSize: '20px', display: 'flex' }}>
+                Stage 1
+                {(() => {
+                  let statusIcon = null
+                  switch (activePipeline.status) {
+                    case 'TASK_COMPLETED':
+                      statusIcon = (
+                        <Icon
+                          icon={<PipelineCompleteIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          size={24}
+                        />
+                      )
+                      break
+                    case 'TASK_FAILED':
+                      statusIcon = (
+                        <Icon
+                          icon={<PipelineFailedIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          size={24}
+                        />
+                      )
+                      break
+                    case 'TASK_RUNNING':
+                    default:
+                      statusIcon = (
+                        <Icon
+                          icon={<PipelineRunningIcon width={24} height={24} style={{ margin: '0 0 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                          size={24}
+                        />
+                      )
+                      break
+                  }
+                  return statusIcon
+                })()}
+              </h3>
+            </Button>
+            {/* <Button
+              minimal style={{
+                backgroundColor: '#eeeeee',
+                color: '#cccccc',
+                fontSize: '35px',
+                lineHeight: '20px',
+                padding: 0,
+                fontWeight: 100,
+              }}
+            >/
+            </Button> */}
+            {/* <Button
+              disabled style={{
+                backgroundColor: '#eeeeee',
+              }}
+            ><h3 style={{ margin: 0, fontSize: '20px' }}>Stage 2</h3>
+            </Button> */}
+            <Button
+              className='btn-stage-endcap'
+              minimal
+              style={{
+                marginLeft: '1px',
+                background: '#ffffff!!important',
+                width: 0,
+                height: 0,
+                borderTop: '16px solid transparent',
+                borderBottom: '16px solid transparent',
+                borderLeft: '16px solid #eeeeee',
+                pointerEvents: 'none'
+              }}
+            />
+          </ButtonGroup>
+          <h3 style={{
+            textTransform: 'uppercase',
+            lineHeight: '33px',
+            margin: 0,
+            fontFamily: 'Montserrat',
+            fontWeight: 800,
+            letterSpacing: '2px'
+          }}
+          >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
+            <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
+          </h3>
+          <div style={{ display: 'flex', fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px', padding: '0 10px' }}>
+
+            {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}%
+          </div>
+        </Card>
+      </CSSTransition>
+    </>
+  )
+}
+
+export default StagePanel

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -1,0 +1,155 @@
+
+import React from 'react'
+// import { CSSTransition } from 'react-transition-group'
+import {
+  // Classes,
+  Icon,
+  Spinner,
+  Colors,
+  // Alignment
+} from '@blueprintjs/core'
+
+const TaskActivity = (props) => {
+  const { activePipeline, dayjs } = props
+
+  return (
+    <>
+
+      <div
+        className='pipeline-task-activity' style={{
+          padding: '20px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis'
+          // paddingTop: '7px',
+          // borderTop: '1px solid #f5f5f5',
+          // marginTop: '14px',
+          // marginBottom: '36px'
+        }}
+      >
+        {activePipeline?.ID && activePipeline.tasks && activePipeline.tasks.map((t, tIdx) => (
+          <div
+            className='pipeline-task-row'
+            key={`pipeline-task-key-${tIdx}`}
+            style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '12px' }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'center', paddingRight: '8px', width: '32px', minWidth: '32px' }}>
+              {t.status === 'TASK_COMPLETED' && (
+                <Icon icon='small-tick' size={18} color={Colors.GREEN5} style={{ marginLeft: '0' }} />
+              )}
+              {t.status === 'TASK_FAILED' && (
+                <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
+              )}
+              {t.status === 'TASK_RUNNING' && (
+                <Spinner
+                  className='task-spinner'
+                  size={14}
+                  intent={t.status === 'TASK_COMPLETED' ? 'success' : 'warning'}
+                  value={t.status === 'TASK_COMPLETED' ? 1 : t.progress}
+                />
+              )}
+            </div>
+            <div
+              className='pipeline-task-cell-name'
+              style={{ padding: '0 8px', minWidth: '100px', display: 'flex', justifyContent: 'space-between' }}
+            >
+              <strong
+                className='task-plugin-name'
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
+                {t.plugin}
+              </strong>
+
+            </div>
+            <div
+              className='pipeline-task-cell-settings'
+              style={{
+                padding: '0 8px',
+                display: 'flex',
+                width: '20%',
+                minWidth: '20%',
+                // whiteSpace: 'nowrap',
+                justifyContent: 'flex-start',
+                // overflow: 'hidden',
+                // textOverflow: 'ellipsis',
+                flexGrow: 1
+              }}
+            >
+              {t.plugin !== 'jenkins' && (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <span style={{ color: Colors.GRAY2 }}>
+                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
+                  </span>
+                  {t.plugin === 'github' && (
+                    <span style={{ fontWeight: 60 }}>/{t.options[Object.keys(t.options)[1]]}</span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div
+              className='pipeline-task-cell-duration'
+              style={{
+                padding: '0',
+                minWidth: '80px',
+                // whiteSpace: 'nowrap',
+                textAlign: 'right'
+              }}
+            >
+              <span style={{ whiteSpace: 'nowrap' }}>
+                {(() => {
+                  let statusRelativeTime = dayjs(t.CreatedAt).toNow(true)
+                  switch (t.status) {
+                    case 'TASK_COMPLETED':
+                    case 'TASK_FAILED':
+                      statusRelativeTime = dayjs(t.UpdatedAt).from(t.CreatedAt, true)
+                      break
+                    case 'TASK_RUNNING':
+                    default:
+                      statusRelativeTime = dayjs(t.CreatedAt).toNow(true)
+                      break
+                  }
+                  return statusRelativeTime
+                })()}
+              </span>
+            </div>
+            <div
+              className='pipeline-task-cell-progress'
+              style={{
+                padding: '0 8px',
+                minWidth: '100px',
+                textAlign: 'right'
+              }}
+            >
+              <span style={{ fontWeight: t.status === 'TASK_COMPLETED' ? 800 : 600 }}>
+                {Number(t.status === 'TASK_COMPLETED' ? 100 : (t.progress / 1) * 100).toFixed(2)}%
+              </span>
+            </div>
+            <div
+              className='pipeline-task-cell-message'
+              style={{ display: 'flex', flexGrow: 1, width: '64%' }}
+            >
+              {/* {t.plugin !== 'jenkins' && (
+                <>
+                  <span style={{ color: Colors.GRAY2 }}>
+                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
+                  </span>
+                  {t.plugin === 'github' && (
+                    <span style={{ fontWeight: 60 }}>/{t.options[Object.keys(t.options)[1]]}</span>
+                  )}
+                </>
+              )} */}
+              {t.message && (
+                <div style={{ width: '98%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  <span style={{ color: t.status === 'TASK_FAILED' ? Colors.RED4 : Colors.GRAY3, paddingLeft: '10px' }}>
+                    {t.message}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+export default TaskActivity

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -6,6 +6,8 @@ import {
   Icon,
   Spinner,
   Colors,
+  Tooltip,
+  Position,
   // Alignment
 } from '@blueprintjs/core'
 import dayjs from '@/utils/time'
@@ -41,12 +43,19 @@ const TaskActivity = (props) => {
                 <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
               )}
               {t.status === 'TASK_RUNNING' && (
-                <Spinner
-                  className='task-spinner'
-                  size={14}
-                  intent={t.status === 'TASK_COMPLETED' ? 'success' : 'warning'}
-                  value={t.status === 'TASK_COMPLETED' ? 1 : t.progress}
-                />
+                <Tooltip content={`Task Running [STAGE ${t.pipelineRow}]`} position={Position.TOP}>
+                  <Spinner
+                    className='task-spinner'
+                    size={14}
+                    intent={t.status === 'TASK_COMPLETED' ? 'success' : 'warning'}
+                    value={t.status === 'TASK_COMPLETED' ? 1 : t.progress}
+                  />
+                </Tooltip>
+              )}
+              {t.status === 'TASK_CREATED' && (
+                <Tooltip content={`Task Created (Pending) [STAGE ${t.pipelineRow}]`} position={Position.TOP}>
+                  <Icon icon='pause' size={14} color={Colors.BLUE3} style={{ marginLeft: '0', marginBottom: '3px' }} />
+                </Tooltip>
               )}
             </div>
             <div

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -8,6 +8,7 @@ import {
   Colors,
   Tooltip,
   Position,
+  Intent,
   // Alignment
 } from '@blueprintjs/core'
 import dayjs from '@/utils/time'
@@ -29,14 +30,24 @@ const TaskActivity = (props) => {
           <div
             className='pipeline-task-row'
             key={`pipeline-task-key-${tIdx}`}
-            style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '12px', opacity: t.status === 'TASK_CREATED' ? 0.7 : 1 }}
+            style={{
+              display: 'flex',
+              padding: '4px 6px',
+              justifyContent: 'space-between',
+              fontSize: '12px',
+              opacity: t.status === 'TASK_CREATED' ? 0.7 : 1
+            }}
           >
             <div style={{ display: 'flex', justifyContent: 'center', paddingRight: '8px', width: '32px', minWidth: '32px' }}>
               {t.status === 'TASK_COMPLETED' && (
-                <Icon icon='small-tick' size={18} color={Colors.GREEN5} style={{ marginLeft: '0' }} />
+                <Tooltip content={`Task Complete [STAGE ${t.pipelineRow}]`} position={Position.TOP} intent={Intent.SUCCESS}>
+                  <Icon icon='small-tick' size={18} color={Colors.GREEN5} style={{ marginLeft: '0' }} />
+                </Tooltip>
               )}
               {t.status === 'TASK_FAILED' && (
-                <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
+                <Tooltip content={`Task Failed [STAGE ${t.pipelineRow}]`} position={Position.TOP} intent={Intent.PRIMARY}>
+                  <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
+                </Tooltip>
               )}
               {t.status === 'TASK_RUNNING' && (
                 <Tooltip content={`Task Running [STAGE ${t.pipelineRow}]`} position={Position.TOP}>

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -8,9 +8,10 @@ import {
   Colors,
   // Alignment
 } from '@blueprintjs/core'
+import dayjs from '@/utils/time'
 
 const TaskActivity = (props) => {
-  const { activePipeline, dayjs } = props
+  const { activePipeline } = props
 
   return (
     <>

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -23,17 +23,13 @@ const TaskActivity = (props) => {
           padding: '20px',
           overflow: 'hidden',
           textOverflow: 'ellipsis'
-          // paddingTop: '7px',
-          // borderTop: '1px solid #f5f5f5',
-          // marginTop: '14px',
-          // marginBottom: '36px'
         }}
       >
         {activePipeline?.ID && activePipeline.tasks && activePipeline.tasks.map((t, tIdx) => (
           <div
             className='pipeline-task-row'
             key={`pipeline-task-key-${tIdx}`}
-            style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '12px' }}
+            style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '12px', opacity: t.status === 'TASK_CREATED' ? 0.7 : 1 }}
           >
             <div style={{ display: 'flex', justifyContent: 'center', paddingRight: '8px', width: '32px', minWidth: '32px' }}>
               {t.status === 'TASK_COMPLETED' && (
@@ -54,7 +50,7 @@ const TaskActivity = (props) => {
               )}
               {t.status === 'TASK_CREATED' && (
                 <Tooltip content={`Task Created (Pending) [STAGE ${t.pipelineRow}]`} position={Position.TOP}>
-                  <Icon icon='pause' size={14} color={Colors.BLUE3} style={{ marginLeft: '0', marginBottom: '3px' }} />
+                  <Icon icon='pause' size={14} color={Colors.GRAY3} style={{ marginLeft: '0', marginBottom: '3px' }} />
                 </Tooltip>
               )}
             </div>

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -32,7 +32,7 @@ const TaskActivity = (props) => {
             key={`pipeline-task-key-${tIdx}`}
             style={{
               display: 'flex',
-              padding: '4px 6px',
+              padding: '4px 0',
               justifyContent: 'space-between',
               fontSize: '12px',
               opacity: t.status === 'TASK_CREATED' ? 0.7 : 1

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -127,16 +127,6 @@ const TaskActivity = (props) => {
               className='pipeline-task-cell-message'
               style={{ display: 'flex', flexGrow: 1, width: '64%' }}
             >
-              {/* {t.plugin !== 'jenkins' && (
-                <>
-                  <span style={{ color: Colors.GRAY2 }}>
-                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
-                  </span>
-                  {t.plugin === 'github' && (
-                    <span style={{ fontWeight: 60 }}>/{t.options[Object.keys(t.options)[1]]}</span>
-                  )}
-                </>
-              )} */}
               {t.message && (
                 <div style={{ width: '98%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                   <span style={{ color: t.status === 'TASK_FAILED' ? Colors.RED4 : Colors.GRAY3, paddingLeft: '10px' }}>

--- a/config-ui/src/data/NullPipelineTask.js
+++ b/config-ui/src/data/NullPipelineTask.js
@@ -1,0 +1,22 @@
+const NullPipelineTask = {
+  ID: null,
+  CreatedAt: null,
+  UpdatedAt: null,
+  plugin: null,
+  options: {
+  },
+  status: 'TASK_CREATED',
+  message: '',
+  progress: 0,
+  pipelineId: null,
+  pipelineRow: 1,
+  pipelineCol: 1,
+  beganAt: null,
+  finishedAt: null,
+  spentSeconds: 0
+
+}
+
+export {
+  NullPipelineTask
+}

--- a/config-ui/src/hooks/usePipelineManager.jsx
+++ b/config-ui/src/hooks/usePipelineManager.jsx
@@ -18,7 +18,7 @@ function usePipelineManager (pipelineName = `COLLECTION ${Date.now()}`, initialT
     ]
   })
 
-  const [activePipeline, setActivePipeline] = useState()
+  const [activePipeline, setActivePipeline] = useState(NullPipelineRun)
   const [lastRunId, setLastRunId] = useState(null)
   const [pipelineRun, setPipelineRun] = useState(NullPipelineRun)
 
@@ -72,6 +72,10 @@ function usePipelineManager (pipelineName = `COLLECTION ${Date.now()}`, initialT
   }, [])
 
   const fetchPipeline = useCallback((pipelineID, refresh = false) => {
+    if (!pipelineID) {
+      console.log('>> !ABORT! Pipeline ID Missing! Aborting Fetch...')
+      // return ToastNotification.show({ message: 'Pipeline ID Missing! Aborting Fetch...', intent: 'danger', icon: 'warning-sign' })
+    }
     try {
       setIsFetching(true)
       setErrors([])
@@ -84,7 +88,7 @@ function usePipelineManager (pipelineName = `COLLECTION ${Date.now()}`, initialT
         console.log('>> RAW PIPELINE TASKS DATA FROM API...', t.data)
         setActivePipeline({
           ...p.data,
-          tasks: t.data
+          tasks: [...t.data.tasks]
         })
         setPipelineRun((pR) => refresh ? { ...p.data, tasks: [...t.data.tasks] } : pR)
         setLastRunId((lrId) => refresh ? p.data?.ID : lrId)

--- a/config-ui/src/hooks/usePipelineManager.jsx
+++ b/config-ui/src/hooks/usePipelineManager.jsx
@@ -127,10 +127,6 @@ function usePipelineManager (pipelineName = `COLLECTION ${Date.now()}`, initialT
   // }
 
   useEffect(() => {
-    // setIntegrations(integrationsData)
-  }, [])
-
-  useEffect(() => {
     console.log('>> PIPELINE MANAGER - RECEIVED RUN/TASK SETTINGS', settings)
   }, [settings])
 

--- a/config-ui/src/hooks/usePipelineManager.jsx
+++ b/config-ui/src/hooks/usePipelineManager.jsx
@@ -142,6 +142,7 @@ function usePipelineManager (pipelineName = `COLLECTION ${Date.now()}`, initialT
     errors,
     isRunning,
     isFetching,
+    isCancelling,
     settings,
     setSettings,
     pipelineRun,

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -16,6 +16,9 @@ import {
   Position,
   Spinner,
   Colors,
+  Drawer,
+  DrawerSize,
+  TextArea,
   Link,
   Classes
 } from '@blueprintjs/core'
@@ -44,6 +47,8 @@ const PipelineActivity = (props) => {
   const [pipelineName, setPipelineName] = useState()
   const [pollTimer, setPollTimer] = useState(5000)
   // const [autoRefresh, setAutoRefresh] = useState(true)
+
+  const [showInspector, setShowInspector] = useState(false)
 
   const {
     runPipeline,
@@ -652,7 +657,7 @@ const PipelineActivity = (props) => {
                 <span>See <strong style={{ textDecoration: 'underline' }}>All Jobs</strong> to monitor all pipeline activity.</span>
                 <div>
                   <Button
-                    // onClick
+                    onClick={() => setShowInspector((iS) => !iS)}
                     icon='code' text='Inspect JSON' small minimal
                     style={{ marginRight: '3px', color: Colors.GRAY3 }}
                   />
@@ -669,6 +674,45 @@ const PipelineActivity = (props) => {
         </Content>
 
       </div>
+      <Drawer
+        className='drawer-json-inspector'
+        icon='code'
+        onClose={() => setShowInspector(false)}
+        title={`RUN No. ${activePipeline.ID} JSON Payload`}
+        position={Position.RIGHT}
+        size={DrawerSize.SMALL}
+        autoFocus
+        canEscapeKeyClose
+        canOutsideClickClose
+        enforceFocus
+        hasBackdrop
+        isOpen={showInspector}
+        usePortal
+      >
+        <div className={Classes.DRAWER_BODY}>
+          <div className={Classes.DIALOG_BODY}>
+            <h3 style={{ margin: 0, padding: '8px 0' }}>
+              <span style={{ float: 'right', fontSize: '9px', color: '#aaaaaa' }}>application/json</span> JSON RESPONSE
+            </h3>
+            <p>If you are submitting a <strong>Bug-Report</strong> regarding a Pipeline Run, include the output below for better debugging.</p>
+            <div className='formContainer'>
+              <Card
+                interactive={false}
+                elevation={Elevation.ZERO}
+                style={{ padding: '6px 12px', minWidth: '320px', width: '100%', maxWidth: '601px', marginBottom: '20px', overflow: 'auto' }}
+              >
+
+                <code>
+                  <pre style={{ fontSize: '10px' }}>
+                    {JSON.stringify(activePipeline, null, '  ')}
+                  </pre>
+                </code>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </Drawer>
+
     </>
   )
 }

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -1,0 +1,506 @@
+import React, { Fragment, useEffect, useCallback, useState, useRef } from 'react'
+import { CSSTransition } from 'react-transition-group'
+import { useHistory, useParams } from 'react-router-dom'
+import { ToastNotification } from '@/components/Toast'
+import { GRAFANA_URL } from '@/utils/config'
+import request from '@/utils/request'
+import {
+  H2, Button, Icon, Intent,
+  ButtonGroup, InputGroup, Input,
+  Card, Elevation, Tag,
+  Popover,
+  Tooltip,
+  Position,
+  Spinner,
+  Colors,
+  Link,
+  Classes
+} from '@blueprintjs/core'
+import { integrationsData } from '@/data/integrations'
+import usePipelineManager from '@/hooks/usePipelineManager'
+import Nav from '@/components/Nav'
+import Sidebar from '@/components/Sidebar'
+import AppCrumbs from '@/components/Breadcrumbs'
+import Content from '@/components/Content'
+import ContentLoader from '@/components/loaders/ContentLoader'
+import { ReactComponent as GitlabProviderIcon } from '@/images/integrations/gitlab.svg'
+import { ReactComponent as JenkinsProviderIcon } from '@/images/integrations/jenkins.svg'
+import { ReactComponent as JiraProviderIcon } from '@/images/integrations/jira.svg'
+import { ReactComponent as GitHubProviderIcon } from '@/images/integrations/github.svg'
+
+import '@/styles/offline.scss'
+import { TAB_LIST } from '@blueprintjs/core/lib/esm/common/classes'
+
+const PipelineActivity = (props) => {
+  const history = useHistory()
+  const { pId } = useParams()
+
+  const [pipelineId, setPipelineId] = useState() // @todo REMOVE TEST RUN ID!
+  const [activeProvider, setActiveProvider] = useState(integrationsData[0])
+  const [pipelineName, setPipelineName] = useState()
+
+  const {
+    runPipeline,
+    cancelPipeline,
+    fetchPipeline,
+    activePipeline,
+    // pipelineRun,
+    isRunning,
+    isFetching,
+    errors: pipelineErrors,
+    // setSettings: setPipelineSettings,
+    lastRunId
+  } = usePipelineManager(pipelineName)
+
+  // useEffect(() => {
+  //   setActiveProvider(providerId ? integrationsData.find(p => p.id === providerId) : integrationsData[0])
+  // }, [providerId])
+
+  useEffect(() => {
+    setPipelineId(pId)
+    console.log('>>> REQUESTED PIPELINE ID ===', pId)
+  }, [pId])
+
+  useEffect(() => {
+    if (pipelineId) {
+      fetchPipeline(pipelineId)
+    }
+  }, [pipelineId, fetchPipeline])
+
+  useEffect(() => {
+    console.log('>>> TASKS KEY', activePipeline.tasks)
+  }, [])
+
+  return (
+    <>
+      <div className='container container-pipeline-activity'>
+        <Nav />
+        <Sidebar />
+        <Content>
+          <main className='main'>
+            <AppCrumbs
+              items={[
+                { href: '/', icon: false, text: 'Dashboard' },
+                { href: '/pipelines/create', icon: false, text: 'Pipelines', disabled: true },
+                { href: `/pipelines/activity/${pipelineId}`, icon: false, text: 'Pipeline Activity', current: true },
+              ]}
+            />
+            <div className='headlineContainer'>
+              {/* <Link style={{ float: 'right', marginLeft: '10px', color: '#777777' }} to='/integrations'>
+                <Icon icon='fast-backward' size={16} /> Go Back
+              </Link> */}
+              <div style={{ display: 'flex' }}>
+                <div>
+                  <span style={{ marginRight: '10px' }}>
+                    <Icon icon='pulse' size={32} color={Colors.RED5} />
+                  </span>
+                </div>
+                <div>
+                  <h1 style={{ margin: 0 }}>
+                    Pipeline Activity
+                    {activePipeline?.ID && (
+                      <>
+                        <span style={{ paddingLeft: '10px' }}>&rarr;
+                          <strong style={{ paddingLeft: '10px' }}>
+                            #{pipelineId}
+                          </strong>
+                        </span>
+                      </>
+                    )}
+                  </h1>
+                  <p className='page-description mb-0'>View the collection stages for a Pipeline  Run.</p>
+                  <p style={{ margin: '0 0 36px 0', padding: 0 }}>
+                    You may <strong>Cancel</strong> a running pipeline before it completes.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {isFetching && (
+              <ContentLoader title='Loading Pipeline Run ...' message='Please wait while pipeline activity is loaded.' />
+            )}
+            {!isFetching && activePipeline?.ID && (
+              <>
+                <div style={{ marginBottom: '24px', width: '100%' }}>
+                  <Card
+                    className='pipeline-activity-card'
+                    elevation={Elevation.TWO}
+                    style={{ width: '100%', display: 'flex', }}
+                  >
+                    <div
+                      className='pipeline-activity' style={{
+                        display: 'flex',
+                        width: '100%',
+                        justifyContent: 'space-between'
+                      }}
+                    >
+
+                      <div className='pipeline-info' style={{ paddingRight: '12px' }}>
+                        <h2 className='headline' style={{ marginTop: '0' }}>
+                          <span
+                            className='pipeline-name'
+                            style={{
+                              textOverflow: 'ellipsis',
+                              overflow: 'hidden',
+                              whiteSpace: 'nowrap',
+                              display: 'block',
+                              maxWidth: '430px',
+                              color: activePipeline.status === 'TASK_FAILED' ? Colors.RED4 : ''
+                            }}
+                          >{activePipeline.name || 'Unamed Collection'}
+                          </span>
+                        </h2>
+                        <div className='pipeline-timestamp'>
+                          2021-12-08 08:00 AM (UTC)
+                        </div>
+                        {/* <div>
+                  <label>Run Date (UTC)</label>
+                  <div>2021-12-08 08:00 AM</div>
+                </div> */}
+                      </div>
+                      <div className='pipeline-status' style={{ paddingRight: '12px' }}>
+                        <label style={{ color: Colors.GRAY3 }}>Status</label>
+                        <div style={{ fontSize: '14px', display: 'flex' }}>
+                          <span style={{ marginRight: '4px', color: activePipeline.status === 'TASK_RUNNING' ? '#0066FF' : '' }}>
+                            {activePipeline.status}
+                          </span>
+                          {activePipeline.status === 'TASK_FAILED' && (
+                            <Icon
+                              icon='warning-sign' size={16}
+                              color={Colors.RED5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
+                            />
+                          )}
+                          {activePipeline.status === 'TASK_COMPLETED' && (
+                            <Icon
+                              icon='tick' size={16}
+                              color={Colors.GREEN5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
+                            />
+                          )}
+                          {activePipeline.status === 'TASK_RUNNING' && (
+                            <Spinner
+                              className='pipeline-status-spinner'
+                              size={14}
+                              intent={activePipeline.status === 'TASK_COMPLETED' ? 'success' : 'danger'}
+                              value={activePipeline.status === 'TASK_COMPLETED' ? 1 : null}
+                            />
+                          )}
+                        </div>
+                      </div>
+                      <div className='pipeline-duration' style={{ paddingRight: '12px' }}>
+                        <label style={{ color: Colors.GRAY3 }}>Duration</label>
+                        <div style={{ fontSize: '14px' }}>
+                          {activePipeline.spentSeconds >= 60 ? `${Number(activePipeline.spentSeconds / 60).toFixed(2)}mins` : `${activePipeline.spentSeconds}secs`}
+                        </div>
+                      </div>
+                      <div className='pipeline-actions' style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                        {activePipeline.status === 'TASK_COMPLETED' && (
+                          <a
+                            className='bp3-button bp3-intent-primary'
+                            href={GRAFANA_URL}
+                            target='_blank'
+                            rel='noreferrer'
+                            style={{ backgroundColor: '#3bd477', color: '#ffffff' }}
+                          >
+                            <Icon icon='doughnut-chart' size={13} /> <span className='bp3-button-text'>Grafana</span>
+                          </a>
+                        )}
+                        {activePipeline.status === 'TASK_RUNNING' && (
+                          <Popover
+                            key='popover-help-key-cancel-run'
+                            className='trigger-pipeline-cancel'
+                            popoverClassName='popover-pipeline-cancel'
+                            position={Position.BOTTOM}
+                            autoFocus={false}
+                            enforceFocus={false}
+                            usePortal={false}
+                            disabled={activePipeline.status !== 'TASK_RUNNING'}
+                          >
+                            <Button
+                              className={`btn-cancel-pipeline${activePipeline.status !== 'TASK_RUNNING' ? '-disabled' : ''}`}
+                              icon='stop' text='CANCEL' intent={activePipeline.status !== 'TASK_RUNNING' ? '' : 'primary'}
+                              disabled={activePipeline.status !== 'TASK_RUNNING'}
+                            />
+                            <>
+                              <div style={{ fontSize: '12px', padding: '12px', maxWidth: '200px' }}>
+                                <p>Are you Sure you want to cancel this <strong>Run</strong>?</p>
+                                <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-end' }}>
+                                  <Button
+                                    text='CANCEL' minimal
+                                    small className={Classes.POPOVER_DISMISS}
+                                    stlye={{ marginLeft: 'auto', marginRight: '3px' }}
+                                  />
+                                  <Button
+                                    text='YES' icon='small-tick' intent={Intent.DANGER} small
+                                    onClick={() => cancelPipeline(activePipeline.ID)}
+                                  />
+                                </div>
+                              </div>
+                            </>
+                          </Popover>
+                        )}
+                        {activePipeline.status === 'TASK_FAILED' && (
+                          <Button
+                            className='btn-restart-pipeline'
+                            icon='reset'
+                            text='RESTART'
+                            intent='warning'
+                            disabled={activePipeline.status !== 'TASK_FAILED'}
+                          />
+                        )}
+                        <Button
+                          icon='refresh'
+                          style={{ marginLeft: '5px' }}
+                          disabled={activePipeline.status === 'TASK_RUNNING' || activePipeline.status === 'TASK_FAILED'}
+                          minimal
+                        />
+                      </div>
+
+                    </div>
+                  </Card>
+                  <p style={{ padding: '5px 3px', fontSize: '10px' }}>
+                    {activePipeline.finishedTasks}/{activePipeline.totalTasks} Tasks Completed
+                    <span style={{ padding: '0 2px' }}><Icon icon='dot' size={10} color={Colors.GRAY4} /></span>
+                    <strong>Created </strong> {activePipeline.CreatedAt}
+                  </p>
+                </div>
+
+                <div className='stage-activity' style={{ alignSelf: 'flex-start', width: '100%' }}>
+                  <h2 className='headline'>
+                    <Icon icon='layers' height={16} size={16} color='rgba(0,0,0,0.5)' /> Stages and Tasks
+                  </h2>
+                  <p>Monitor <strong>Duration</strong> and <strong>Progress</strong> for all tasks. <strong>Grafana</strong> access will be  enabled when the pipeline completes.</p>
+                  <h3 style={{ fontSize: '20px' }}>Stage 1</h3>
+                  <div style={{
+                    paddingTop: '7px',
+                    // borderTop: '1px solid #f5f5f5',
+                    marginTop: '14px',
+                    marginBottom: '36px'
+                  }}
+                  >
+                    {activePipeline?.ID && activePipeline.tasks && activePipeline.tasks.map((t, tIdx) => (
+                      <div
+                        className='pipeline-task-'
+                        key={`pipeline-task-key-${tIdx}`}
+                        style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '14px' }}
+                      >
+                        <div style={{ display: 'flex', justifyContent: 'center', paddingRight: '8px', width: '32px', minWidth: '32px' }}>
+                          {t.status === 'TASK_COMPLETED' && (
+                            <Icon icon='small-tick' size={18} color={Colors.GREEN5} style={{ marginLeft: '0' }} />
+                          )}
+                          {t.status === 'TASK_FAILED' && (
+                            <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
+                          )}
+                          {t.status === 'TASK_RUNNING' && (
+                            <Spinner
+                              className='task-spinner'
+                              size={14}
+                              intent={t.status === 'TASK_COMPLETED' ? 'success' : 'warning'}
+                              value={t.status === 'TASK_COMPLETED' ? 1 : t.progress}
+                            />
+                          )}
+                        </div>
+                        <div style={{ padding: '0 8px', width: '30%', display: 'flex', justifyContent: 'space-between' }}>
+                          <strong
+                            className='task-plugin-name'
+                            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                          >
+                            {t.plugin}
+                          </strong>
+                          {/* <div style={{
+                            width: '120px',
+                            // backgroundColor: '#f0f0f0',
+                            justifyContent: 'flex-end',
+                            display: 'flex',
+                            textAlign: 'right'
+                          }}
+                          >
+                            <span style={{ fontSize: '10px', color: Colors.GRAY3, alignSelf: 'center' }}>
+                              {t.plugin !== 'jenkins' && (
+                                <span>
+                                  {Object.keys(t.options)[0]}
+                                </span>
+                              )}
+                              {t.plugin === 'github' && (
+                                <span>
+                                  <br />{Object.keys(t.options)[1]}
+                                </span>
+                              )}
+                            </span>
+                          </div>
+                          <div style={{
+                            width: '120px',
+                            display: 'flex',
+                            alignContent: 'flex-start',
+                            // backgroundColor: '#f7f7f7',
+                            marginRight: 'auto',
+                            paddingLeft: '10px'
+                          }}
+                          >
+                            <span style={{ fontSize: '10px', color: Colors.GRAY3, alignSelf: 'center', fontWeight: 600 }}>
+                              {t.plugin !== 'jenkins' && (
+                                <span>
+                                  {t.options[Object.keys(t.options)[0]]}
+                                </span>
+                              )}
+                              {t.plugin === 'github' && (
+                                <span>
+                                  <br />{t.options[Object.keys(t.options)[1]]}
+                                </span>
+                              )}
+                            </span>
+                          </div> */}
+                          {/* {t.status === 'TASK_COMPLETED' && (
+                            <Icon icon='small-tick' size={14} color={Colors.GREEN5} style={{ marginLeft: '5px' }} />
+                          )}
+                          {t.status === 'TASK_FAILED' && (
+                            <Icon icon='warning-sign' size={11} color={Colors.RED5} style={{ marginLeft: '5px', marginBottom: '3px' }} />
+                          )} */}
+                        </div>
+                        <div style={{
+                          padding: '0',
+                          minWidth: '80px',
+                          textAlign: 'right'
+                        }}
+                        ><span>{t.spentSeconds >= 60 ? `${Number(t.spentSeconds / 60).toFixed(2)}mins` : `${t.spentSeconds}secs`}</span>
+                        </div>
+                        <div style={{
+                          padding: '0 8px',
+                          minWidth: '100px',
+                          textAlign: 'right'
+                        }}
+                        >
+                          <span style={{ fontWeight: t.status === 'TASK_COMPLETED' ? 800 : 600 }}>
+                            {Number(t.status === 'TASK_COMPLETED' ? 100 : (t.progress / 1) * 100).toFixed(2)}%
+                          </span>
+                        </div>
+                        <div style={{ width: '70%', paddingLeft: '10px', fontSize: '12px' }}>
+                          {t.plugin !== 'jenkins' && (
+                            <>
+                              <span style={{ color: Colors.GRAY2 }}>
+                                <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
+                              </span>
+                              {t.plugin === 'github' && (
+                                <span style={{ fontWeight: 60 }}>/{t.options[Object.keys(t.options)[1]]}</span>
+                              )}
+                            </>
+                          )}
+                          {t.message && (<><span style={{ color: t.status === 'TASK_FAILED' ? Colors.RED4 : Colors.GRAY3, paddingLeft: '10px' }}>{t.message}</span></>)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className='run-settings' style={{ alignSelf: 'flex-start', width: '100%' }}>
+                  <h2 className='headline'>
+                    <Icon icon='cloud-upload' height={16} size={16} color='rgba(0,0,0,0.5)' /> Run Settings
+                  </h2>
+                  <p>Data Provider settings configured for this pipeline execution.</p>
+
+                  <div style={{ padding: '0 10px', display: 'flex', marginTop: '24px', justifyContent: 'space-between', width: '100%' }}>
+                    <div className='jenkins-settings' style={{ display: 'flex' }}>
+                      <div style={{ display: 'flex', padding: '2px 6px' }}>
+                        <JenkinsProviderIcon width={24} height={24} />
+                      </div>
+                      <div>
+                        <label>Auto</label><br />
+                        <span style={{ color: Colors.GRAY3 }}>(No Settings)</span>
+                      </div>
+                    </div>
+                    <div className='jira-settings' style={{ display: 'flex' }}>
+                      <div style={{ display: 'flex', padding: '2px 6px' }}>
+                        <JiraProviderIcon width={24} height={24} />
+                      </div>
+                      <div>
+                        <label style={{ display: 'block', fontSize: '14px', marginTop: '3px', marginBottom: '10px' }}>Board IDs</label>
+                        {activePipeline.tasks.filter(t => t.plugin === 'jira').map((t, tIdx) => (
+                          <div key={`board-id-key-${tIdx}`}>
+                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                            <span>
+                              {t.options[Object.keys(t.options)[0]]} on Server #{t.options[Object.keys(t.options)[1]]}<br />
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    <div className='gitlab-settings' style={{ display: 'flex' }}>
+                      <div style={{ display: 'flex', padding: '2px 6px' }}>
+                        <GitlabProviderIcon width={24} height={24} />
+                      </div>
+                      <div>
+                        <label style={{ display: 'block', fontSize: '14px', marginTop: '3px', marginBottom: '10px' }}>Project IDs</label>
+                        {activePipeline.tasks.filter(t => t.plugin === 'gitlab').map((t, tIdx) => (
+                          <div key={`project-id-key-${tIdx}`}>
+                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                            <span>
+                              {t.options[Object.keys(t.options)[0]]}<br />
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    <div className='github-settings' style={{ display: 'flex' }}>
+                      <div style={{ display: 'flex', padding: '2px 6px' }}>
+                        <GitHubProviderIcon width={24} height={24} />
+                      </div>
+                      <div>
+                        <label style={{ display: 'block', fontSize: '14px', marginTop: '3px', marginBottom: '10px' }}>Repositories</label>
+                        {activePipeline.tasks.filter(t => t.plugin === 'github').map((t, tIdx) => (
+                          <div key={`repostitory-id-key-${tIdx}`}>
+                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                            <span>
+                              <strong>{t.options[Object.keys(t.options)[0]]}</strong><span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
+                              <strong>{t.options[Object.keys(t.options)[1]]}</strong>
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {!pipelineId && (
+              <Card elevation={Elevation.TWO} style={{ display: 'flex', alignSelf: 'flex-start' }}>
+                <div style={{ display: 'flex', alignSelf: 'flex-start', flexDirection: 'column' }}>
+                  <h2 style={{ margin: '0 0 12px 0'}}><Icon icon='warning-sign' color={Colors.RED4} size={16} style={{ marginBottom: '4px' }} /> Pipeline Run ID <strong>Missing</strong>...</h2>
+                  <p>Please provide a Pipeline ID to load Run activity and details.<br /> Check the Address URL in your Browser and try again.</p>
+                </div>
+              </Card>
+            )}
+
+            <div style={{
+              marginTop: '40px',
+              borderTop: '1px solid #f0f0f0',
+              display: 'flex',
+              width: '100%',
+              justifyContent: 'flex-start'
+            }}
+            >
+
+              <div style={{ padding: '8px', display: 'flex', width: '100%', justifyContent: 'space-between' }}>
+                <span>See <strong style={{ textDecoration: 'underline' }}>All Jobs</strong> to monitor all pipeline activity.</span>
+                <div>
+                  <Button
+                    // onClick
+                    icon='code' text='Inspect JSON' small minimal
+                    style={{ marginRight: '3px', color: Colors.GRAY3 }}
+                  />
+                  <Button
+                    onClick={() => history.push('/pipelines/create')}
+                    icon='add' text='Create New Run' small minimal
+                  />
+                </div>
+              </div>
+            </div>
+
+          </main>
+
+        </Content>
+
+      </div>
+    </>
+  )
+}
+
+export default PipelineActivity

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -36,6 +36,7 @@ import { ReactComponent as GitHubProviderIcon } from '@/images/integrations/gith
 import { ReactComponent as PipelineRunningIcon } from '@/images/synchronize.svg'
 import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.svg'
 import { ReactComponent as PipelineCompleteIcon } from '@/images/check-circle.svg'
+import { ReactComponent as HelpIcon } from '@/images/help.svg'
 
 const PipelineActivity = (props) => {
   const history = useHistory()
@@ -49,6 +50,7 @@ const PipelineActivity = (props) => {
   // const [autoRefresh, setAutoRefresh] = useState(true)
 
   const [showInspector, setShowInspector] = useState(false)
+  const [pipelineReady, setPipelineReady] = useState(false)
 
   const {
     runPipeline,
@@ -109,9 +111,9 @@ const PipelineActivity = (props) => {
     console.log('>>> TASKS KEY', activePipeline.tasks)
   }, [])
 
-  // useEffect(() => {
-
-  // }, [pipelineId, fetchPipeline])
+  useEffect(() => {
+    setPipelineReady(activePipeline.ID !== null && !isFetching)
+  }, [activePipeline.ID, isFetching])
 
   return (
     <>
@@ -124,7 +126,7 @@ const PipelineActivity = (props) => {
               items={[
                 { href: '/', icon: false, text: 'Dashboard' },
                 { href: '/pipelines/create', icon: false, text: 'Pipelines', disabled: true },
-                { href: `/pipelines/activity/${pipelineId}`, icon: false, text: 'Pipeline Activity', current: true },
+                { href: `/pipelines/activity/${pipelineId}`, icon: false, text: 'Pipeline Activity & Details', current: true },
               ]}
             />
             <div className='headlineContainer'>
@@ -149,6 +151,26 @@ const PipelineActivity = (props) => {
                         </span>
                       </>
                     )}
+                    <Popover
+                      className='trigger-pipeline-activity-help'
+                      popoverClassName='popover-help-pipeline-activity'
+                      position={Position.RIGHT}
+                      autoFocus={false}
+                      enforceFocus={false}
+                      usePortal={false}
+                    >
+                      <a href='#' rel='noreferrer'><HelpIcon width={19} height={19} style={{ marginLeft: '10px' }} /></a>
+                      <>
+                        <div style={{ textShadow: 'none', fontSize: '12px', padding: '12px', maxWidth: '300px' }}>
+                          <div style={{ marginBottom: '10px', fontWeight: 700, fontSize: '14px', fontFamily: '"Montserrat", sans-serif' }}>
+                            <Icon icon='help' size={16} /> Pipeline RUN Activity
+                          </div>
+                          <p>Need Help? &mdash; For better accuracy, ensure that all of your Data Integrations
+                            successfully pass the <strong>Connection Test</strong>.
+                          </p>
+                        </div>
+                      </>
+                    </Popover>
                   </h1>
                   <p className='page-description mb-0'>View the collection stages for a Pipeline  Run.</p>
                   <p style={{ margin: '0 0 36px 0', padding: 0 }}>
@@ -163,142 +185,149 @@ const PipelineActivity = (props) => {
             {!isFetching && activePipeline?.ID && (
               <>
                 <div style={{ marginBottom: '24px', width: '100%' }}>
-                  <Card
-                    className='pipeline-activity-card'
-                    elevation={Elevation.TWO}
-                    style={{ width: '100%', display: 'flex', }}
+                  <CSSTransition
+                    in={pipelineReady}
+                    timeout={300}
+                    classNames='activity-panel'
+                    unmountOnExit
                   >
-                    <div
-                      className='pipeline-activity' style={{
-                        display: 'flex',
-                        width: '100%',
-                        justifyContent: 'space-between'
-                      }}
+                    <Card
+                      className='pipeline-activity-card'
+                      elevation={Elevation.TWO}
+                      style={{ width: '100%', display: 'flex', }}
                     >
+                      <div
+                        className='pipeline-activity' style={{
+                          display: 'flex',
+                          width: '100%',
+                          justifyContent: 'space-between'
+                        }}
+                      >
 
-                      <div className='pipeline-info' style={{ paddingRight: '12px' }}>
-                        <h2 className='headline' style={{ marginTop: '0' }}>
-                          <span
-                            className='pipeline-name'
-                            style={{
-                              textOverflow: 'ellipsis',
-                              overflow: 'hidden',
-                              whiteSpace: 'nowrap',
-                              display: 'block',
-                              maxWidth: '430px',
-                              color: activePipeline.status === 'TASK_FAILED' ? Colors.RED4 : ''
-                            }}
-                          >{activePipeline.name || 'Unamed Collection'}
-                          </span>
-                        </h2>
-                        <div className='pipeline-timestamp'>
-                          2021-12-08 08:00 AM (UTC)
+                        <div className='pipeline-info' style={{ paddingRight: '12px' }}>
+                          <h2 className='headline' style={{ marginTop: '0' }}>
+                            <span
+                              className='pipeline-name'
+                              style={{
+                                textOverflow: 'ellipsis',
+                                overflow: 'hidden',
+                                whiteSpace: 'nowrap',
+                                display: 'block',
+                                maxWidth: '430px',
+                                color: activePipeline.status === 'TASK_FAILED' ? Colors.RED4 : ''
+                              }}
+                            >{activePipeline.name || 'Unamed Collection'}
+                            </span>
+                          </h2>
+                          <div className='pipeline-timestamp'>
+                            2021-12-08 08:00 AM (UTC)
+                          </div>
+                          {/* <div>
+                    <label>Run Date (UTC)</label>
+                    <div>2021-12-08 08:00 AM</div>
+                  </div> */}
                         </div>
-                        {/* <div>
-                  <label>Run Date (UTC)</label>
-                  <div>2021-12-08 08:00 AM</div>
-                </div> */}
-                      </div>
-                      <div className='pipeline-status' style={{ paddingRight: '12px' }}>
-                        <label style={{ color: Colors.GRAY3 }}>Status</label>
-                        <div style={{ fontSize: '14px', display: 'flex' }}>
-                          <span style={{ marginRight: '4px', color: activePipeline.status === 'TASK_RUNNING' ? '#0066FF' : '' }}>
-                            {activePipeline.status}
-                          </span>
-                          {activePipeline.status === 'TASK_FAILED' && (
-                            <Icon
-                              icon='warning-sign' size={16}
-                              color={Colors.RED5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
-                            />
-                          )}
+                        <div className='pipeline-status' style={{ paddingRight: '12px' }}>
+                          <label style={{ color: Colors.GRAY3 }}>Status</label>
+                          <div style={{ fontSize: '14px', display: 'flex' }}>
+                            <span style={{ marginRight: '4px', color: activePipeline.status === 'TASK_RUNNING' ? '#0066FF' : '' }}>
+                              {activePipeline.status}
+                            </span>
+                            {activePipeline.status === 'TASK_FAILED' && (
+                              <Icon
+                                icon='warning-sign' size={16}
+                                color={Colors.RED5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
+                              />
+                            )}
+                            {activePipeline.status === 'TASK_COMPLETED' && (
+                              <Icon
+                                icon='tick' size={16}
+                                color={Colors.GREEN5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
+                              />
+                            )}
+                            {activePipeline.status === 'TASK_RUNNING' && (
+                              <Spinner
+                                className='pipeline-status-spinner'
+                                size={14}
+                                intent={activePipeline.status === 'TASK_COMPLETED' ? 'success' : 'danger'}
+                                value={activePipeline.status === 'TASK_COMPLETED' ? 1 : null}
+                              />
+                            )}
+                          </div>
+                        </div>
+                        <div className='pipeline-duration' style={{ paddingRight: '12px' }}>
+                          <label style={{ color: Colors.GRAY3 }}>Duration</label>
+                          <div style={{ fontSize: '14px', whiteSpace: 'nowrap' }}>
+                            {/* {activePipeline.spentSeconds >= 60 ? `${Number(activePipeline.spentSeconds / 60).toFixed(2)}mins` : `${activePipeline.spentSeconds}secs`} */}
+                            {activePipeline.status === 'TASK_RUNNING' ? dayjs(activePipeline.CreatedAt).toNow(true) : dayjs(activePipeline.UpdatedAt).from(activePipeline.CreatedAt, true)}
+                          </div>
+                        </div>
+                        <div className='pipeline-actions' style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                           {activePipeline.status === 'TASK_COMPLETED' && (
-                            <Icon
-                              icon='tick' size={16}
-                              color={Colors.GREEN5} style={{ alignSelf: 'flex-start', marginLeft: '5px', marginBottom: '2px' }}
-                            />
+                            <a
+                              className='bp3-button bp3-intent-primary'
+                              href={GRAFANA_URL}
+                              target='_blank'
+                              rel='noreferrer'
+                              style={{ backgroundColor: '#3bd477', color: '#ffffff' }}
+                            >
+                              <Icon icon='doughnut-chart' size={13} /> <span className='bp3-button-text'>Grafana</span>
+                            </a>
                           )}
                           {activePipeline.status === 'TASK_RUNNING' && (
-                            <Spinner
-                              className='pipeline-status-spinner'
-                              size={14}
-                              intent={activePipeline.status === 'TASK_COMPLETED' ? 'success' : 'danger'}
-                              value={activePipeline.status === 'TASK_COMPLETED' ? 1 : null}
+                            <Popover
+                              key='popover-help-key-cancel-run'
+                              className='trigger-pipeline-cancel'
+                              popoverClassName='popover-pipeline-cancel'
+                              position={Position.BOTTOM}
+                              autoFocus={false}
+                              enforceFocus={false}
+                              usePortal={false}
+                              disabled={activePipeline.status !== 'TASK_RUNNING'}
+                            >
+                              <Button
+                                className={`btn-cancel-pipeline${activePipeline.status !== 'TASK_RUNNING' ? '-disabled' : ''}`}
+                                icon='stop' text='CANCEL' intent={activePipeline.status !== 'TASK_RUNNING' ? '' : 'primary'}
+                                disabled={activePipeline.status !== 'TASK_RUNNING'}
+                              />
+                              <>
+                                <div style={{ fontSize: '12px', padding: '12px', maxWidth: '200px' }}>
+                                  <p>Are you Sure you want to cancel this <strong>Run</strong>?</p>
+                                  <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-end' }}>
+                                    <Button
+                                      text='CANCEL' minimal
+                                      small className={Classes.POPOVER_DISMISS}
+                                      stlye={{ marginLeft: 'auto', marginRight: '3px' }}
+                                    />
+                                    <Button
+                                      text='YES' icon='small-tick' intent={Intent.DANGER} small
+                                      onClick={() => cancelPipeline(activePipeline.ID)}
+                                    />
+                                  </div>
+                                </div>
+                              </>
+                            </Popover>
+                          )}
+                          {activePipeline.status === 'TASK_FAILED' && (
+                            <Button
+                              className='btn-restart-pipeline'
+                              icon='reset'
+                              text='RESTART'
+                              intent='warning'
+                              disabled={activePipeline.status !== 'TASK_FAILED'}
                             />
                           )}
-                        </div>
-                      </div>
-                      <div className='pipeline-duration' style={{ paddingRight: '12px' }}>
-                        <label style={{ color: Colors.GRAY3 }}>Duration</label>
-                        <div style={{ fontSize: '14px', whiteSpace: 'nowrap' }}>
-                          {/* {activePipeline.spentSeconds >= 60 ? `${Number(activePipeline.spentSeconds / 60).toFixed(2)}mins` : `${activePipeline.spentSeconds}secs`} */}
-                          {activePipeline.status === 'TASK_RUNNING' ? dayjs(activePipeline.CreatedAt).toNow(true) : dayjs(activePipeline.UpdatedAt).from(activePipeline.CreatedAt, true)}
-                        </div>
-                      </div>
-                      <div className='pipeline-actions' style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                        {activePipeline.status === 'TASK_COMPLETED' && (
-                          <a
-                            className='bp3-button bp3-intent-primary'
-                            href={GRAFANA_URL}
-                            target='_blank'
-                            rel='noreferrer'
-                            style={{ backgroundColor: '#3bd477', color: '#ffffff' }}
-                          >
-                            <Icon icon='doughnut-chart' size={13} /> <span className='bp3-button-text'>Grafana</span>
-                          </a>
-                        )}
-                        {activePipeline.status === 'TASK_RUNNING' && (
-                          <Popover
-                            key='popover-help-key-cancel-run'
-                            className='trigger-pipeline-cancel'
-                            popoverClassName='popover-pipeline-cancel'
-                            position={Position.BOTTOM}
-                            autoFocus={false}
-                            enforceFocus={false}
-                            usePortal={false}
-                            disabled={activePipeline.status !== 'TASK_RUNNING'}
-                          >
-                            <Button
-                              className={`btn-cancel-pipeline${activePipeline.status !== 'TASK_RUNNING' ? '-disabled' : ''}`}
-                              icon='stop' text='CANCEL' intent={activePipeline.status !== 'TASK_RUNNING' ? '' : 'primary'}
-                              disabled={activePipeline.status !== 'TASK_RUNNING'}
-                            />
-                            <>
-                              <div style={{ fontSize: '12px', padding: '12px', maxWidth: '200px' }}>
-                                <p>Are you Sure you want to cancel this <strong>Run</strong>?</p>
-                                <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-end' }}>
-                                  <Button
-                                    text='CANCEL' minimal
-                                    small className={Classes.POPOVER_DISMISS}
-                                    stlye={{ marginLeft: 'auto', marginRight: '3px' }}
-                                  />
-                                  <Button
-                                    text='YES' icon='small-tick' intent={Intent.DANGER} small
-                                    onClick={() => cancelPipeline(activePipeline.ID)}
-                                  />
-                                </div>
-                              </div>
-                            </>
-                          </Popover>
-                        )}
-                        {activePipeline.status === 'TASK_FAILED' && (
                           <Button
-                            className='btn-restart-pipeline'
-                            icon='reset'
-                            text='RESTART'
-                            intent='warning'
-                            disabled={activePipeline.status !== 'TASK_FAILED'}
+                            icon='refresh'
+                            style={{ marginLeft: '5px' }}
+                            disabled={activePipeline.status === 'TASK_RUNNING' || activePipeline.status === 'TASK_FAILED'}
+                            minimal
                           />
-                        )}
-                        <Button
-                          icon='refresh'
-                          style={{ marginLeft: '5px' }}
-                          disabled={activePipeline.status === 'TASK_RUNNING' || activePipeline.status === 'TASK_FAILED'}
-                          minimal
-                        />
-                      </div>
+                        </div>
 
-                    </div>
-                  </Card>
+                      </div>
+                    </Card>
+                  </CSSTransition>
                   <p style={{ padding: '5px 3px', fontSize: '10px' }}>
                     {activePipeline.finishedTasks}/{activePipeline.totalTasks} Tasks Completed
                     <span style={{ padding: '0 2px' }}><Icon icon='dot' size={10} color={Colors.GRAY4} /></span>
@@ -313,74 +342,102 @@ const PipelineActivity = (props) => {
                   <p>Monitor <strong>Duration</strong> and <strong>Progress</strong> completion for all tasks. <strong>Grafana</strong> access will be  enabled when the pipeline completes.
                     Warning messages will also be displayed here when present.
                   </p>
-                  <Card elevation={Elevation.TWO} style={{ display: 'flex', padding: 0 }}>
+                  <CSSTransition
+                    in={pipelineReady}
+                    timeout={350}
+                    classNames='activity-panel'
+                    unmountOnExit
+                  >
+                    <Card
+                      elevation={Elevation.TWO}
+                      style={{ display: 'flex', padding: 0, backgroundColor: activePipeline.status === 'TASK_COMPLETED' ? 'rgba(245, 255, 250, 0.99)' : 'inherit' }}
+                    >
 
-                    <ButtonGroup style={{ backgroundColor: 'transparent' }}>
-                      <Button active>
-                        <h3 style={{ margin: 0, fontSize: '20px' }}>
-                          Stage 1
-                        </h3>
-                      </Button>
-                      <Button disabled><h3 style={{ margin: 0, fontSize: '20px' }}>Stage 2</h3></Button>
-                      <Button
-                        minimal
-                        style={{
-                          marginLeft: '1px',
-                          background: '#ffffff!!important',
-                          width: 0,
-                          height: 0,
-                          borderTop: '16px solid transparent',
-                          borderBottom: '16px solid transparent',
-                          borderLeft: '16px solid rgba(206, 217, 224, 0.5)'
-                        }}
-                      />
-                    </ButtonGroup>
-                    <h3 style={{
-                      textTransform: 'uppercase',
-                      lineHeight: '33px',
-                      margin: 0,
-                      fontFamily: 'Montserrat',
-                      fontWeight: 800,
-                      letterSpacing: '2px'
-                    }}
-                    >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
-                      <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
-                    </h3>
-                    <div style={{ display: 'flex', fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px', padding: '0 10px' }}>
-                      {(() => {
-                        let statusIcon = null
-                        switch (activePipeline.status) {
-                          case 'TASK_COMPLETED':
-                            statusIcon = (
-                              <Icon
-                                icon={<PipelineCompleteIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                size={24}
-                              />
-                            )
-                            break
-                          case 'TASK_FAILED':
-                            statusIcon = (
-                              <Icon
-                                icon={<PipelineFailedIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                size={24}
-                              />
-                            )
-                            break
-                          case 'TASK_RUNNING':
-                          default:
-                            statusIcon = (
-                              <Icon
-                                icon={<PipelineRunningIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                size={24}
-                              />
-                            )
-                            break
-                        }
-                        return statusIcon
-                      })()}
-                      {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}%
-                    </div>
-                  </Card>
+                      <ButtonGroup style={{ backgroundColor: 'transparent' }}>
+                        <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
+                          <h3 style={{ margin: 0, fontSize: '20px' }}>
+                            Stage 1
+                          </h3>
+                        </Button>
+                        <Button
+                          minimal style={{
+                            backgroundColor: '#eeeeee',
+                            color: '#cccccc',
+                            fontSize: '35px',
+                            lineHeight: '20px',
+                            padding: 0,
+                            fontWeight: 100,
+                          }}
+                        >/
+                        </Button>
+                        <Button
+                          disabled style={{
+                            backgroundColor: '#eeeeee',
+                          }}
+                        ><h3 style={{ margin: 0, fontSize: '20px' }}>Stage 2</h3>
+                        </Button>
+                        <Button
+                          className='btn-stage-endcap'
+                          minimal
+                          style={{
+                            marginLeft: '1px',
+                            background: '#ffffff!!important',
+                            width: 0,
+                            height: 0,
+                            borderTop: '16px solid transparent',
+                            borderBottom: '16px solid transparent',
+                            borderLeft: '16px solid #eeeeee',
+                            pointerEvents: 'none'
+                          }}
+                        />
+                      </ButtonGroup>
+                      <h3 style={{
+                        textTransform: 'uppercase',
+                        lineHeight: '33px',
+                        margin: 0,
+                        fontFamily: 'Montserrat',
+                        fontWeight: 800,
+                        letterSpacing: '2px'
+                      }}
+                      >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
+                        <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
+                      </h3>
+                      <div style={{ display: 'flex', fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px', padding: '0 10px' }}>
+                        {(() => {
+                          let statusIcon = null
+                          switch (activePipeline.status) {
+                            case 'TASK_COMPLETED':
+                              statusIcon = (
+                                <Icon
+                                  icon={<PipelineCompleteIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                                  size={24}
+                                />
+                              )
+                              break
+                            case 'TASK_FAILED':
+                              statusIcon = (
+                                <Icon
+                                  icon={<PipelineFailedIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                                  size={24}
+                                />
+                              )
+                              break
+                            case 'TASK_RUNNING':
+                            default:
+                              statusIcon = (
+                                <Icon
+                                  icon={<PipelineRunningIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
+                                  size={24}
+                                />
+                              )
+                              break
+                          }
+                          return statusIcon
+                        })()}
+                        {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}%
+                      </div>
+                    </Card>
+                  </CSSTransition>
                   <div style={{
                     paddingTop: '7px',
                     // borderTop: '1px solid #f5f5f5',

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -2,9 +2,10 @@ import React, { Fragment, useEffect, useState, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { useHistory, useParams } from 'react-router-dom'
 import { GRAFANA_URL } from '@/utils/config'
-import * as dayjs from 'dayjs'
-import * as relativeTime from 'dayjs/plugin/relativeTime'
-import * as updateLocale from 'dayjs/plugin/updateLocale'
+import dayjs from '@/utils/time'
+// import * as dayjs from 'dayjs'
+// import * as relativeTime from 'dayjs/plugin/relativeTime'
+// import * as updateLocale from 'dayjs/plugin/updateLocale'
 import {
   Button, Icon, Intent,
   Card, Elevation,
@@ -67,25 +68,25 @@ const PipelineActivity = (props) => {
 
   useEffect(() => {
     setPipelineId(pId)
-    dayjs.extend(relativeTime)
-    dayjs.extend(updateLocale)
-    dayjs.updateLocale('en', {
-      relativeTime: {
-        future: 'in %s',
-        past: '%s ago',
-        s: '< 1min',
-        m: 'a minute',
-        mm: '%d minutes',
-        h: 'an hour',
-        hh: '%d hours',
-        d: 'a day',
-        dd: '%d days',
-        M: 'a month',
-        MM: '%d months',
-        y: 'a year',
-        yy: '%d years'
-      }
-    })
+    // dayjs.extend(relativeTime)
+    // dayjs.extend(updateLocale)
+    // dayjs.updateLocale('en', {
+    //   relativeTime: {
+    //     future: 'in %s',
+    //     past: '%s ago',
+    //     s: '< 1min',
+    //     m: 'a minute',
+    //     mm: '%d minutes',
+    //     h: 'an hour',
+    //     hh: '%d hours',
+    //     d: 'a day',
+    //     dd: '%d days',
+    //     M: 'a month',
+    //     MM: '%d months',
+    //     y: 'a year',
+    //     yy: '%d years'
+    //   }
+    // })
     console.log('>>> REQUESTED PIPELINE ID ===', pId)
   }, [pId])
 
@@ -331,7 +332,7 @@ const PipelineActivity = (props) => {
                         </div>
 
                       </div>
-                      <TaskActivity activePipeline={activePipeline} dayjs={dayjs} />
+                      <TaskActivity activePipeline={activePipeline} />
                     </Card>
                   </CSSTransition>
                   <div style={{ display: 'flex', padding: '5px 3px', fontSize: '10px', color: '#777777', justifyContent: 'space-between' }}>

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -17,6 +17,10 @@ import {
   // ButtonGroup, InputGroup, Input, Tag,H2, TextArea,Link
 } from '@blueprintjs/core'
 import { integrationsData } from '@/data/integrations'
+import {
+  Providers,
+  ProviderLabels
+} from '@/data/Providers'
 import usePipelineManager from '@/hooks/usePipelineManager'
 import Nav from '@/components/Nav'
 import Sidebar from '@/components/Sidebar'
@@ -38,8 +42,7 @@ const PipelineActivity = (props) => {
   const { pId } = useParams()
   const pollInterval = useRef()
 
-  const [pipelineId, setPipelineId] = useState() // @todo REMOVE TEST RUN ID!
-  const [activeProvider, setActiveProvider] = useState(integrationsData[0])
+  const [pipelineId, setPipelineId] = useState()
   const [pipelineName, setPipelineName] = useState()
   const [pollTimer, setPollTimer] = useState(5000)
   const [autoRefresh, setAutoRefresh] = useState(false)
@@ -60,9 +63,9 @@ const PipelineActivity = (props) => {
     // lastRunId
   } = usePipelineManager(pipelineName)
 
-  // useEffect(() => {
-  //   setActiveProvider(providerId ? integrationsData.find(p => p.id === providerId) : integrationsData[0])
-  // }, [providerId])
+  const pipelineHasProvider = (providerId) => {
+    return activePipeline.tasks.some(t => t.plugin === providerId)
+  }
 
   useEffect(() => {
     setPipelineId(pId)
@@ -387,93 +390,107 @@ const PipelineActivity = (props) => {
                   </div>
 
                   <div style={{ padding: '0 10px', display: 'flex', marginTop: '24px', justifyContent: 'space-between', width: '100%' }}>
-                    <div className='jenkins-settings' style={{ display: 'flex' }}>
-                      <div style={{ display: 'flex', padding: '2px 6px' }}>
-                        <JenkinsProviderIcon width={24} height={24} />
+                    {pipelineHasProvider(Providers.JENKINS) && (
+                      <div className='jenkins-settings' style={{ display: 'flex' }}>
+                        <div style={{ display: 'flex', padding: '2px 6px' }}>
+                          <JenkinsProviderIcon width={24} height={24} />
+                        </div>
+                        <div>
+                          <label style={{
+                            lineHeight: '100%',
+                            display: 'block',
+                            fontSize: '14px',
+                            marginTop: '0',
+                            marginBottom: '10px'
+                          }}
+                          >
+                            <strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>
+                              {ProviderLabels.JENKINS}
+                            </strong>
+                            <br />Auto-configured
+                          </label>
+                          <span style={{ color: Colors.GRAY3 }}>(No Settings)</span>
+                        </div>
                       </div>
-                      <div>
-                        <label style={{
-                          lineHeight: '100%',
-                          display: 'block',
-                          fontSize: '14px',
-                          marginTop: '0',
-                          marginBottom: '10px'
-                        }}
-                        >
-                          <strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>Jenkins</strong>
-                          <br />Auto-configured
-                        </label>
-                        <span style={{ color: Colors.GRAY3 }}>(No Settings)</span>
+                    )}
+                    {pipelineHasProvider(Providers.JIRA) && (
+                      <div className='jira-settings' style={{ display: 'flex', paddingLeft: '20px' }}>
+                        <div style={{ display: 'flex', padding: '2px 6px' }}>
+                          <JiraProviderIcon width={24} height={24} />
+                        </div>
+                        <div>
+                          <label style={{
+                            lineHeight: '100%',
+                            display: 'block',
+                            fontSize: '14px',
+                            marginTop: '0',
+                            marginBottom: '10px'
+                          }}
+                          >
+                            <strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>
+                              {ProviderLabels.JIRA}
+                            </strong><br />Board IDs
+                          </label>
+                          {activePipeline.tasks.filter(t => t.plugin === Providers.JIRA).map((t, tIdx) => (
+                            <div key={`board-id-key-${tIdx}`}>
+                              <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                              <span>
+                                {t.options[Object.keys(t.options)[0]]} on Server #{t.options[Object.keys(t.options)[1]]}<br />
+                              </span>
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                    <div className='jira-settings' style={{ display: 'flex' }}>
-                      <div style={{ display: 'flex', padding: '2px 6px' }}>
-                        <JiraProviderIcon width={24} height={24} />
+                    )}
+                    {pipelineHasProvider(Providers.GITLAB) && (
+                      <div className='gitlab-settings' style={{ display: 'flex', paddingLeft: '20px' }}>
+                        <div style={{ display: 'flex', padding: '2px 6px' }}>
+                          <GitlabProviderIcon width={24} height={24} />
+                        </div>
+                        <div>
+                          <label style={{
+                            lineHeight: '100%',
+                            display: 'block',
+                            fontSize: '14px',
+                            marginTop: '0',
+                            marginBottom: '10px'
+                          }}
+                          ><strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>{ProviderLabels.GITLAB}</strong><br />Project IDs
+                          </label>
+                          {activePipeline.tasks.filter(t => t.plugin === 'gitlab').map((t, tIdx) => (
+                            <div key={`project-id-key-${tIdx}`}>
+                              <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                              <span>
+                                {t.options[Object.keys(t.options)[0]]}<br />
+                              </span>
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                      <div>
-                        <label style={{
-                          lineHeight: '100%',
-                          display: 'block',
-                          fontSize: '14px',
-                          marginTop: '0',
-                          marginBottom: '10px'
-                        }}
-                        ><strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>JIRA</strong><br />Board IDs
-                        </label>
-                        {activePipeline.tasks.filter(t => t.plugin === 'jira').map((t, tIdx) => (
-                          <div key={`board-id-key-${tIdx}`}>
-                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
-                            <span>
-                              {t.options[Object.keys(t.options)[0]]} on Server #{t.options[Object.keys(t.options)[1]]}<br />
-                            </span>
-                          </div>
-                        ))}
+                    )}
+                    {pipelineHasProvider(Providers.GITHUB) && (
+                      <div className='github-settings' style={{ display: 'flex', paddingLeft: '20px', justifySelf: 'flex-start' }}>
+                        <div style={{ display: 'flex', padding: '2px 6px' }}>
+                          <GitHubProviderIcon width={24} height={24} />
+                        </div>
+                        <div>
+                          <label style={{ lineHeight: '100%', display: 'block', fontSize: '14px', marginTop: '0', marginBottom: '10px' }}>
+                            <strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>{ProviderLabels.GITHUB}</strong><br />Repositories
+                          </label>
+                          {activePipeline.tasks.filter(t => t.plugin === Providers.GITHUB).map((t, tIdx) => (
+                            <div key={`repostitory-id-key-${tIdx}`}>
+                              <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
+                              <span>
+                                <strong>{t.options[Object.keys(t.options)[0]]}</strong>
+                                <span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
+                                <strong>{t.options[Object.keys(t.options)[1]]}</strong>
+                              </span>
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                    <div className='gitlab-settings' style={{ display: 'flex' }}>
-                      <div style={{ display: 'flex', padding: '2px 6px' }}>
-                        <GitlabProviderIcon width={24} height={24} />
-                      </div>
-                      <div>
-                        <label style={{
-                          lineHeight: '100%',
-                          display: 'block',
-                          fontSize: '14px',
-                          marginTop: '0',
-                          marginBottom: '10px'
-                        }}
-                        ><strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>GitLab</strong><br />Project IDs
-                        </label>
-                        {activePipeline.tasks.filter(t => t.plugin === 'gitlab').map((t, tIdx) => (
-                          <div key={`project-id-key-${tIdx}`}>
-                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
-                            <span>
-                              {t.options[Object.keys(t.options)[0]]}<br />
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                    <div className='github-settings' style={{ display: 'flex' }}>
-                      <div style={{ display: 'flex', padding: '2px 6px' }}>
-                        <GitHubProviderIcon width={24} height={24} />
-                      </div>
-                      <div>
-                        <label style={{ lineHeight: '100%', display: 'block', fontSize: '14px', marginTop: '0', marginBottom: '10px' }}>
-                          <strong style={{ fontSize: '11px', fontFamily: 'Montserrat', fontWeight: 800 }}>GitHub</strong><br />Repositories
-                        </label>
-                        {activePipeline.tasks.filter(t => t.plugin === 'github').map((t, tIdx) => (
-                          <div key={`repostitory-id-key-${tIdx}`}>
-                            <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
-                            <span>
-                              <strong>{t.options[Object.keys(t.options)[0]]}</strong>
-                              <span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
-                              <strong>{t.options[Object.keys(t.options)[1]]}</strong>
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
+                    )}
+                    <div style={{ marginRight: 'auto' }} />
                   </div>
                 </div>
               </>

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -256,8 +256,7 @@ const PipelineActivity = (props) => {
                           padding: '20px'
                         }}
                       >
-
-                        <div className='pipeline-info' style={{ paddingRight: '12px' }}>
+                        <div className='pipeline-info' style={{ paddingRight: '12px', maxWidth: '50%', textOverflow: 'ellipsis' }}>
                           <h2 className='headline' style={{ marginTop: '0' }}>
                             <span
                               className='pipeline-name'
@@ -266,7 +265,7 @@ const PipelineActivity = (props) => {
                                 overflow: 'hidden',
                                 whiteSpace: 'nowrap',
                                 display: 'block',
-                                maxWidth: '430px',
+                                // maxWidth: '430px',
                                 color: activePipeline.status === 'TASK_FAILED' ? Colors.RED4 : ''
                               }}
                             >{activePipeline.name || 'Unamed Collection'}

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -61,8 +61,9 @@ const PipelineActivity = (props) => {
     // isRunning,
     isFetching,
     errors: pipelineErrors,
-    // setSettings: setPipelineSettings,
-    // lastRunId
+    setSettings: setPipelineSettings,
+    // setAutoStart: setPipelineAutoStart,
+    lastRunId,
   } = usePipelineManager(pipelineName)
 
   const pipelineHasProvider = (providerId) => {
@@ -86,9 +87,34 @@ const PipelineActivity = (props) => {
     return activeTask?.pipelineRow || 1
   }
 
+  const restartPipeline = useCallback((tasks = []) => {
+    const existingTasksConfiguration = tasks.map(t => {
+      return {
+        plugin: t.plugin,
+        options: t.options
+      }
+    })
+    console.log('>>> RESTARTING PIPELINE WITH EXISTING CONFIGURATION!!', existingTasksConfiguration)
+    // setPipelineAutoStart(true)
+    // setPipelineSettings({
+    //   autoStart: true,
+    //   name: `RETRY | ${activePipeline.name}`,
+    //   tasks: [
+    //     [...existingTasksConfiguration]
+    //   ]
+    // })
+    history.push({
+      pathname: '/pipelines/create',
+      state: {
+        existingTasks: existingTasksConfiguration
+      }
+    })
+  }, [activePipeline.name, setPipelineSettings])
+
   useEffect(() => {
     setPipelineId(pId)
     console.log('>>> REQUESTED PIPELINE ID ===', pId)
+    // return () => setPipelineAutoStart(false)
   }, [pId])
 
   useEffect(() => {
@@ -127,6 +153,10 @@ const PipelineActivity = (props) => {
   useEffect(() => {
 
   }, [stages])
+
+  useEffect(() => {
+    console.log('>>> GOT LAST RUN ID!', lastRunId)
+  }, [lastRunId])
 
   return (
     <>
@@ -344,15 +374,19 @@ const PipelineActivity = (props) => {
                               icon='reset'
                               text='RESTART'
                               intent='warning'
+                              onClick={() => restartPipeline(activePipeline.tasks)}
                               disabled={activePipeline.status !== 'TASK_FAILED'}
                             />
                           )}
-                          <Button
-                            icon='refresh'
-                            style={{ marginLeft: '5px' }}
-                            disabled={activePipeline.status === 'TASK_RUNNING' || activePipeline.status === 'TASK_FAILED'}
-                            minimal
-                          />
+                          {activePipeline.status !== 'TASK_FAILED' && (
+                            <Button
+                              icon='refresh'
+                              style={{ marginLeft: '5px' }}
+                              onClick={() => restartPipeline(activePipeline.tasks)}
+                              disabled={activePipeline.status === 'TASK_RUNNING' || activePipeline.status === 'TASK_FAILED'}
+                              minimal
+                            />
+                          )}
                         </div>
 
                       </div>

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -1,16 +1,13 @@
-import React, { Fragment, useEffect, useCallback, useState, useRef } from 'react'
+import React, { Fragment, useEffect, useState, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { useHistory, useParams } from 'react-router-dom'
-import { ToastNotification } from '@/components/Toast'
 import { GRAFANA_URL } from '@/utils/config'
-import request from '@/utils/request'
 import * as dayjs from 'dayjs'
 import * as relativeTime from 'dayjs/plugin/relativeTime'
 import * as updateLocale from 'dayjs/plugin/updateLocale'
 import {
-  H2, Button, Icon, Intent,
-  ButtonGroup, InputGroup, Input,
-  Card, Elevation, Tag,
+  Button, Icon, Intent,
+  Card, Elevation,
   Popover,
   Tooltip,
   Position,
@@ -18,9 +15,8 @@ import {
   Colors,
   Drawer,
   DrawerSize,
-  TextArea,
-  Link,
-  Classes
+  Classes,
+  // ButtonGroup, InputGroup, Input, Tag,H2, TextArea,Link
 } from '@blueprintjs/core'
 import { integrationsData } from '@/data/integrations'
 import usePipelineManager from '@/hooks/usePipelineManager'
@@ -35,9 +31,7 @@ import { ReactComponent as GitlabProviderIcon } from '@/images/integrations/gitl
 import { ReactComponent as JenkinsProviderIcon } from '@/images/integrations/jenkins.svg'
 import { ReactComponent as JiraProviderIcon } from '@/images/integrations/jira.svg'
 import { ReactComponent as GitHubProviderIcon } from '@/images/integrations/github.svg'
-// import { ReactComponent as PipelineRunningIcon } from '@/images/synchronize.svg'
-// import { ReactComponent as PipelineFailedIcon } from '@/images/no-synchronize.svg'
-// import { ReactComponent as PipelineCompleteIcon } from '@/images/check-circle.svg'
+
 import { ReactComponent as HelpIcon } from '@/images/help.svg'
 
 const PipelineActivity = (props) => {
@@ -98,11 +92,7 @@ const PipelineActivity = (props) => {
   useEffect(() => {
     if (pipelineId) {
       fetchPipeline(pipelineId)
-      // @todo: ENABLE ACTIVITY POLLING
       setAutoRefresh(activePipeline.status === 'TASK_RUNNING')
-      // pollInterval.current = setInterval(() => {
-      //   fetchPipeline(pipelineId)
-      // }, pollTimer)
     }
 
     return () => {
@@ -240,10 +230,7 @@ const PipelineActivity = (props) => {
                           <div className='pipeline-timestamp'>
                             2021-12-08 08:00 AM (UTC)
                           </div>
-                          {/* <div>
-                    <label>Run Date (UTC)</label>
-                    <div>2021-12-08 08:00 AM</div>
-                  </div> */}
+
                         </div>
                         <div className='pipeline-status' style={{ paddingRight: '12px' }}>
                           <label style={{ color: Colors.GRAY3 }}>Status</label>
@@ -385,219 +372,17 @@ const PipelineActivity = (props) => {
                       <strong>Created </strong> {activePipeline.CreatedAt}
                     </div>
                     <div>
-                      {isFetching && (<span style={{ color: Colors.GREEN5 }}><Icon icon='updated' size={11} style={{ marginBottom: '2px' }} /> Refreshing Activity...</span>)}
+                      {isFetching && (
+                        <span style={{ color: Colors.GREEN5 }}>
+                          <Icon icon='updated' size={11} style={{ marginBottom: '2px' }} /> Refreshing Activity...
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>
 
-                <div className='stage-activity' style={{ alignSelf: 'flex-start', width: '100%' }}>
-                  {/* <h2 className='headline'>
-                    <Icon icon='layers' height={16} size={16} color='rgba(0,0,0,0.5)' /> Stages and Tasks
-                  </h2>
-                  <p>Monitor <strong>Duration</strong> and <strong>Progress</strong> completion for all tasks. <strong>Grafana</strong> access will be  enabled when the pipeline completes.
-                    Warning messages will also be displayed here when present.
-                  </p> */}
-                  {/* <CSSTransition
-                    in={pipelineReady}
-                    timeout={350}
-                    classNames='activity-panel'
-                    // unmountOnExit
-                  >
-                    <Card
-                      elevation={Elevation.TWO}
-                      style={{ display: 'flex', padding: 0, backgroundColor: activePipeline.status === 'TASK_COMPLETED' ? 'rgba(245, 255, 250, 0.99)' : 'inherit' }}
-                    >
-
-                      <ButtonGroup style={{ backgroundColor: 'transparent' }}>
-                        <Button minimal active style={{ backgroundColor: '#eeeeee' }}>
-                          <h3 style={{ margin: 0, fontSize: '20px' }}>
-                            Stage 1
-                          </h3>
-                        </Button>
-                        <Button
-                          minimal style={{
-                            backgroundColor: '#eeeeee',
-                            color: '#cccccc',
-                            fontSize: '35px',
-                            lineHeight: '20px',
-                            padding: 0,
-                            fontWeight: 100,
-                          }}
-                        >/
-                        </Button>
-                        <Button
-                          disabled style={{
-                            backgroundColor: '#eeeeee',
-                          }}
-                        ><h3 style={{ margin: 0, fontSize: '20px' }}>Stage 2</h3>
-                        </Button>
-                        <Button
-                          className='btn-stage-endcap'
-                          minimal
-                          style={{
-                            marginLeft: '1px',
-                            background: '#ffffff!!important',
-                            width: 0,
-                            height: 0,
-                            borderTop: '16px solid transparent',
-                            borderBottom: '16px solid transparent',
-                            borderLeft: '16px solid #eeeeee',
-                            pointerEvents: 'none'
-                          }}
-                        />
-                      </ButtonGroup>
-                      <h3 style={{
-                        textTransform: 'uppercase',
-                        lineHeight: '33px',
-                        margin: 0,
-                        fontFamily: 'Montserrat',
-                        fontWeight: 800,
-                        letterSpacing: '2px'
-                      }}
-                      >Finished Tasks &middot; <span style={{ color: Colors.GREEN5 }}>{activePipeline.finishedTasks}</span>
-                        <em style={{ color: '#dddddd', padding: '0 4px', textTransform: 'lowercase' }}>/</em>{activePipeline.totalTasks}
-                      </h3>
-                      <div style={{ display: 'flex', fontSize: '16px', fontWeight: 700, marginLeft: 'auto', lineHeight: '33px', padding: '0 10px' }}>
-                        {(() => {
-                          let statusIcon = null
-                          switch (activePipeline.status) {
-                            case 'TASK_COMPLETED':
-                              statusIcon = (
-                                <Icon
-                                  icon={<PipelineCompleteIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                  size={24}
-                                />
-                              )
-                              break
-                            case 'TASK_FAILED':
-                              statusIcon = (
-                                <Icon
-                                  icon={<PipelineFailedIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                  size={24}
-                                />
-                              )
-                              break
-                            case 'TASK_RUNNING':
-                            default:
-                              statusIcon = (
-                                <Icon
-                                  icon={<PipelineRunningIcon width={24} height={24} style={{ margin: '0 6px 0 10px', display: 'flex', alignSelf: 'center' }} />}
-                                  size={24}
-                                />
-                              )
-                              break
-                          }
-                          return statusIcon
-                        })()}
-                        {Number((activePipeline.finishedTasks / activePipeline.totalTasks) * 100).toFixed(1)}%
-                      </div>
-                    </Card>
-                  </CSSTransition> */}
-                  {/* <TaskActivity activePipeline={activePipeline} dayjs={dayjs} /> */}
-                  {/* <div style={{
-                    paddingTop: '7px',
-                    // borderTop: '1px solid #f5f5f5',
-                    marginTop: '14px',
-                    marginBottom: '36px'
-                  }}
-                  >
-                    {activePipeline?.ID && activePipeline.tasks && activePipeline.tasks.map((t, tIdx) => (
-                      <div
-                        className='pipeline-task-row'
-                        key={`pipeline-task-key-${tIdx}`}
-                        style={{ display: 'flex', padding: '4px 6px', justifyContent: 'space-between', fontSize: '14px' }}
-                      >
-                        <div style={{ display: 'flex', justifyContent: 'center', paddingRight: '8px', width: '32px', minWidth: '32px' }}>
-                          {t.status === 'TASK_COMPLETED' && (
-                            <Icon icon='small-tick' size={18} color={Colors.GREEN5} style={{ marginLeft: '0' }} />
-                          )}
-                          {t.status === 'TASK_FAILED' && (
-                            <Icon icon='warning-sign' size={14} color={Colors.RED5} style={{ marginLeft: '0', marginBottom: '3px' }} />
-                          )}
-                          {t.status === 'TASK_RUNNING' && (
-                            <Spinner
-                              className='task-spinner'
-                              size={14}
-                              intent={t.status === 'TASK_COMPLETED' ? 'success' : 'warning'}
-                              value={t.status === 'TASK_COMPLETED' ? 1 : t.progress}
-                            />
-                          )}
-                        </div>
-                        <div
-                          className='pipeline-task-cell-name'
-                          style={{ padding: '0 8px', width: '20%', display: 'flex', justifyContent: 'space-between' }}
-                        >
-                          <strong
-                            className='task-plugin-name'
-                            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                          >
-                            {t.plugin}
-                          </strong>
-                        </div>
-                        <div
-                          className='pipeline-task-cell-duration'
-                          style={{
-                            padding: '0',
-                            minWidth: '80px',
-                            // whiteSpace: 'nowrap',
-                            textAlign: 'right'
-                          }}
-                        >
-                          <span style={{ whiteSpace: 'nowrap' }}>
-                            {(() => {
-                              let statusRelativeTime = dayjs(t.CreatedAt).toNow(true)
-                              switch (t.status) {
-                                case 'TASK_COMPLETED':
-                                case 'TASK_FAILED':
-                                  statusRelativeTime = dayjs(t.UpdatedAt).from(t.CreatedAt, true)
-                                  break
-                                case 'TASK_RUNNING':
-                                default:
-                                  statusRelativeTime = dayjs(t.CreatedAt).toNow(true)
-                                  break
-                              }
-                              return statusRelativeTime
-                            })()}
-                          </span>
-                        </div>
-                        <div
-                          className='pipeline-task-cell-progress'
-                          style={{
-                            padding: '0 8px',
-                            minWidth: '100px',
-                            textAlign: 'right'
-                          }}
-                        >
-                          <span style={{ fontWeight: t.status === 'TASK_COMPLETED' ? 800 : 600 }}>
-                            {Number(t.status === 'TASK_COMPLETED' ? 100 : (t.progress / 1) * 100).toFixed(2)}%
-                          </span>
-                        </div>
-                        <div
-                          className='pipeline-task-cell-message'
-                          style={{ width: '70%', paddingLeft: '10px', fontSize: '12px' }}
-                        >
-                          {t.plugin !== 'jenkins' && (
-                            <>
-                              <span style={{ color: Colors.GRAY2 }}>
-                                <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
-                              </span>
-                              {t.plugin === 'github' && (
-                                <span style={{ fontWeight: 60 }}>/{t.options[Object.keys(t.options)[1]]}</span>
-                              )}
-                            </>
-                          )}
-                          {t.message && (
-                            <>
-                              <span style={{ color: t.status === 'TASK_FAILED' ? Colors.RED4 : Colors.GRAY3, paddingLeft: '10px' }}>
-                                {t.message}
-                              </span>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div> */}
-                </div>
+                {/* <div className='stage-activity' style={{ alignSelf: 'flex-start', width: '100%' }}>
+                </div> */}
 
                 <div className='run-settings' style={{ alignSelf: 'flex-start', width: '100%' }}>
                   <div style={{ display: 'flex' }}>
@@ -605,7 +390,7 @@ const PipelineActivity = (props) => {
                       <Icon icon='cog' height={16} size={16} color='rgba(0,0,0,0.5)' />
                     </div>
                     <div>
-                      <h2 className='headline' style={{ marginTop: 0}}>
+                      <h2 className='headline' style={{ marginTop: 0 }}>
                         Run Settings
                       </h2>
                       <p>Data Provider settings configured for this pipeline execution.</p>
@@ -692,7 +477,8 @@ const PipelineActivity = (props) => {
                           <div key={`repostitory-id-key-${tIdx}`}>
                             <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '6px' }} />
                             <span>
-                              <strong>{t.options[Object.keys(t.options)[0]]}</strong><span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
+                              <strong>{t.options[Object.keys(t.options)[0]]}</strong>
+                              <span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
                               <strong>{t.options[Object.keys(t.options)[1]]}</strong>
                             </span>
                           </div>
@@ -707,8 +493,15 @@ const PipelineActivity = (props) => {
             {!pipelineId && (
               <Card elevation={Elevation.TWO} style={{ display: 'flex', alignSelf: 'flex-start' }}>
                 <div style={{ display: 'flex', alignSelf: 'flex-start', flexDirection: 'column' }}>
-                  <h2 style={{ margin: '0 0 12px 0' }}><Icon icon='warning-sign' color={Colors.RED4} size={16} style={{ marginBottom: '4px' }} /> Pipeline Run ID <strong>Missing</strong>...</h2>
-                  <p>Please provide a Pipeline ID to load Run activity and details.<br /> Check the Address URL in your Browser and try again.</p>
+                  <h2 style={{ margin: '0 0 12px 0' }}>
+                    <Icon
+                      icon='warning-sign'
+                      color={Colors.RED4} size={16} style={{ marginBottom: '4px' }}
+                    /> Pipeline Run ID <strong>Missing</strong>...
+                  </h2>
+                  <p>Please provide a Pipeline ID to load Run activity and details.
+                    <br /> Check the Address URL in your Browser and try again.
+                  </p>
                 </div>
               </Card>
             )}
@@ -763,7 +556,10 @@ const PipelineActivity = (props) => {
             <h3 style={{ margin: 0, padding: '8px 0' }}>
               <span style={{ float: 'right', fontSize: '9px', color: '#aaaaaa' }}>application/json</span> JSON RESPONSE
             </h3>
-            <p>If you are submitting a <strong>Bug-Report</strong> regarding a Pipeline Run, include the output below for better debugging.</p>
+            <p>
+              If you are submitting a
+              <strong>Bug-Report</strong> regarding a Pipeline Run, include the output below for better debugging.
+            </p>
             <div className='formContainer'>
               <Card
                 interactive={false}

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -11,8 +11,8 @@ import {
   Position,
   Spinner,
   Colors,
-  Drawer,
-  DrawerSize,
+  // Drawer,
+  // DrawerSize,
   Classes,
   // ButtonGroup, InputGroup, Input, Tag,H2, TextArea,Link
 } from '@blueprintjs/core'
@@ -26,7 +26,7 @@ import Nav from '@/components/Nav'
 import Sidebar from '@/components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '@/components/Content'
-import ContentLoader from '@/components/loaders/ContentLoader'
+// import ContentLoader from '@/components/loaders/ContentLoader'
 import StagePanel from '@/components/pipelines/StagePanel'
 import TaskActivity from '@/components/pipelines/TaskActivity'
 import CodeInspector from '@/components/pipelines/CodeInspector'
@@ -95,14 +95,6 @@ const PipelineActivity = (props) => {
       }
     })
     console.log('>>> RESTARTING PIPELINE WITH EXISTING CONFIGURATION!!', existingTasksConfiguration)
-    // setPipelineAutoStart(true)
-    // setPipelineSettings({
-    //   autoStart: true,
-    //   name: `RETRY | ${activePipeline.name}`,
-    //   tasks: [
-    //     [...existingTasksConfiguration]
-    //   ]
-    // })
     history.push({
       pathname: '/pipelines/create',
       state: {
@@ -114,7 +106,6 @@ const PipelineActivity = (props) => {
   useEffect(() => {
     setPipelineId(pId)
     console.log('>>> REQUESTED PIPELINE ID ===', pId)
-    // return () => setPipelineAutoStart(false)
   }, [pId])
 
   useEffect(() => {

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -351,6 +351,7 @@ const PipelineActivity = (props) => {
                                       stlye={{ marginLeft: 'auto', marginRight: '3px' }}
                                     />
                                     <Button
+                                      className={Classes.POPOVER_DISMISS}
                                       text='YES' icon='small-tick' intent={Intent.DANGER} small
                                       onClick={() => cancelPipeline(activePipeline.ID)}
                                     />

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -202,15 +202,17 @@ const PipelineActivity = (props) => {
                 </div>
               </div>
             </div>
-            {!autoRefresh && isFetching && (
+            {/* (using native loader instead...) */}
+            {/* {!autoRefresh && isFetching && (
               <ContentLoader title='Loading Pipeline Run ...' message='Please wait while pipeline activity is loaded.' />
-            )}
+            )} */}
             {activePipeline?.ID && (
               <>
                 <StagePanel
                   activePipeline={activePipeline} pipelineReady={pipelineReady}
                   stages={buildPipelineStages(activePipeline.tasks)}
                   activeStageId={findActiveStageId(activePipeline.tasks)}
+                  isLoading={isFetching}
                 />
                 <div style={{ marginBottom: '24px', width: '100%' }}>
                   <CSSTransition

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -11,12 +11,12 @@ import {
   Position,
   Spinner,
   Colors,
+  Classes,
   // Drawer,
   // DrawerSize,
-  Classes,
   // ButtonGroup, InputGroup, Input, Tag,H2, TextArea,Link
 } from '@blueprintjs/core'
-import { integrationsData } from '@/data/integrations'
+// import { integrationsData } from '@/data/integrations'
 import {
   Providers,
   ProviderLabels
@@ -101,7 +101,7 @@ const PipelineActivity = (props) => {
         existingTasks: existingTasksConfiguration
       }
     })
-  }, [activePipeline.name, setPipelineSettings])
+  }, [history])
 
   useEffect(() => {
     setPipelineId(pId)

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -1,11 +1,8 @@
 import React, { Fragment, useEffect, useState, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
-import { useHistory, useParams } from 'react-router-dom'
+import { useHistory, useParams, Link } from 'react-router-dom'
 import { GRAFANA_URL } from '@/utils/config'
 import dayjs from '@/utils/time'
-// import * as dayjs from 'dayjs'
-// import * as relativeTime from 'dayjs/plugin/relativeTime'
-// import * as updateLocale from 'dayjs/plugin/updateLocale'
 import {
   Button, Icon, Intent,
   Card, Elevation,
@@ -32,7 +29,7 @@ import { ReactComponent as GitlabProviderIcon } from '@/images/integrations/gitl
 import { ReactComponent as JenkinsProviderIcon } from '@/images/integrations/jenkins.svg'
 import { ReactComponent as JiraProviderIcon } from '@/images/integrations/jira.svg'
 import { ReactComponent as GitHubProviderIcon } from '@/images/integrations/github.svg'
-
+import { ReactComponent as BackArrowIcon } from '@/images/undo.svg'
 import { ReactComponent as HelpIcon } from '@/images/help.svg'
 
 const PipelineActivity = (props) => {
@@ -55,11 +52,11 @@ const PipelineActivity = (props) => {
     fetchPipeline,
     activePipeline,
     // pipelineRun,
-    isRunning,
+    // isRunning,
     isFetching,
     errors: pipelineErrors,
     // setSettings: setPipelineSettings,
-    lastRunId
+    // lastRunId
   } = usePipelineManager(pipelineName)
 
   // useEffect(() => {
@@ -68,25 +65,6 @@ const PipelineActivity = (props) => {
 
   useEffect(() => {
     setPipelineId(pId)
-    // dayjs.extend(relativeTime)
-    // dayjs.extend(updateLocale)
-    // dayjs.updateLocale('en', {
-    //   relativeTime: {
-    //     future: 'in %s',
-    //     past: '%s ago',
-    //     s: '< 1min',
-    //     m: 'a minute',
-    //     mm: '%d minutes',
-    //     h: 'an hour',
-    //     hh: '%d hours',
-    //     d: 'a day',
-    //     dd: '%d days',
-    //     M: 'a month',
-    //     MM: '%d months',
-    //     y: 'a year',
-    //     yy: '%d years'
-    //   }
-    // })
     console.log('>>> REQUESTED PIPELINE ID ===', pId)
   }, [pId])
 
@@ -100,10 +78,6 @@ const PipelineActivity = (props) => {
       clearInterval(pollInterval.current)
     }
   }, [pipelineId, activePipeline.status, fetchPipeline])
-
-  useEffect(() => {
-    console.log('>>> TASKS KEY', activePipeline.tasks)
-  }, [])
 
   useEffect(() => {
     setPipelineReady(activePipeline.ID !== null && !isFetching)
@@ -136,9 +110,19 @@ const PipelineActivity = (props) => {
               ]}
             />
             <div className='headlineContainer'>
-              {/* <Link style={{ float: 'right', marginLeft: '10px', color: '#777777' }} to='/integrations'>
-                <Icon icon='fast-backward' size={16} /> Go Back
-              </Link> */}
+              <Link style={{ display: 'flex', fontSize: '14px', float: 'right', marginLeft: '10px', color: '#777777' }} to='/'>
+                <Icon
+                  icon={
+                    <BackArrowIcon
+                      width={16} height={16}
+                      fill='rgba(0,0,0,0.25)'
+                      style={{
+                        marginRight: '6px'
+                      }}
+                    />
+                  } size={16}
+                /> Go Back
+              </Link>
               <div style={{ display: 'flex' }}>
                 <div>
                   <span style={{ marginRight: '10px' }}>
@@ -264,8 +248,9 @@ const PipelineActivity = (props) => {
                         <div className='pipeline-duration' style={{ paddingRight: '12px' }}>
                           <label style={{ color: Colors.GRAY3 }}>Duration</label>
                           <div style={{ fontSize: '15px', whiteSpace: 'nowrap' }}>
-                            {/* {activePipeline.spentSeconds >= 60 ? `${Number(activePipeline.spentSeconds / 60).toFixed(2)}mins` : `${activePipeline.spentSeconds}secs`} */}
-                            {activePipeline.status === 'TASK_RUNNING' ? dayjs(activePipeline.CreatedAt).toNow(true) : dayjs(activePipeline.UpdatedAt).from(activePipeline.CreatedAt, true)}
+                            {activePipeline.status === 'TASK_RUNNING'
+                              ? dayjs(activePipeline.CreatedAt).toNow(true)
+                              : dayjs(activePipeline.UpdatedAt).from(activePipeline.CreatedAt, true)}
                           </div>
                         </div>
                         <div className='pipeline-actions' style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -345,7 +330,9 @@ const PipelineActivity = (props) => {
                         enforceFocus={false}
                         usePortal={false}
                       >
-                        <a href='#' rel='noreferrer'><Icon icon='help' color={Colors.GRAY3} size={12} style={{ marginTop: '0', marginRight: '5px' }} /></a>
+                        <a href='#' rel='noreferrer'>
+                          <Icon icon='help' color={Colors.GRAY3} size={12} style={{ marginTop: '0', marginRight: '5px' }} />
+                        </a>
                         <>
                           <div style={{ textShadow: 'none', fontSize: '12px', padding: '12px', maxWidth: '315px' }}>
                             <div style={{
@@ -358,8 +345,8 @@ const PipelineActivity = (props) => {
                               <Icon icon='help' size={16} /> Stages and Tasks
                             </div>
                             <p>
-                              Monitor <strong>Duration</strong> and <strong>Progress</strong> completion for all tasks. <strong>Grafana</strong> access will be  enabled when the pipeline completes.
-
+                              Monitor <strong>Duration</strong> and <strong>Progress</strong> completion for all tasks.
+                              <strong>Grafana</strong> access will be  enabled when the pipeline completes.
                             </p>
 
                           </div>
@@ -374,7 +361,7 @@ const PipelineActivity = (props) => {
                     </div>
                     <div>
                       {isFetching && (
-                        <span style={{ color: Colors.GREEN5 }}>
+                        <span style={{ color: Colors.GRAY3 }}>
                           <Icon icon='updated' size={11} style={{ marginBottom: '2px' }} /> Refreshing Activity...
                         </span>
                       )}

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -25,6 +25,7 @@ import Content from '@/components/Content'
 import ContentLoader from '@/components/loaders/ContentLoader'
 import StagePanel from '@/components/pipelines/StagePanel'
 import TaskActivity from '@/components/pipelines/TaskActivity'
+import CodeInspector from '@/components/pipelines/CodeInspector'
 import { ReactComponent as GitlabProviderIcon } from '@/images/integrations/gitlab.svg'
 import { ReactComponent as JenkinsProviderIcon } from '@/images/integrations/jenkins.svg'
 import { ReactComponent as JiraProviderIcon } from '@/images/integrations/jira.svg'
@@ -524,48 +525,7 @@ const PipelineActivity = (props) => {
         </Content>
 
       </div>
-      <Drawer
-        className='drawer-json-inspector'
-        icon='code'
-        onClose={() => setShowInspector(false)}
-        title={`RUN No. ${activePipeline.ID} JSON Payload`}
-        position={Position.RIGHT}
-        size={DrawerSize.SMALL}
-        autoFocus
-        canEscapeKeyClose
-        canOutsideClickClose
-        enforceFocus
-        hasBackdrop
-        isOpen={showInspector}
-        usePortal
-      >
-        <div className={Classes.DRAWER_BODY}>
-          <div className={Classes.DIALOG_BODY}>
-            <h3 style={{ margin: 0, padding: '8px 0' }}>
-              <span style={{ float: 'right', fontSize: '9px', color: '#aaaaaa' }}>application/json</span> JSON RESPONSE
-            </h3>
-            <p>
-              If you are submitting a
-              <strong>Bug-Report</strong> regarding a Pipeline Run, include the output below for better debugging.
-            </p>
-            <div className='formContainer'>
-              <Card
-                interactive={false}
-                elevation={Elevation.ZERO}
-                style={{ padding: '6px 12px', minWidth: '320px', width: '100%', maxWidth: '601px', marginBottom: '20px', overflow: 'auto' }}
-              >
-
-                <code>
-                  <pre style={{ fontSize: '10px' }}>
-                    {JSON.stringify(activePipeline, null, '  ')}
-                  </pre>
-                </code>
-              </Card>
-            </div>
-          </div>
-        </div>
-      </Drawer>
-
+      <CodeInspector isOpen={showInspector} activePipeline={activePipeline} onClose={setShowInspector} />
     </>
   )
 }

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -234,7 +234,7 @@ const CreatePipeline = (props) => {
 
   return (
     <>
-      <div className='container'>
+      <div className='container container-create-pipeline'>
         <Nav />
         <Sidebar />
         <Content>

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -583,8 +583,19 @@ const CreatePipeline = (props) => {
                 loading={isRunning}
               ><strong>Run</strong> Pipeline
               </Button>
-              <Button className='btn-pipeline btn-view-jobs' icon='eye-open' minimal style={{ marginLeft: '5px' }}>View All Jobs</Button>
-              <Button className='btn-pipeline btn-reset-pipeline' icon='eraser' minimal style={{ marginLeft: '5px' }} onClick={resetConfiguration}>Reset</Button>
+              <Tooltip content='Manage Pipelines (Coming Soon)' position={Position.TOP}>
+                <Button
+                  className='btn-pipeline btn-view-jobs'
+                  icon='eye-open' minimal style={{ marginLeft: '5px' }}
+                >View All Pipelines
+                </Button>
+              </Tooltip>
+              <Button
+                className='btn-pipeline btn-reset-pipeline'
+                icon='eraser' minimal style={{ marginLeft: '5px' }}
+                onClick={resetConfiguration}
+              >Reset
+              </Button>
               {/* <div style={{ padding: '7px 5px 0 5px' }}>
                 <Tooltip content='Manage API Rate Limits' position={Position.TOP}>
                   <Switch

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -83,6 +83,8 @@ const CreatePipeline = (props) => {
   const [repositoryName, setRepositoryName] = useState('')
   const [owner, setOwner] = useState('')
 
+  const [autoRedirect, setAutoRedirect] = useState(true)
+
   const {
     runPipeline,
     cancelPipeline,
@@ -209,7 +211,10 @@ const CreatePipeline = (props) => {
 
   useEffect(() => {
     console.log('>> PIPELINE LAST RUN OBJECT CHANGED!!...', pipelineRun)
-  }, [pipelineRun])
+    if (pipelineRun.ID && autoRedirect) {
+      history.push(`/pipelines/activity/${pipelineRun.ID}`)
+    }
+  }, [pipelineRun, autoRedirect, history])
 
   useEffect(() => {
     console.log(namePrefix, nameSuffix)

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -185,13 +185,14 @@ const CreatePipeline = (props) => {
   }
 
   const resetConfiguration = () => {
+    window.history.replaceState(null, '')
     setExistingTasks([])
     setEnabledProviders([])
     setProjectId(null)
     setBoardId(null)
     setSelectedSource(null)
-    setRepositoryName(null)
-    setOwner(null)
+    setRepositoryName('')
+    setOwner('')
   }
 
   useEffect(() => {
@@ -249,13 +250,7 @@ const CreatePipeline = (props) => {
 
   useEffect(() => {
     console.log('>> BUILT JIRA INSTANCE SELECT MENU... ', sources)
-    if (sources.length > 0 && restartDetected) {
-      const JiraTask = existingTasks.find(t => t.plugin === Providers.JIRA)
-      if (JiraTask) {
-        setSelectedSource(sources.find(s => s.id === parseInt(JiraTask.options?.sourceId, 10)))
-      }
-    }
-  }, [sources, existingTasks, restartDetected])
+  }, [sources])
 
   useEffect(() => {
     if (location.state?.existingTasks) {
@@ -280,8 +275,14 @@ const CreatePipeline = (props) => {
         setOwner(GitHubTask.options?.owner)
       }
       if (JiraTask) {
+        // const selSource = sources.find(s => s.ID === parseInt(JiraTask.options?.sourceId, 10))
         setEnabledProviders(eP => [...eP, Providers.JIRA])
         setBoardId(JiraTask.options?.boardId)
+        setSelectedSource({
+          id: parseInt(JiraTask.options?.sourceId, 10),
+          title: '(Instance)',
+          value: parseInt(JiraTask.options?.sourceId, 10)
+        })
       }
       if (JenkinsTask) {
         setEnabledProviders(eP => [...eP, Providers.JENKINS])

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -252,7 +252,6 @@ const CreatePipeline = (props) => {
     if (sources.length > 0 && restartDetected) {
       const JiraTask = existingTasks.find(t => t.plugin === Providers.JIRA)
       if (JiraTask) {
-        console.log('>>>>>HERE!!!', sources.find(s => s.id === parseInt(JiraTask.options?.sourceId, 10)))
         setSelectedSource(sources.find(s => s.id === parseInt(JiraTask.options?.sourceId, 10)))
       }
     }
@@ -273,21 +272,16 @@ const CreatePipeline = (props) => {
       const JenkinsTask = tasks.find(t => t.plugin === Providers.JENKINS)
       if (GitLabTask) {
         setEnabledProviders(eP => [...eP, Providers.GITLAB])
-        // console.log('>>>> GL TASK OBJECT = ', GitLabTask)
         setProjectId(GitLabTask.options?.projectId)
       }
       if (GitHubTask) {
         setEnabledProviders(eP => [...eP, Providers.GITHUB])
-        // console.log('>>>> GH TASK OBJECT = ', GitHubTask)
         setRepositoryName(GitHubTask.options?.repositoryName)
         setOwner(GitHubTask.options?.owner)
       }
       if (JiraTask) {
         setEnabledProviders(eP => [...eP, Providers.JIRA])
-        // console.log('>>>> JIRA TASK OBJECT = ', JiraTask)
         setBoardId(JiraTask.options?.boardId)
-        // setSourceId(JiraTask.options?.sourceId)
-        // setSelectedSource(sources.find(s => s.id === parseInt(JiraTask.options?.sourceId, 10)))
       }
       if (JenkinsTask) {
         setEnabledProviders(eP => [...eP, Providers.JENKINS])

--- a/config-ui/src/pages/triggers/index.jsx
+++ b/config-ui/src/pages/triggers/index.jsx
@@ -92,7 +92,7 @@ export default function Triggers () {
       const res = await request.post(
         `${DEVLAKE_ENDPOINT}/pipelines`,
         JSON.stringify({
-          name: `config-ui trigger ${new Date()}`,
+          name: `(m)RUN ${new Date()}`,
           tasks: JSON.parse(textAreaBody)
         })
       )

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -206,6 +206,28 @@
   transition: opacity 300ms, transform 300ms;
 }
 
+.activity-panel-enter {
+  transform: rotateX(-50deg);
+  opacity: 0.6;
+  transition: opacity 300ms, transform 300ms;
+}
+
+.activity-panel-enter-done {
+  transform: rotateX(0deg);
+  opacity: 1;
+  transition: opacity 300ms, transform 300ms;
+}
+
+.activity-panel-exit {
+  transform: rotateX(20deg);
+  transition: opacity 300ms, transform 300ms;
+}
+
+.activity-panel-exit-active {
+  transform: rotateX(40deg);
+  transition: opacity 300ms, transform 300ms;
+}
+
 .bp3-spinner {
   &.lastrun-spinner {
     position: absolute;
@@ -242,16 +264,16 @@
     border: 1px solid darken(#FF6D6D, 5%);
     box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 6px;
-    font-family: 'Montserrat', sans-serif;
+    // font-family: 'Montserrat', sans-serif;
     font-style: normal;
     font-weight: 900;
-    font-size: 11px;
+    // font-size: 11px;
     color: #ffffff;
 
-    &:hover {
-      background-color: darken(#FFA8A8, 10%);
-      border: 1px solid darken(#FF6D6D, 10%);
-      box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40);
+    &:hover,:active,&.bp3-active {
+      background-color: darken(#FFA8A8, 10%)!important;
+      border: 1px solid darken(#FF6D6D, 10%)!important;
+      box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40)!important;
     }
   }
 
@@ -261,13 +283,13 @@
     // border: 1px solid darken(#6dd6ff, 5%);
     box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 6px;
-    font-family: 'Montserrat', sans-serif;
+    // font-family: 'Montserrat', sans-serif;
     font-style: normal;
     font-weight: 900;
-    font-size: 11px;
+    // font-size: 11px;
     color: #ffffff;
 
-    &:hover {
+    &:hover,:active,&.bp3-active {
       // background-color: darken(#a8d8ff, 15%);
       // border: 1px solid darken(#6dd6ff, 15%);
       box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40);

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -1,4 +1,3 @@
-
 .data-providers {
   min-width: 514px;
 }
@@ -9,7 +8,7 @@
   width: 100%;
   padding: 24px 12px;
   transition: background-color 0.3s ease;
-  border-bottom: 1px solid rgba(0,0,0,0.08);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 8px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -29,13 +28,12 @@
     opacity: 0;
     visibility: hidden;
     content: '(Turn ON to Configure)';
-    color: rgba(100,100,100,0.25);
+    color: rgba(100, 100, 100, 0.25);
     transition: all 0.4s ease-in;
   }
 
   &:hover {
-    background-color: rgba(0,0,0,0.03);
-    // box-shadow: 0 0 0 0 rgba(232, 71, 28, 0), 0 0 0 0 rgba(232, 71, 28, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2);
+    background-color: rgba(0, 0, 0, 0.03);
   }
 
   &.on {
@@ -48,27 +46,18 @@
     .provider-name {
       opacity: 0.7;
     }
+
     .provider-icon {
       opacity: 0.7;
       transform: scale(0.9);
     }
+
     &:hover {
       &:after {
         top: 5px;
         right: 5px;
         opacity: 1;
-        visibility: visible;        
-        // display: inline-block;
-        // width: 150px;
-        // height: 24px;
-        // line-height: 24px;
-        // font-size: 11px;
-        // position: absolute;
-        // top: 5px;
-        // right: 10px;
-        // content: '(Turn ON to Configure)';
-        // color: rgba(100,100,100,0.25);
-        // transition: all 0.4s ease-in;
+        visibility: visible;
       }
     }
   }
@@ -82,10 +71,12 @@
 
     .provider-icon {
       transition: all 0.3s ease;
-      > svg {
+
+      >svg {
         transition: all 0.3s ease;
       }
     }
+
     .provider-name {
       font-family: 'Montserrat', sans-serif;
       font-weight: 900;
@@ -93,10 +84,12 @@
       font-size: 14px;
       margin-bottom: 3px;
       transition: all 0.3s ease;
+
       &:hover {
         color: #007cff;
-      } 
+      }
     }
+
     .bp3-popover-wrapper {
       width: auto;
     }
@@ -107,7 +100,7 @@
     padding: 0 20px;
     align-items: flex-end;
     display: flex;
-    
+
     .bp3-form-group {
       margin-bottom: 0;
     }
@@ -131,9 +124,6 @@
 }
 
 .btn-pipeline {
-  // font-family: 'Montserrat', sans-serif;
-  // text-transform: uppercase;
-  // letter-spacing: 2px;
   font-weight: 800;
   transition: all 0.4s ease;
   white-space: nowrap;
@@ -146,18 +136,20 @@
 .bp3-switch {
   &.provider-toggle-switch {
     margin-bottom: 0;
+
     &:not(.bp3-align-right) {
       padding-left: 43px
     }
-    
+
   }
 }
 
 .pipeline-action-btn {
   transition: all 0.4s ease;
+
   &:hover {
     svg {
-      fill: #007cff!important
+      fill: #007cff !important
     }
   }
 }
@@ -207,7 +199,6 @@
 }
 
 .activity-panel-enter {
-  // transform: rotateX(-50deg);
   transform: scale(1.01);
   background-color: #f0f0f0;
   opacity: 1;
@@ -215,7 +206,6 @@
 }
 
 .activity-panel-enter-done {
-  // transform: rotateX(0deg);
   transform: scale(1);
   background-color: #ffffff;
   opacity: 1;
@@ -223,16 +213,14 @@
 }
 
 .activity-panel-exit {
-  // transform: rotateX(20deg);
   background-color: #f7f7f7;
   opacity: 1;
   transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
 .activity-panel-exit-active {
-  // transform: rotateX(40deg);
   background-color: #eeeeee;
-  opacity: 1;  
+  opacity: 1;
   transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
@@ -247,7 +235,6 @@
 
 .bp3-popover {
   &.popover-lastrun {
-    // margin-left: -8px;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -261,81 +248,80 @@
   }
 }
 
-.trigger-module-lastrun {
-
-}
+.trigger-module-lastrun {}
 
 .bp3-button {
-    &.btn-cancel-pipeline {
+  &.btn-cancel-pipeline {
     transition: all 0.4s ease;
     background-color: darken(#FFA8A8, 5%);
     border: 1px solid darken(#FF6D6D, 5%);
     box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 6px;
-    // font-family: 'Montserrat', sans-serif;
     font-style: normal;
     font-weight: 900;
-    // font-size: 11px;
     color: #ffffff;
 
-    &:hover,:active,&.bp3-active {
-      background-color: darken(#FFA8A8, 10%)!important;
-      border: 1px solid darken(#FF6D6D, 10%)!important;
-      box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40)!important;
+    &:hover,
+    :active,
+    &.bp3-active {
+      background-color: darken(#FFA8A8, 10%) !important;
+      border: 1px solid darken(#FF6D6D, 10%) !important;
+      box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40) !important;
     }
   }
 
   &.btn-retry-pipeline {
     transition: all 0.4s ease;
-    // background-color: darken(#a8d8ff, 5%);
-    // border: 1px solid darken(#6dd6ff, 5%);
     box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 6px;
-    // font-family: 'Montserrat', sans-serif;
     font-style: normal;
     font-weight: 900;
-    // font-size: 11px;
     color: #ffffff;
 
-    &:hover,:active,&.bp3-active {
-      // background-color: darken(#a8d8ff, 15%);
-      // border: 1px solid darken(#6dd6ff, 15%);
+    &:hover,
+    :active,
+    &.bp3-active {
       box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40);
     }
-  }  
+  }
 }
 
 .bp3-input-group {
   .bp3-input {
     transition: all 0.3s ease;
   }
+
   &.is-invalid {
     .bp3-input {
       background-color: lighten(#FFA8A8, 13%);
       color: darken(#FF6D6D, 20%);
       border: 1px solid darken(#FF6D6D, 10%);
+
       &::placeholder {
         color: lighten(#FF6D6D, 10%);
       }
     }
-  }  
+  }
+
   &.is-valid {
     .bp3-input {
       background-color: lighten(#b5ffe0, 11%);
       color: darken(#00cf8a, 5%);
       border: 1px solid darken(#6dffce, 15%);
-      // font-weight: 800;
+
       &::placeholder {
         color: lighten(#6dffce, 10%);
       }
+
       &:focus {
         box-shadow: 0 0 0 1px #1ce878, 0 0 0 3px rgba(28, 232, 188, 0.3), inset 0 1px 1px rgba(16, 26, 23, 0.2)
       }
     }
-  }    
+  }
 }
 
-.bp3-popover-wrapper, .bp3-popover-target {
+.bp3-popover-wrapper,
+.bp3-popover-target {
   width: auto;
 }
 
@@ -348,12 +334,13 @@
 }
 
 .bp3-menu {
- &.pipeline-presets-menu {
+  &.pipeline-presets-menu {
     .bp3-menu-item {
-        &.bp3-active {
+      &.bp3-active {
         background-color: transparent;
         color: #007cff;
         font-weight: 800;
+
         &:hover {
           background-color: rgba(66, 66, 66, 0.08);
           color: darken(#007cff, 5%);

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -207,25 +207,33 @@
 }
 
 .activity-panel-enter {
-  transform: rotateX(-50deg);
-  opacity: 0.6;
-  transition: opacity 300ms, transform 300ms;
+  // transform: rotateX(-50deg);
+  transform: scale(1.01);
+  background-color: #f0f0f0;
+  opacity: 1;
+  transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
 .activity-panel-enter-done {
-  transform: rotateX(0deg);
+  // transform: rotateX(0deg);
+  transform: scale(1);
+  background-color: #ffffff;
   opacity: 1;
-  transition: opacity 300ms, transform 300ms;
+  transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
 .activity-panel-exit {
-  transform: rotateX(20deg);
-  transition: opacity 300ms, transform 300ms;
+  // transform: rotateX(20deg);
+  background-color: #f7f7f7;
+  opacity: 1;
+  transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
 .activity-panel-exit-active {
-  transform: rotateX(40deg);
-  transition: opacity 300ms, transform 300ms;
+  // transform: rotateX(40deg);
+  background-color: #eeeeee;
+  opacity: 1;  
+  transition: opacity 300ms, transform 300ms, background-color 800ms;
 }
 
 .bp3-spinner {

--- a/config-ui/src/utils/time.js
+++ b/config-ui/src/utils/time.js
@@ -1,0 +1,27 @@
+import * as dayjs from 'dayjs'
+import * as relativeTime from 'dayjs/plugin/relativeTime'
+import * as updateLocale from 'dayjs/plugin/updateLocale'
+
+const localeConfiguration = {
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: '< 1min',
+    m: 'a minute',
+    mm: '%d minutes',
+    h: 'an hour',
+    hh: '%d hours',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years'
+  }
+}
+
+dayjs.extend(relativeTime)
+dayjs.extend(updateLocale)
+dayjs.updateLocale('en', localeConfiguration)
+
+export default dayjs


### PR DESCRIPTION
### Config-UI / Pipelines / Pipeline Activity & Details

- [x] :new: Implement **Pipeline RUN Activity** Feature
  - [x] Apply reference UX Design & Layout
  - [x] Import SVG & Image Assets
- [x] Support URL Routing by **Pipeline ID**
- [x] Update **Pipeline Manager Hook** (`@/hooks/usePipelineManager.jsx`)
   - Polling _Disabled_ for `Completed` and `Failed` tasks.
- [x] Enable Refresh Polling (`5second` Intervals)
- [x] Display Pipeline Run Details
   - Pipeline Name
   - Run Date
   - Duration
   - Progress
- [x] Display Pipeline Stage & Tasks
  - Show Task Name
  - Show Task Duration
  - Show Task Progress
- [x] Hook-up Pipeline Actions
  - [x] **CANCEL** Pipeline Support
  - [x] **RESTART** Pipeline Support
 - [x] Create **JSON Inspector** Panel
- [x] Added **Day.js** Package (`2KB` Date/Time Library) to `package.json` 
- [x] Test Backend API Functionality
- [x] Test Production Build

### Description

This PR adds support for monitoring **Pipeline Activity**. After creating a new **Pipeline Run**, users will be guided to the activity screen to monitor the collection process. This page will provide users with all the relevant stage and task activity along with control actions to **CANCEL** `Running` and **RESTART** `Failed` and `Completed` pipelines.

As our Create Pipeline UX flow only supports **ONE** (1) Stage lane at this time, not all features to support multiple stages will be applied at this time. Basic Stage rendering logic has been added, however, and if a Pipeline were to be issued using the Triggers page or via direct API contact such as Postman that contains a multiple-stage configuration, stage indicators will be displayed.

This is not the final design and look of the Run/Activity Page, it does however capture and exceed our original requirements for activity details. Any additional changes whether visual or functional should be requested under a new development ticket.

Going forward, **Multi-stage** support is a future feature that will enhance the **Create Pipeline** UX flow, allowing users to add multiple stages each with their own task configuration (up to a specific/sane limit).


⚠️ **Limitations of CANCEL Feature**
Given that there are known issues with _cancelling_ a pipeline with multiple tasks, until all backend issues regarding cancellation process are resolved the user may experience degraded behavior due to the fact that cancelled pipelines do not have an official `CANCELLED` status value (See #996). In certain scenarios where collection fails for a task due to DB error or other failure, tasks may run stray and will require manual intervention to cancel the tasks.

**Next Up** &mdash; Manage Pipelines

### Does this close any open issues?
#965 

### **V2 Screenshots**
NOTE: A revised `Version 2` UX Layout has been applied as realtime changes were provided by the team during our daily standup meetings.

<img width="1506" alt="Screen Shot 2021-12-23 at 6 40 21 PM" src="https://user-images.githubusercontent.com/1742233/147299913-2f35057e-1424-4045-9b9d-39c541f52cca.png">
<img width="1506" alt="Screen Shot 2021-12-23 at 6 40 37 PM" src="https://user-images.githubusercontent.com/1742233/147299911-db356fac-fc92-4a2d-8bf2-b053efbdb379.png">
<img width="1508" alt="Screen Shot 2021-12-23 at 6 42 45 PM" src="https://user-images.githubusercontent.com/1742233/147299899-9a8898ec-e06c-4ed5-ab03-63d9354e1246.png">
<img width="1507" alt="Screen Shot 2021-12-23 at 6 41 54 PM" src="https://user-images.githubusercontent.com/1742233/147299906-ba90d20a-39fd-440f-8d07-5e4067c47b46.png">
<img width="1506" alt="Screen Shot 2021-12-23 at 6 41 23 PM" src="https://user-images.githubusercontent.com/1742233/147299910-1e61e48f-d89d-4bb5-b159-fb30a7a13a29.png">
<img width="1505" alt="Screen Shot 2021-12-23 at 6 44 37 PM" src="https://user-images.githubusercontent.com/1742233/147299994-8262c822-5ecd-44a4-874f-a75de843d8e7.png">



### V1 Screenshots

<img width="1180" alt="Screen Shot 2021-12-21 at 10 24 05 PM" src="https://user-images.githubusercontent.com/1742233/147030304-08799900-fefe-4717-9df6-5d51f4533fa3.png">
<img width="1181" alt="Screen Shot 2021-12-21 at 10 23 41 PM" src="https://user-images.githubusercontent.com/1742233/147030306-fd6faf45-2a7c-486c-b760-76677de834c6.png">
<img width="1180" alt="Screen Shot 2021-12-21 at 10 23 24 PM" src="https://user-images.githubusercontent.com/1742233/147030308-66c87bfb-1a83-45ee-81ba-339fa0d0b12c.png">
<img width="1178" alt="Screen Shot 2021-12-21 at 10 26 10 PM" src="https://user-images.githubusercontent.com/1742233/147030449-c14e1b99-f471-4d72-a56e-647eccf5478e.png">
<img width="1179" alt="Screen Shot 2021-12-21 at 10 26 39 PM" src="https://user-images.githubusercontent.com/1742233/147030496-e8822a27-0957-42f9-8fd3-f41d01706075.png">
<img width="1397" alt="Screen Shot 2021-12-21 at 10 28 07 PM" src="https://user-images.githubusercontent.com/1742233/147030624-ed75ead0-7029-44c8-a9f1-0e8590c79454.png">
<img width="982" alt="Screen Shot 2021-12-21 at 10 33 38 PM" src="https://user-images.githubusercontent.com/1742233/147031112-b292573d-0519-4a09-a3c7-4e2eced13de6.png">

### Build Log (`npm run build-production`)
```bash
shogun@z06 config-ui % npm run build-production

> frontend@0.1.0 build-production
> webpack --config webpack.production.config.js --mode production

[BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
Hash: c86adda7dbc6af1ed653
Version: webpack 4.46.0
Time: 19371ms
Built at: 12/23/2021 8:44:41 PM
                                                  Asset       Size  Chunks                                Chunk Names
assets/github-help.png?b5cbab0fb88a73592351f46cc498ecb5   16.1 KiB          [emitted]                     
assets/gitlab-help.png?fab7a9e8561bad1b1f30cc1a7a7b8dc7   25.4 KiB          [emitted]                     
  assets/jira-help.png?a06bb791c2076a6b1bbe0688822897c5   15.4 KiB          [emitted]                     
                                            favicon.ico   14.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-100.eot   22.1 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-100.svg   48.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-100.ttf   50.4 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-100.woff   24.4 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-100.woff2   18.9 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-100italic.eot   23.3 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-100italic.svg   51.9 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-100italic.ttf   51.8 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-100italic.woff     26 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-100italic.woff2   20.1 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-200.eot   22.6 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-200.svg   48.6 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-200.ttf   50.5 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-200.woff   24.9 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-200.woff2   19.4 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-200italic.eot   23.9 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-200italic.svg   51.9 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-200italic.ttf   51.9 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-200italic.woff   26.5 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-200italic.woff2   20.5 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-300.eot   22.8 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-300.svg   48.6 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-300.ttf   50.4 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-300.woff     25 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-300.woff2   19.5 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-300italic.eot   24.2 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-300italic.svg   51.9 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-300italic.ttf   51.8 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-300italic.woff   26.6 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-300italic.woff2   20.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-500.eot   22.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-500.svg   48.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-500.ttf   50.4 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-500.woff   24.9 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-500.woff2   19.4 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-500italic.eot     24 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-500italic.svg     52 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-500italic.ttf   51.7 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-500italic.woff   26.6 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-500italic.woff2   20.6 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-600.eot   22.8 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-600.svg   48.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-600.ttf   50.4 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-600.woff     25 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-600.woff2   19.5 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-600italic.eot   24.1 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-600italic.svg     52 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-600italic.ttf   51.7 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-600italic.woff   26.5 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-600italic.woff2   20.6 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-700.eot   22.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-700.svg   48.8 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-700.ttf   50.3 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-700.woff     25 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-700.woff2   19.3 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-700italic.eot     24 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-700italic.svg     52 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-700italic.ttf   51.6 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-700italic.woff   26.5 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-700italic.woff2   20.7 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-800.eot     22 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-800.svg   48.8 KiB          [emitted]                     
                  fonts/jetbrains-mono-v6-latin-800.ttf   50.3 KiB          [emitted]                     
                 fonts/jetbrains-mono-v6-latin-800.woff   24.2 KiB          [emitted]                     
                fonts/jetbrains-mono-v6-latin-800.woff2   18.8 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-800italic.eot   23.2 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-800italic.svg   52.2 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-800italic.ttf   51.7 KiB          [emitted]                     
           fonts/jetbrains-mono-v6-latin-800italic.woff   25.8 KiB          [emitted]                     
          fonts/jetbrains-mono-v6-latin-800italic.woff2   19.8 KiB          [emitted]                     
               fonts/jetbrains-mono-v6-latin-italic.eot   23.1 KiB          [emitted]                     
               fonts/jetbrains-mono-v6-latin-italic.svg     52 KiB          [emitted]                     
               fonts/jetbrains-mono-v6-latin-italic.ttf   51.6 KiB          [emitted]                     
              fonts/jetbrains-mono-v6-latin-italic.woff   25.8 KiB          [emitted]                     
             fonts/jetbrains-mono-v6-latin-italic.woff2   19.9 KiB          [emitted]                     
              fonts/jetbrains-mono-v6-latin-regular.eot   21.9 KiB          [emitted]                     
              fonts/jetbrains-mono-v6-latin-regular.svg   48.7 KiB          [emitted]                     
              fonts/jetbrains-mono-v6-latin-regular.ttf   50.4 KiB          [emitted]                     
             fonts/jetbrains-mono-v6-latin-regular.woff   24.2 KiB          [emitted]                     
            fonts/jetbrains-mono-v6-latin-regular.woff2   18.7 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-100.eot   21.7 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-100.svg   52.5 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-100.ttf   47.4 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-100.woff   22.8 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-100.woff2   18.6 KiB          [emitted]                     
               fonts/montserrat-v18-latin-100italic.eot   21.9 KiB          [emitted]                     
               fonts/montserrat-v18-latin-100italic.svg   54.2 KiB          [emitted]                     
               fonts/montserrat-v18-latin-100italic.ttf   47.7 KiB          [emitted]                     
              fonts/montserrat-v18-latin-100italic.woff   23.1 KiB          [emitted]                     
             fonts/montserrat-v18-latin-100italic.woff2   18.8 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-200.eot   22.4 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-200.svg   52.5 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-200.ttf   47.2 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-200.woff   23.6 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-200.woff2   19.1 KiB          [emitted]                     
               fonts/montserrat-v18-latin-200italic.eot   22.8 KiB          [emitted]                     
               fonts/montserrat-v18-latin-200italic.svg   54.3 KiB          [emitted]                     
               fonts/montserrat-v18-latin-200italic.ttf   47.5 KiB          [emitted]                     
              fonts/montserrat-v18-latin-200italic.woff     24 KiB          [emitted]                     
             fonts/montserrat-v18-latin-200italic.woff2   19.4 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-300.eot   22.3 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-300.svg   52.6 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-300.ttf   46.7 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-300.woff   23.5 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-300.woff2   19.1 KiB          [emitted]                     
               fonts/montserrat-v18-latin-300italic.eot   22.8 KiB          [emitted]                     
               fonts/montserrat-v18-latin-300italic.svg   54.3 KiB          [emitted]                     
               fonts/montserrat-v18-latin-300italic.ttf   46.9 KiB          [emitted]                     
              fonts/montserrat-v18-latin-300italic.woff     24 KiB          [emitted]                     
             fonts/montserrat-v18-latin-300italic.woff2   19.5 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-500.eot   22.7 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-500.svg   52.5 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-500.ttf     47 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-500.woff   23.8 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-500.woff2   19.4 KiB          [emitted]                     
               fonts/montserrat-v18-latin-500italic.eot   23.2 KiB          [emitted]                     
               fonts/montserrat-v18-latin-500italic.svg   54.3 KiB          [emitted]                     
               fonts/montserrat-v18-latin-500italic.ttf   47.6 KiB          [emitted]                     
              fonts/montserrat-v18-latin-500italic.woff   24.3 KiB          [emitted]                     
             fonts/montserrat-v18-latin-500italic.woff2   19.8 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-600.eot   22.7 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-600.svg   52.2 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-600.ttf   47.8 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-600.woff   23.8 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-600.woff2   19.4 KiB          [emitted]                     
               fonts/montserrat-v18-latin-600italic.eot   23.3 KiB          [emitted]                     
               fonts/montserrat-v18-latin-600italic.svg   54.1 KiB          [emitted]                     
               fonts/montserrat-v18-latin-600italic.ttf   48.4 KiB          [emitted]                     
              fonts/montserrat-v18-latin-600italic.woff   24.4 KiB          [emitted]                     
             fonts/montserrat-v18-latin-600italic.woff2   19.9 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-700.eot   22.9 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-700.svg   51.9 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-700.ttf   47.8 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-700.woff     24 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-700.woff2   19.6 KiB          [emitted]                     
               fonts/montserrat-v18-latin-700italic.eot   23.6 KiB          [emitted]                     
               fonts/montserrat-v18-latin-700italic.svg     54 KiB          [emitted]                     
               fonts/montserrat-v18-latin-700italic.ttf   48.4 KiB          [emitted]                     
              fonts/montserrat-v18-latin-700italic.woff   24.7 KiB          [emitted]                     
             fonts/montserrat-v18-latin-700italic.woff2     20 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-800.eot   22.9 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-800.svg   51.6 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-800.ttf   48.2 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-800.woff   24.1 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-800.woff2   19.5 KiB          [emitted]                     
               fonts/montserrat-v18-latin-800italic.eot   23.6 KiB          [emitted]                     
               fonts/montserrat-v18-latin-800italic.svg   53.6 KiB          [emitted]                     
               fonts/montserrat-v18-latin-800italic.ttf   48.7 KiB          [emitted]                     
              fonts/montserrat-v18-latin-800italic.woff   24.6 KiB          [emitted]                     
             fonts/montserrat-v18-latin-800italic.woff2   20.1 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-900.eot   22.8 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-900.svg   51.7 KiB          [emitted]                     
                     fonts/montserrat-v18-latin-900.ttf   50.6 KiB          [emitted]                     
                    fonts/montserrat-v18-latin-900.woff   23.9 KiB          [emitted]                     
                   fonts/montserrat-v18-latin-900.woff2   19.2 KiB          [emitted]                     
               fonts/montserrat-v18-latin-900italic.eot   23.2 KiB          [emitted]                     
               fonts/montserrat-v18-latin-900italic.svg   53.7 KiB          [emitted]                     
               fonts/montserrat-v18-latin-900italic.ttf   51.1 KiB          [emitted]                     
              fonts/montserrat-v18-latin-900italic.woff   24.4 KiB          [emitted]                     
             fonts/montserrat-v18-latin-900italic.woff2   19.8 KiB          [emitted]                     
                  fonts/montserrat-v18-latin-italic.eot   23.1 KiB          [emitted]                     
                  fonts/montserrat-v18-latin-italic.svg   54.4 KiB          [emitted]                     
                  fonts/montserrat-v18-latin-italic.ttf   47.5 KiB          [emitted]                     
                 fonts/montserrat-v18-latin-italic.woff   24.3 KiB          [emitted]                     
                fonts/montserrat-v18-latin-italic.woff2   19.8 KiB          [emitted]                     
                 fonts/montserrat-v18-latin-regular.eot   22.6 KiB          [emitted]                     
                 fonts/montserrat-v18-latin-regular.svg   52.5 KiB          [emitted]                     
                 fonts/montserrat-v18-latin-regular.ttf   47.2 KiB          [emitted]                     
                fonts/montserrat-v18-latin-regular.woff   23.8 KiB          [emitted]                     
               fonts/montserrat-v18-latin-regular.woff2   19.4 KiB          [emitted]                     
                                             index.html  662 bytes          [emitted]                     
                                               logo.svg  677 bytes          [emitted]                     
                           main.c86adda7dbc6af1ed653.js   1.34 MiB       0  [emitted] [immutable]  [big]  main
               main.c86adda7dbc6af1ed653.js.LICENSE.txt   3.66 KiB          [emitted]                     
                       main.c86adda7dbc6af1ed653.js.map    3.2 MiB       0  [emitted] [dev]               main
                                               main.css    323 KiB       0  [emitted]              [big]  main
                                           main.css.map    378 KiB       0  [emitted] [dev]               main
Entrypoint main [big] = main.css main.c86adda7dbc6af1ed653.js main.css.map main.c86adda7dbc6af1ed653.js.map
  [0] ./node_modules/react/index.js 190 bytes {0} [built]
  [1] ./node_modules/@babel/runtime/helpers/slicedToArray.js 522 bytes {0} [built]
  [4] ./node_modules/@babel/runtime/regenerator/index.js 49 bytes {0} [built]
  [5] ./node_modules/@babel/runtime/helpers/defineProperty.js 367 bytes {0} [built]
  [8] ./node_modules/@blueprintjs/core/lib/esm/index.js 806 bytes [built]
  [9] ./src/utils/config.js 318 bytes {0} [built]
 [11] ./node_modules/@babel/runtime/helpers/asyncToGenerator.js 887 bytes {0} [built]
 [13] ./node_modules/@babel/runtime/helpers/toConsumableArray.js 521 bytes {0} [built]
 [14] ./node_modules/react-dom/index.js 1.33 KiB {0} [built]
 [15] ./node_modules/react-transition-group/index.js 604 bytes {0} [built]
[111] ./node_modules/react/cjs/react.production.min.js 6.3 KiB {0} [built]
[112] ./node_modules/react-dom/cjs/react-dom.production.min.js 118 KiB {0} [built]
[115] ./node_modules/normalize.css/normalize.css 39 bytes {0} [built]
[116] ./src/styles/app.scss 39 bytes {0} [built]
[185] ./src/index.js + 144 modules 1.92 MiB {0} [built]
      | ./src/index.js 180 bytes [built]
      | ./src/App.js 2.84 KiB [built]
      | ./node_modules/react-router-dom/esm/react-router-dom.js 10.5 KiB [built]
      | ./src/pages/configure/index.jsx 8.88 KiB [built]
      | ./src/pages/configure/integration/index.jsx 2.97 KiB [built]
      | ./src/pages/configure/integration/manage.jsx 14.4 KiB [built]
      | ./src/pages/configure/connections/AddConnection.jsx 6.73 KiB [built]
      | ./src/pages/configure/connections/EditConnection.jsx 6.11 KiB [built]
      | ./src/pages/configure/connections/ConfigureConnection.jsx 12.7 KiB [built]
      | ./src/pages/triggers/index.jsx 15.1 KiB [built]
      | ./src/pages/offline/index.jsx 62.4 KiB [built]
      | ./src/pages/pipelines/create.jsx 28.5 KiB [built]
      | ./src/pages/pipelines/activity.jsx 28.4 KiB [built]
      | ./node_modules/@babel/runtime/helpers/esm/extends.js 397 bytes [built]
      | ./node_modules/tiny-invariant/dist/tiny-invariant.esm.js 436 bytes [built]
      |     + 130 hidden modules
    + 217 hidden modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  main.css (323 KiB)
  main.c86adda7dbc6af1ed653.js (1.34 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (1.65 MiB)
      main.css
      main.c86adda7dbc6af1ed653.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
Child HtmlWebpackCompiler:
                          Asset      Size  Chunks  Chunk Names
    __child-HtmlWebpackPlugin_0  4.23 KiB       0  HtmlWebpackPlugin_0
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [0] ./node_modules/html-webpack-plugin/lib/loader.js!./src/index-production.html 633 bytes {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--5-1!node_modules/normalize.css/normalize.css:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--5-1!./node_modules/normalize.css/normalize.css 6.58 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/app.scss:
    Entrypoint mini-css-extract-plugin = *
     [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/app.scss 311 KiB {0} [built]
     [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
     [2] ./node_modules/css-loader/dist/runtime/getUrl.js 830 bytes {0} [built]
     [3] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100.eot 80 bytes {0} [built]
     [4] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100.woff2 82 bytes {0} [built]
     [5] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100.woff 81 bytes {0} [built]
     [6] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100.ttf 80 bytes {0} [built]
     [7] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100.svg 80 bytes {0} [built]
     [8] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100italic.eot 86 bytes {0} [built]
     [9] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100italic.woff2 88 bytes {0} [built]
    [10] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100italic.woff 87 bytes {0} [built]
    [11] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100italic.ttf 86 bytes {0} [built]
    [12] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-100italic.svg 86 bytes {0} [built]
    [13] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-200.eot 80 bytes {0} [built]
    [14] ./src/fonts/montserrat/montserrat-v18-latin/montserrat-v18-latin-200.woff2 82 bytes {0} [built]
        + 158 hidden modules
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/breadcrumbs.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/breadcrumbs.scss 364 bytes {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/common.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/common.scss 3.38 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/configure.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/configure.scss 235 bytes {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/connections.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/connections.scss 4.01 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/integration.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/integration.scss 9.64 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/nav.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/nav.scss 556 bytes {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/offline.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/offline.scss 1.68 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/pipelines.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/pipelines.scss 5.59 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/sidebar-menu.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/sidebar-menu.scss 35.3 KiB {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]
Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--6-1!node_modules/postcss-loader/dist/cjs.js??ref--6-2!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/dist/cjs.js??ref--6-4!src/styles/sidebar.scss:
    Entrypoint mini-css-extract-plugin = *
    [0] ./node_modules/css-loader/dist/cjs.js??ref--6-1!./node_modules/postcss-loader/dist/cjs.js??ref--6-2!./node_modules/resolve-url-loader!./node_modules/sass-loader/dist/cjs.js??ref--6-4!./src/styles/sidebar.scss 1010 bytes {0} [built]
    [1] ./node_modules/css-loader/dist/runtime/api.js 2.46 KiB {0} [built]

```

