### PR TITLE
"/env" Set and Get refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,8 @@ GRAFANA_ENDPOINT=http://localhost:3002
 AE_APP_ID=
 AE_SECRET_KEY=
 AE_ENDPOINT=
+
+#########################
+# Testing
+#########################
+TEST_VAR=false

--- a/api/env/env.go
+++ b/api/env/env.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/logger"
 	"github.com/spf13/viper"
@@ -22,8 +21,8 @@ func Get(ctx *gin.Context) {
 }
 
 func Set(ctx *gin.Context) {
-	var data config.Config
-	err := ctx.MustBindWith(&data, binding.JSON)
+	var envVars map[string]interface{}
+	err := ctx.BindJSON(&envVars)
 	if err != nil {
 		logger.Error("", err)
 		ctx.JSON(http.StatusBadRequest, "Your json is malformed")
@@ -32,26 +31,9 @@ func Set(ctx *gin.Context) {
 
 	V := config.LoadConfigFile()
 
-	V.Set("PORT", data.PORT)
-	V.Set("DB_URL", data.DB_URL)
-	V.Set("MODE", data.MODE)
-	V.Set("JIRA_ENDPOINT", data.JIRA_ENDPOINT)
-	V.Set("JIRA_BASIC_AUTH_ENCODED", data.JIRA_BASIC_AUTH_ENCODED)
-	V.Set("JIRA_ISSUE_EPIC_KEY_FIELD", data.JIRA_ISSUE_EPIC_KEY_FIELD)
-	V.Set("JIRA_ISSUE_WORKLOAD_FIELD", data.JIRA_ISSUE_WORKLOAD_FIELD)
-	V.Set("JIRA_BOARD_GITLAB_PROJECTS", data.JIRA_BOARD_GITLAB_PROJECTS)
-	V.Set("JIRA_ISSUE_BUG_STATUS_MAPPING", data.JIRA_ISSUE_BUG_STATUS_MAPPING)
-	V.Set("JIRA_ISSUE_INCIDENT_STATUS_MAPPING", data.JIRA_ISSUE_INCIDENT_STATUS_MAPPING)
-	V.Set("JIRA_ISSUE_STORY_STATUS_MAPPING", data.JIRA_ISSUE_STORY_STATUS_MAPPING)
-	V.Set("JIRA_ISSUE_TYPE_MAPPING", data.JIRA_ISSUE_TYPE_MAPPING)
-	V.Set("GITLAB_ENDPOINT", data.GITLAB_ENDPOINT)
-	V.Set("GITLAB_AUTH", data.GITLAB_AUTH)
-	V.Set("GITHUB_ENDPOINT", data.GITHUB_ENDPOINT)
-	V.Set("GITHUB_AUTH", data.GITHUB_AUTH)
-	V.Set("GITHUB_PROXY", data.GITHUB_PROXY)
-	V.Set("JENKINS_ENDPOINT", data.JENKINS_ENDPOINT)
-	V.Set("JENKINS_USERNAME", data.JENKINS_USERNAME)
-	V.Set("JENKINS_PASSWORD", data.JENKINS_PASSWORD)
+	for key, value := range envVars {
+		V.Set(key, value)
+	}
 
 	err = V.WriteConfig()
 	if err != nil {
@@ -59,5 +41,5 @@ func Set(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, data)
+	ctx.JSON(http.StatusOK, envVars)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,35 +4,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-type Config struct {
-	PORT                               string `mapstructure:"PORT"`
-	DB_URL                             string `mapstructure:"DB_URL"`
-	MODE                               string `mapstructure:"MODE"`
-	JIRA_ENDPOINT                      string `mapstructure:"JIRA_ENDPOINT"`
-	JIRA_BASIC_AUTH_ENCODED            string `mapstructure:"JIRA_BASIC_AUTH_ENCODED"`
-	JIRA_ISSUE_EPIC_KEY_FIELD          string `mapstructure:"JIRA_ISSUE_EPIC_KEY_FIELD"`
-	JIRA_ISSUE_WORKLOAD_FIELD          string `mapstructure:"JIRA_ISSUE_WORKLOAD_FIELD"`
-	JIRA_BOARD_GITLAB_PROJECTS         string `mapstructure:"JIRA_BOARD_GITLAB_PROJECTS"`
-	JIRA_ISSUE_BUG_STATUS_MAPPING      string `mapstructure:"JIRA_ISSUE_BUG_STATUS_MAPPING"`
-	JIRA_ISSUE_INCIDENT_STATUS_MAPPING string `mapstructure:"JIRA_ISSUE_INCIDENT_STATUS_MAPPING"`
-	JIRA_ISSUE_STORY_STATUS_MAPPING    string `mapstructure:"JIRA_ISSUE_STORY_STATUS_MAPPING"`
-	JIRA_ISSUE_TYPE_MAPPING            string `mapstructure:"JIRA_ISSUE_TYPE_MAPPING"`
-	GITLAB_ENDPOINT                    string `mapstructure:"GITLAB_ENDPOINT"`
-	GITLAB_AUTH                        string `mapstructure:"GITLAB_AUTH"`
-	GITHUB_ENDPOINT                    string `mapstructure:"GITHUB_ENDPOINT"`
-	GITHUB_AUTH                        string `mapstructure:"GITHUB_AUTH"`
-	GITHUB_PROXY                       string `mapstructure:"GITHUB_PROXY"`
-	JENKINS_ENDPOINT                   string `mapstructure:"JENKINS_ENDPOINT"`
-	JENKINS_USERNAME                   string `mapstructure:"JENKINS_USERNAME"`
-	JENKINS_PASSWORD                   string `mapstructure:"JENKINS_PASSWORD"`
-	FEISHU_APPID                       string `mapstructure:"FEISHU_APPID"`
-	FEISHU_APPSCRECT                   string `mapstructure:"FEISHU_APPSCRECT"`
-	AE_APP_ID                          string `mapstructure:"AE_APP_ID"`
-	AE_NONCE_STR                       string `mapstructure:"AE_NONCE_STR"`
-	AE_SIGN                            string `mapstructure:"AE_SIGN"`
-	AE_ENDPOINT                        string `mapstructure:"AE_ENDPOINT"`
-}
-
 var V *viper.Viper
 
 func LoadConfigFile() *viper.Viper {
@@ -51,11 +22,11 @@ func init() {
 	V.WatchConfig()
 }
 
-func GetConfigJson() (*Config, error) {
-	var configJson Config
+func GetConfigJson() (map[string]string, error) {
+	var configJson map[string]string
 	err := V.Unmarshal(&configJson)
 	if err != nil {
 		return nil, err
 	}
-	return &configJson, nil
+	return configJson, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,18 +15,18 @@ func TestReadAndWriteToConfig(t *testing.T) {
 	// Verify new value is not equal to current value
 	configJson, err := GetConfigJson()
 	assert.Equal(t, err == nil, true)
-	currentDbUrl := configJson.DB_URL
-	newDbUrl := "ThisIsATest"
-	assert.Equal(t, currentDbUrl != newDbUrl, true)
+	currentTestVar := configJson["test_var"]
+	newTestVar := "true"
+	assert.Equal(t, currentTestVar != newTestVar, true)
 	V := LoadConfigFile()
-	V.Set("DB_URL", newDbUrl)
+	V.Set("TEST_VAR", newTestVar)
 	err = V.WriteConfig()
 	assert.Equal(t, err == nil, true)
 	newConfigJson, err := GetConfigJson()
 	assert.Equal(t, err == nil, true)
-	assert.Equal(t, newConfigJson.DB_URL, newDbUrl)
+	assert.Equal(t, newConfigJson["test_var"], newTestVar)
 	// Reset back to current
-	V.Set("DB_URL", currentDbUrl)
+	V.Set("TEST_VAR", currentTestVar)
 	err = V.WriteConfig()
 	assert.Equal(t, err == nil, true)
 }

--- a/plugins/jenkins/api/jenkins_sources.go
+++ b/plugins/jenkins/api/jenkins_sources.go
@@ -89,15 +89,10 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*JenkinsSource, error) {
-	// or just read from env using V.Get
-	configJson, err := config.GetConfigJson()
-	if err != nil {
-		return nil, err
-	}
 	return &JenkinsSource{
-		Endpoint: configJson["JENKINS_ENDPOINT"],
-		Username: configJson["JENKINS_USERNAME"],
-		Password: configJson["JENKINS_PASSWORD"],
+		Endpoint: config.V.GetString("JENKINS_ENDPOINT"),
+		Username: config.V.GetString("JENKINS_USERNAME"),
+		Password: config.V.GetString("JENKINS_PASSWORD"),
 		// The UI relies on a source ID here but we will hardcode it until the sources work is done for Jenkins
 		ID:   1,
 		Name: "Jenkins",

--- a/plugins/jenkins/api/jenkins_sources.go
+++ b/plugins/jenkins/api/jenkins_sources.go
@@ -89,14 +89,15 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*JenkinsSource, error) {
+	// or just read from env using V.Get
 	configJson, err := config.GetConfigJson()
 	if err != nil {
 		return nil, err
 	}
 	return &JenkinsSource{
-		Endpoint: configJson.JENKINS_ENDPOINT,
-		Username: configJson.JENKINS_USERNAME,
-		Password: configJson.JENKINS_PASSWORD,
+		Endpoint: configJson["JENKINS_ENDPOINT"],
+		Username: configJson["JENKINS_USERNAME"],
+		Password: configJson["JENKINS_PASSWORD"],
 		// The UI relies on a source ID here but we will hardcode it until the sources work is done for Jenkins
 		ID:   1,
 		Name: "Jenkins",


### PR DESCRIPTION
### Description
This PR contains a small refactor to make handling ENV variables through the /env endpoint easier. The solution provided here allows us to read/write without adhering to a specifically determined set of variables. This means we have less maintenance overhead and changes are easier to make. 

### Does this close any open issues?
Closes #1001

### Current Behavior
Env vars are read/written using hardcoded lists we need to maintain.

### New Behavior
Env vars are read/written dynamically; no list is needed.

### Other Information
- @e2corporation My search through the code suggested we are not using the "/env" endpoint directly from any active pages on the config-ui (only "offline" index page and "configure" index page, both deprecated). Please confirm that this endpoint is not used and no frontend changes are needed. 
- Jenkins sources was refactored a little due to a change to the GetConfigJson() util method.
- "TEST_VAR" added to .env.example to make Config Read/Write unit test pass.
- Test updated to pass as well
