### PR TITLE
chore: auto release to docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  build:
+    name: Build Server
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+    - name: Build lake image
+      run: |
+        export IMAGE_LAKE=mericodev/lake
+        docker build -t $IMAGE_LAKE:latest --file ./Dockerfile .
+        docker tag $IMAGE_LAKE:latest $IMAGE_LAKE:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_LAKE:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_LAKE:latest
+    - name: Build config ui image
+      run: |
+        export IMAGE_CONFIG_UI=mericodev/config-ui
+        cd config-ui
+        docker build -t $IMAGE_CONFIG_UI:latest --file ./Dockerfile .
+        docker tag $IMAGE_CONFIG_UI:latest $IMAGE_CONFIG_UI:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_CONFIG_UI:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_CONFIG_UI:latest
+    - name: Build grafana
+      run: |
+        export IMAGE_GRAFANA=mericodev/grafana
+        cd grafana
+        docker build -t $IMAGE_GRAFANA:latest --file ./Dockerfile .
+        docker tag $IMAGE_GRAFANA:latest $IMAGE_GRAFANA:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_GRAFANA:$(echo ${GITHUB_REF:10})
+        docker push $IMAGE_GRAFANA:latest

--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:16 as builder
+WORKDIR /home/node/code
+COPY package.json /home/node/code
+COPY package-lock.json /home/node/code
+RUN npm ci
+COPY . /home/node/code
+RUN npm run build-production
+
 FROM nginx:latest
 #ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 #RUN chmod +x /wait
@@ -6,5 +14,6 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf.tpl
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY ./dist/* ./
+COPY --from=builder /home/node/code/dist/* ./
 EXPOSE 80 443
 CMD envsubst '${DEVLAKE_ENDPOINT} ${GRAFANA_ENDPOINT}' < /etc/nginx/conf.d/default.conf.tpl > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       MYSQL_PASSWORD: merico
 
   grafana:
-    image: mericodev/grafana:0.5.0
+    image: mericodev/grafana:latest
     profiles:
       - user
     ports:
@@ -53,7 +53,7 @@ services:
       - mysql
 
   devlake:
-    image: mericodev/lake:0.5.0
+    image: mericodev/lake:latest
     profiles:
       - user
     build: "."
@@ -66,7 +66,7 @@ services:
       - mysql
 
   config-ui:
-    image: mericodev/config-ui:0.5.0
+    image: mericodev/config-ui:latest
     profiles:
       - user
     ports:


### PR DESCRIPTION
# Summary
Auto build and push docker image to docker hub when push a tag to this repository.

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
#433 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
![image](https://user-images.githubusercontent.com/11383928/147755021-fd8d0ad6-859d-42e1-9dad-5a61234b7b22.png)

### Other Information
Should add `DOCKER_REGISTRY_USERNAME` and `DOCKER_REGISTRY_PASSWORD` to secrets.
