### PR TITLE
`Hotfix` manage pipelines : fix pagination displayed count & range

### DIFF
--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -362,9 +362,9 @@ const PipelineActivity = (props) => {
                                     <p>Are you Sure you want to cancel this <strong>Run</strong>?</p>
                                     <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-end' }}>
                                       <Button
-                                        text='CANCEL' minimal
+                                        text='NO' minimal
                                         small className={Classes.POPOVER_DISMISS}
-                                        stlye={{ marginLeft: 'auto', marginRight: '3px' }}
+                                        style={{ marginLeft: 'auto', marginRight: '3px' }}
                                       />
                                       <Button
                                         className={Classes.POPOVER_DISMISS}

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -181,7 +181,7 @@ const Pipelines = (props) => {
 
   useEffect(() => {
     console.log('>>> FILTERED PIPELINES!', filteredPipelines)
-    setMaxPage(filteredPipelines.length <= perPage ? 1 : Math.floor(filteredPipelines.length / perPage))
+    setMaxPage(filteredPipelines.length <= perPage ? 1 : Math.floor(filteredPipelines.length / perPage) - 1)
     setPagedPipelines(filteredPipelines.slice(currentPage.current === 1
       ? 0
       : currentPage.current * perPage, currentPage.current === 1 ? perPage : (currentPage.current * perPage) + perPage))
@@ -493,9 +493,9 @@ const Pipelines = (props) => {
                                         <p>Are you Sure you want to cancel this <strong>Run</strong>?</p>
                                         <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-end' }}>
                                           <Button
-                                            text='CANCEL' minimal
+                                            text='NO' minimal
                                             small className={Classes.POPOVER_DISMISS}
-                                            stlye={{ marginLeft: 'auto', marginRight: '3px' }}
+                                            style={{ marginLeft: 'auto', marginRight: '3px' }}
                                           />
                                           <Button
                                             className={Classes.POPOVER_DISMISS}
@@ -574,8 +574,20 @@ const Pipelines = (props) => {
                         {filteredPipelines.length === 0 && (<>0</>)}
                         {filteredPipelines.length > 0 && (
                           <>
-                            {currentPage.current === 0 ? 0 : perPage * currentPage.current} - {' '}
-                            {(perPage * currentPage.current) + perPage} of {filteredPipelines.length}
+                            {currentPage.current === 1 && filteredPipelines.length <= perPage && (
+                              <>1 - {filteredPipelines.length}</>
+                            )}
+                            {currentPage.current === 1 && filteredPipelines.length > perPage && (
+                              <>1 - {perPage}</>
+                            )}
+                            {currentPage.current > 1 && filteredPipelines.length > perPage && (
+                              <>
+                                {(perPage * currentPage.current) - perPage} - {currentPage.current === 1
+                                  ? perPage
+                                  : (perPage * currentPage.current + perPage)}
+                              </>
+                            )}
+                            {' '} of {filteredPipelines.length}
                           </>
                         )}
                         {' '}pipeline runs from API.

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -581,6 +581,7 @@ const Pipelines = (props) => {
                     <Icon icon='user' size={14} style={{ marginRight: '8px' }} />
                     <div>
                       <span>by {' '} <strong>Administrator</strong></span><br />
+
                       <span style={{ color: '#888888' }}>Displaying{' '}
                         {filteredPipelines.length === 0 && (<>0</>)}
                         {filteredPipelines.length > 0 && (
@@ -598,11 +599,18 @@ const Pipelines = (props) => {
                                   : (Math.min(filteredPipelines.length, perPage * currentPage.current))}
                               </>
                             )}
-                            {' '} of {filteredPipelines.length}
+                            {' '} of {' '}
+                            <Tooltip
+                              content={`Page ${currentPage.current.toString()} of ${maxPage}`}
+                            >
+                              <strong>{filteredPipelines.length}</strong>
+                            </Tooltip>
+
                           </>
                         )}
                         {' '}pipeline runs from API.
                       </span>
+
                     </div>
                   </div>
 

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -571,8 +571,13 @@ const Pipelines = (props) => {
                     <div>
                       <span>by {' '} <strong>Administrator</strong></span><br />
                       <span style={{ color: '#888888' }}>Displaying{' '}
-                        {currentPage.current === 0 ? 0 : perPage * currentPage.current} - {' '}
-                        {(perPage * currentPage.current) + perPage} of {filteredPipelines.length}
+                        {filteredPipelines.length === 0 && (<>0</>)}
+                        {filteredPipelines.length > 0 && (
+                          <>
+                            {currentPage.current === 0 ? 0 : perPage * currentPage.current} - {' '}
+                            {(perPage * currentPage.current) + perPage} of {filteredPipelines.length}
+                          </>
+                        )}
                         {' '}pipeline runs from API.
                       </span>
                     </div>


### PR DESCRIPTION
### Config UI / Pipelines / Manage Pipelines

- [x] `Fixed` Display count should be 0 when no data
- [x] `Fixed` Incorrect Max Page Detection (Prefer `ceil` not `floor`)
- [x] `Fixed` Display count when filtered count less-than-or-equal to `perPage` 
- [x] `Fixed` Handle Last Page not accessible scenario
- [x] `Fixed` Handle Overpaging
- [x] `Fixed` Add special `PAGE 2` Offset Condition
- [x] Add Current Page Tooltip
- [x] Test Paging Options & Behavior

### Description
This Hotfix PR resolves an inaccurate Pagination display counts due when the filtered result set contains 0 records, along with required improvements to pagination slicing with respect to start and end offsets. Max-page detection has also been corrected.

### Does this close any open issues?
#1044 

 
### Screenshots

<img width="1173" alt="Screen Shot 2022-01-07 at 8 51 56 AM" src="https://user-images.githubusercontent.com/1742233/148553695-74b123e0-59a0-487a-a4dd-5ee2406ecbd1.png">

<img width="1196" alt="Screen Shot 2022-01-07 at 2 22 46 PM" src="https://user-images.githubusercontent.com/1742233/148596197-5a8462ae-ba94-41cd-ae91-e7702113a258.png">
<img width="1195" alt="Screen Shot 2022-01-07 at 2 22 25 PM" src="https://user-images.githubusercontent.com/1742233/148596210-6aa714f7-b372-4a9c-b5ca-01d276cd8466.png">
<img width="1196" alt="Screen Shot 2022-01-07 at 2 24 35 PM" src="https://user-images.githubusercontent.com/1742233/148596333-244e00e9-fe06-4fa0-87f5-0b4a5331b17e.png">

 
