### PR TITLE
feat: create pipelines - use multi-tag selector for gitlab projects and jira boards | `987`

### DIFF
--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -17,11 +17,11 @@ import { Select } from '@blueprintjs/select'
 const ProviderSettings = (props) => {
   const {
     providerId,
-    projectId,
+    projectId = [],
     sourceId,
     selectedSource,
     sources = [],
-    boardId,
+    boardId = [],
     owner,
     repositoryName,
     setProjectId = () => {},
@@ -105,8 +105,18 @@ const ProviderSettings = (props) => {
           </FormGroup>
           <FormGroup
             disabled={isRunning || !isEnabled(providerId)}
-            label={<strong>Board ID<span className='requiredStar'>*</span></strong>}
-            labelInfo={<span style={{ display: 'block' }}>Enter JIRA Board No.</span>}
+            label={
+              <strong>Board IDs<span className='requiredStar'>*</span>
+                <span
+                  className='badge-count'
+                  style={{
+                    opacity: isEnabled(providerId) ? 0.5 : 0.1
+                  }}
+                >{boardId.length}
+                </span>
+              </strong>
+            }
+            labelInfo={<span style={{ display: 'block' }}>Enter one or more JIRA Board IDs.</span>}
             inline={false}
             labelFor='board-id'
             className=''
@@ -114,7 +124,8 @@ const ProviderSettings = (props) => {
             style={{ marginLeft: '12px' }}
             fill
           >
-            <InputGroup
+            {/* (DISABLED) Single Input */}
+            {/* <InputGroup
               id='board-id'
               disabled={isRunning || !isEnabled(providerId)}
               placeholder='eg. 8'
@@ -123,7 +134,29 @@ const ProviderSettings = (props) => {
               className='input-board-id'
               autoComplete='off'
               fill={false}
-            />
+            /> */}
+            <div style={{ width: '100%' }}>
+              <TagInput
+                id='board-id'
+                disabled={isRunning || !isEnabled(providerId)}
+                placeholder='eg. 8, 100, 200'
+                values={boardId || []}
+                fill={true}
+                onChange={(values) => setBoardId([...new Set(values)])}
+                addOnPaste={true}
+                addOnBlur={true}
+                rightElement={
+                  <Button
+                    disabled={isRunning || !isEnabled(providerId)}
+                    icon='eraser'
+                    minimal
+                    onClick={() => setBoardId([])}
+                  />
+                  }
+                onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
+                className='input-board-id tagInput'
+              />
+            </div>
           </FormGroup>
         </>
       )
@@ -210,6 +243,7 @@ const ProviderSettings = (props) => {
             /> */}
             <div style={{ width: '100%' }}>
               <TagInput
+                id='project-id'
                 disabled={isRunning || !isEnabled(providerId)}
                 placeholder='eg. 937810831, 95781015'
                 values={projectId || []}
@@ -226,7 +260,7 @@ const ProviderSettings = (props) => {
                   />
                   }
                 onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
-                className='tagInput'
+                className='input-project-id tagInput'
               />
             </div>
           </FormGroup>

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -88,7 +88,6 @@ const ProviderSettings = (props) => {
                 }}
               >
                 <Button
-                  // intent={Intent.DANGER}
                   disabled={isRunning || !isEnabled(providerId)}
                   style={{ justifyContent: 'space-between', minWidth: '206px', maxWidth: '290px', whiteSpace: 'nowrap' }}
                   text={selectedSource ? `${selectedSource.title} [${selectedSource.value}]` : 'Select Instance'}
@@ -187,17 +186,7 @@ const ProviderSettings = (props) => {
                 <span
                   className='badge-count'
                   style={{
-                    opacity: isEnabled(providerId) ? 0.5 : 0.1,
-                    // width: 18,
-                    // height: 18,
-                    // display: 'inline-block',
-                    // borderRadius: '50%',
-                    // backgroundColor: 'rgba(0,0,255,0.9)',
-                    // color: '#ffffff',
-                    // lineHeight: '18px',
-                    // textAlign: 'center',
-                    // marginLeft: '5px',
-                    // fontWeight: 300
+                    opacity: isEnabled(providerId) ? 0.5 : 0.1
                   }}
                 >{projectId.length}
                 </span>

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -8,7 +8,9 @@ import {
   FormGroup,
   InputGroup,
   MenuItem,
-  Intent
+  Intent,
+  TagInput,
+  Tooltip,
 } from '@blueprintjs/core'
 import { Select } from '@blueprintjs/select'
 
@@ -180,14 +182,35 @@ const ProviderSettings = (props) => {
         <>
           <FormGroup
             disabled={isRunning || !isEnabled(providerId)}
-            label={<strong>Project ID<span className='requiredStar'>*</span></strong>}
-            labelInfo={<span style={{ display: 'block' }}>Enter the GitLab Project ID No.</span>}
+            label={
+              <strong>Project IDs<span className='requiredStar'>*</span>
+                <span
+                  className='badge-count'
+                  style={{
+                    opacity: isEnabled(providerId) ? 0.5 : 0.1,
+                    // width: 18,
+                    // height: 18,
+                    // display: 'inline-block',
+                    // borderRadius: '50%',
+                    // backgroundColor: 'rgba(0,0,255,0.9)',
+                    // color: '#ffffff',
+                    // lineHeight: '18px',
+                    // textAlign: 'center',
+                    // marginLeft: '5px',
+                    // fontWeight: 300
+                  }}
+                >{projectId.length}
+                </span>
+              </strong>
+            }
+            labelInfo={<span style={{ display: 'block' }}>Enter one or more GitLab Project IDs.</span>}
             inline={false}
             labelFor='project-id'
             className=''
             contentClassName=''
           >
-            <InputGroup
+            {/* (DISABLED) Single Input */}
+            {/* <InputGroup
               id='project-id'
               disabled={isRunning || !isEnabled(providerId)}
               placeholder='eg. 937810831'
@@ -195,7 +218,28 @@ const ProviderSettings = (props) => {
               onChange={(e) => setProjectId(pId => e.target.value)}
               className='input-project-id'
               autoComplete='off'
-            />
+            /> */}
+            <div style={{ width: '100%' }}>
+              <TagInput
+                disabled={isRunning || !isEnabled(providerId)}
+                placeholder='eg. 937810831, 95781015'
+                values={projectId || []}
+                fill={true}
+                onChange={(values) => setProjectId([...new Set(values)])}
+                addOnPaste={true}
+                addOnBlur={true}
+                rightElement={
+                  <Button
+                    disabled={isRunning || !isEnabled(providerId)}
+                    icon='eraser'
+                    minimal
+                    onClick={() => setProjectId([])}
+                  />
+                  }
+                onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
+                className='tagInput'
+              />
+            </div>
           </FormGroup>
         </>
       )

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { ToastNotification } from '@/components/Toast'
+// import { ToastNotification } from '@/components/Toast'
 import {
   Providers,
 } from '@/data/Providers'
@@ -28,16 +28,6 @@ function usePipelineValidation ({
   const validate = useCallback(() => {
     const errs = []
     console.log('>> VALIDATING PIPELINE RUN ', pipelineName)
-    // console.log('>> RUNNING FORM VALIDATIONS AGAINST FIELD VALUES...')
-    // console.log(
-    //   'PIPELINE NAME', name,
-    //   'PROJECT ID', projectId,
-    //   'BOARD ID', boardId,
-    //   'SOURCE ID', sourceId,
-    //   'OWNER', owner,
-    //   'REPOSITORY NAME', repositoryName,
-    //   'TASKS', tasks
-    // )
 
     if (!pipelineName || pipelineName.length <= 2) {
       errs.push('Name: Enter a valid Pipeline Name')
@@ -102,7 +92,6 @@ function usePipelineValidation ({
     setIsValid(errors.length === 0)
     if (errors.length > 0) {
       // ToastNotification.clear()
-
     }
   }, [errors])
 

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -22,7 +22,7 @@ function usePipelineValidation ({
   }
 
   const validateNumericSet = (set = []) => {
-    return set.every(i => !isNaN(i))
+    return Array.isArray(set) ? set.every(i => !isNaN(i)) : false
   }
 
   const validate = useCallback(() => {

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -39,8 +39,8 @@ function usePipelineValidation ({
       errs.push('Name: Enter a valid Pipeline Name')
     }
 
-    if (enabledProviders.includes(Providers.GITLAB) && (!projectId || isNaN(projectId))) {
-      errs.push('GitLab: Enter a valid Project ID (Numeric)')
+    if (enabledProviders.includes(Providers.GITLAB) && (!projectId || projectId.length === 0 || projectId.toString() === '')) {
+      errs.push('GitLab: Enter one or more valid Project IDs (Numeric)')
     }
 
     if (enabledProviders.includes(Providers.JIRA) && (!sourceId || isNaN(sourceId))) {

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -21,6 +21,10 @@ function usePipelineValidation ({
     setErrors([])
   }
 
+  const validateNumericSet = (set = []) => {
+    return set.every(i => !isNaN(i))
+  }
+
   const validate = useCallback(() => {
     const errs = []
     console.log('>> VALIDATING PIPELINE RUN ', pipelineName)
@@ -43,8 +47,11 @@ function usePipelineValidation ({
       errs.push('GitLab: Enter one or more valid Project IDs (Numeric)')
     }
 
+    if (enabledProviders.includes(Providers.GITLAB) && !validateNumericSet(projectId)) {
+      errs.push('GitLab: One of the entered Project IDs is NOT numeric!')
+    }
+
     if (enabledProviders.includes(Providers.JIRA) && (!sourceId || isNaN(sourceId))) {
-      // errs.push('JIRA: Enter a valid Connection Source ID (Numeric)')
       errs.push('JIRA: Select a valid Connection Source ID (Numeric)')
     }
 

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -45,8 +45,12 @@ function usePipelineValidation ({
       errs.push('JIRA: Select a valid Connection Source ID (Numeric)')
     }
 
-    if (enabledProviders.includes(Providers.JIRA) && (!boardId || isNaN(boardId))) {
-      errs.push('JIRA: Enter a valid Board ID (Numeric)')
+    if (enabledProviders.includes(Providers.JIRA) && (!boardId || boardId.length === 0 || boardId.toString() === '')) {
+      errs.push('JIRA: Enter one or more valid Board IDs (Numeric)')
+    }
+
+    if (enabledProviders.includes(Providers.JIRA) && !validateNumericSet(boardId)) {
+      errs.push('JIRA: One of the entered Board IDs is NOT numeric!')
     }
 
     if (enabledProviders.includes(Providers.GITHUB) && (!owner || owner <= 2)) {

--- a/config-ui/src/pages/configure/settings/jira/MappingTag.jsx
+++ b/config-ui/src/pages/configure/settings/jira/MappingTag.jsx
@@ -14,9 +14,11 @@ const MappingTag = ({ classNames, labelIntent, labelName, onChange, rightElement
           className='formGroup'
           contentClassName='formGroupContent'
         >
-          <Label style={{ display: 'inline' }}>
-            <span style={{ marginRight: '10px' }}><Tag className={classNames} intent={labelIntent}>{labelName}</Tag></span>
-          </Label>
+          {labelName && (
+            <Label style={{ display: 'inline' }}>
+              <span style={{ marginRight: '10px' }}><Tag className={classNames} intent={labelIntent}>{labelName}</Tag></span>
+            </Label>
+          )}
           <TagInput
             placeholder={placeholderText}
             values={values || []}

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -229,6 +229,11 @@ const CreatePipeline = (props) => {
     setOwner('')
   }
 
+  const getConnectionName = useCallback((connectionId) => {
+    const source = sources.find(s => s.id === connectionId)
+    return source ? source.title : '(Instance)'
+  }, [sources])
+
   useEffect(() => {
 
   }, [pipelineName])
@@ -310,13 +315,15 @@ const CreatePipeline = (props) => {
       }
       if (JiraTask && JiraTask.length > 0) {
         // const selSource = sources.find(s => s.ID === parseInt(JiraTask.options?.sourceId, 10))
+        fetchAllConnections(false)
         setEnabledProviders(eP => [...eP, Providers.JIRA])
         // setBoardId(JiraTask.options?.boardId)
         setBoardId(Array.isArray(JiraTask) ? JiraTask.map(jT => jT.options?.boardId) : JiraTask.options?.boardId)
+        const connSrcId = JiraTask[0].options?.sourceId
         setSelectedSource({
-          id: parseInt(JiraTask[0].options?.sourceId, 10),
-          title: '(Instance)',
-          value: parseInt(JiraTask[0].options?.sourceId, 10)
+          id: parseInt(connSrcId, 10),
+          title: getConnectionName(connSrcId),
+          value: parseInt(connSrcId, 10)
         })
       }
       if (JenkinsTask) {

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -181,14 +181,6 @@ const CreatePipeline = (props) => {
     switch (providerId) {
       case Providers.GITLAB:
         providerConfig = getManyProviderOptions(providerId, 'projectId', [...projectId])
-        // projectId.map(pId => {
-        //   return {
-        //     Plugin: providerId,
-        //     Options: {
-        //       projectId: parseInt(pId, 10)
-        //     }
-        //   }
-        // })
         break
       case Providers.JIRA:
         providerConfig = getManyProviderOptions(
@@ -314,10 +306,8 @@ const CreatePipeline = (props) => {
         setOwner(GitHubTask.options?.owner)
       }
       if (JiraTask && JiraTask.length > 0) {
-        // const selSource = sources.find(s => s.ID === parseInt(JiraTask.options?.sourceId, 10))
         fetchAllConnections(false)
         setEnabledProviders(eP => [...eP, Providers.JIRA])
-        // setBoardId(JiraTask.options?.boardId)
         setBoardId(Array.isArray(JiraTask) ? JiraTask.map(jT => jT.options?.boardId) : JiraTask.options?.boardId)
         const connSrcId = JiraTask[0].options?.sourceId
         setSelectedSource({

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -73,7 +73,7 @@ const CreatePipeline = (props) => {
   const [nameSuffix, setNameSuffix] = useState(pipelineSuffixes[0])
   const [pipelineName, setPipelineName] = useState(`${namePrefix} ${nameSuffix}`)
   const [projectId, setProjectId] = useState([])
-  const [boardId, setBoardId] = useState('')
+  const [boardId, setBoardId] = useState([])
   const [sourceId, setSourceId] = useState('')
   const [sources, setSources] = useState([])
   const [selectedSource, setSelectedSource] = useState()
@@ -135,6 +135,18 @@ const CreatePipeline = (props) => {
       validationErrors.length === 0
   }
 
+  const getManyProviderOptions = useCallback((providerId, optionProperty, ids, options = {}) => {
+    return ids.map(id => {
+      return {
+        Plugin: providerId,
+        Options: {
+          [optionProperty]: parseInt(id, 10),
+          ...options
+        }
+      }
+    })
+  }, [])
+
   const getProviderOptions = useCallback((providerId) => {
     let options = {}
     switch (providerId) {
@@ -168,14 +180,25 @@ const CreatePipeline = (props) => {
     let providerConfig = {}
     switch (providerId) {
       case Providers.GITLAB:
-        providerConfig = projectId.map(pId => {
-          return {
-            Plugin: providerId,
-            Options: {
-              projectId: parseInt(pId, 10)
-            }
+        providerConfig = getManyProviderOptions(providerId, 'projectId', [...projectId])
+        // projectId.map(pId => {
+        //   return {
+        //     Plugin: providerId,
+        //     Options: {
+        //       projectId: parseInt(pId, 10)
+        //     }
+        //   }
+        // })
+        break
+      case Providers.JIRA:
+        providerConfig = getManyProviderOptions(
+          providerId,
+          'boardId',
+          [...boardId],
+          {
+            sourceId: parseInt(sourceId, 10)
           }
-        })
+        )
         break
       default:
         providerConfig = {
@@ -187,7 +210,7 @@ const CreatePipeline = (props) => {
         break
     }
     return providerConfig
-  }, [getProviderOptions, projectId])
+  }, [getProviderOptions, getManyProviderOptions, projectId, boardId, sourceId])
 
   const resetPipelineName = () => {
     setToday(new Date())
@@ -200,7 +223,7 @@ const CreatePipeline = (props) => {
     setExistingTasks([])
     setEnabledProviders([])
     setProjectId([])
-    setBoardId('')
+    setBoardId([])
     setSelectedSource(null)
     setRepositoryName('')
     setOwner('')

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -297,9 +297,9 @@ const CreatePipeline = (props) => {
       // @todo: refactor later for multi-stage
       const GitLabTask = tasks.filter(t => t.plugin === Providers.GITLAB)
       const GitHubTask = tasks.find(t => t.plugin === Providers.GITHUB)
-      const JiraTask = tasks.find(t => t.plugin === Providers.JIRA)
+      const JiraTask = tasks.filter(t => t.plugin === Providers.JIRA)
       const JenkinsTask = tasks.find(t => t.plugin === Providers.JENKINS)
-      if (GitLabTask) {
+      if (GitLabTask && GitLabTask.length > 0) {
         setEnabledProviders(eP => [...eP, Providers.GITLAB])
         setProjectId(Array.isArray(GitLabTask) ? GitLabTask.map(gT => gT.options?.projectId) : GitLabTask.options?.projectId)
       }
@@ -308,14 +308,15 @@ const CreatePipeline = (props) => {
         setRepositoryName(GitHubTask.options?.repositoryName)
         setOwner(GitHubTask.options?.owner)
       }
-      if (JiraTask) {
+      if (JiraTask && JiraTask.length > 0) {
         // const selSource = sources.find(s => s.ID === parseInt(JiraTask.options?.sourceId, 10))
         setEnabledProviders(eP => [...eP, Providers.JIRA])
-        setBoardId(JiraTask.options?.boardId)
+        // setBoardId(JiraTask.options?.boardId)
+        setBoardId(Array.isArray(JiraTask) ? JiraTask.map(jT => jT.options?.boardId) : JiraTask.options?.boardId)
         setSelectedSource({
-          id: parseInt(JiraTask.options?.sourceId, 10),
+          id: parseInt(JiraTask[0].options?.sourceId, 10),
           title: '(Instance)',
-          value: parseInt(JiraTask.options?.sourceId, 10)
+          value: parseInt(JiraTask[0].options?.sourceId, 10)
         })
       }
       if (JenkinsTask) {

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -464,7 +464,7 @@ const Pipelines = (props) => {
                                 {['TASK_FAILED', 'TASK_COMPLETED'].includes(pipeline.status) && (
                                   <a
                                     href='#'
-                                    onClick={() => restartPipeline(activePipeline.tasks)}
+                                    onClick={() => restartPipeline(pipeline.tasks.flat())}
                                     data-provider={pipeline.id}
                                     className='bp3-button bp3-small bp3-minimal'
                                   >
@@ -501,7 +501,7 @@ const Pipelines = (props) => {
                                           <Button
                                             className={Classes.POPOVER_DISMISS}
                                             text='YES' icon='small-tick' intent={Intent.DANGER} small
-                                            onClick={() => cancelPipeline(activePipeline.ID)}
+                                            onClick={() => cancelPipeline(pipeline.ID)}
                                           />
                                         </div>
                                       </div>

--- a/config-ui/src/styles/common.scss
+++ b/config-ui/src/styles/common.scss
@@ -260,3 +260,17 @@ h3 {
   color: #717484;
   padding-left: 26px;
 }
+
+.badge-count {
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+  border-radius: 50%;
+  background-color: rgba(0,0,255,0.9);
+  color: #ffffff;
+  line-height: 18px;
+  text-align: center;
+  margin-left: 5px;
+  font-weight: 300;
+  opacity: 1.0;
+}


### PR DESCRIPTION
### Config-UI / Pipelines / Create Pipeline

- [x] **Create Pipeline** - Add Multiple ID Support
   - [x] Support multiple **GitLab Project IDs**
   - [x] Support multiple **JIRA Board IDs** 
- [x] Update Pipeline Validator Rules (`@/hooks/usePipelineValidation`)
- [x] Update Validation Messaging and Alerts
- [x] Update Restart Action
- [x] Test Create Pipeline Flow

### Description
This PR adds multi-tag selector support on the Create Pipeline form that allows users to enter one or more GitLab Projects and JIRA Boards. All Tasks will belong to the default stage, Stage One.

### Does this close any open issues?
#987

### Current Behavior
Users can only enter ONE (1) Gitlab Project ID or JIRA Board ID when Creating a Pipeline.

### New Behavior
Users can now enter many Project IDs and Board IDs for Gitlab and JIRA.

### Screenshots

<img width="1133" alt="Screen Shot 2022-01-17 at 6 06 34 PM" src="https://user-images.githubusercontent.com/1742233/149846095-adaea1e0-6913-4c5f-8149-b85de4aa0b3d.png">
<img width="1133" alt="Screen Shot 2022-01-17 at 6 10 53 PM" src="https://user-images.githubusercontent.com/1742233/149846338-c68480eb-9af3-40ea-ab72-c4b65290cf1d.png">
<img width="1217" alt="Screen Shot 2022-01-17 at 6 33 44 PM" src="https://user-images.githubusercontent.com/1742233/149847671-52f35368-9ff6-4cc1-8b28-05f9cf216422.png">
<img width="1280" alt="Screen Shot 2022-01-18 at 3 17 06 PM" src="https://user-images.githubusercontent.com/1742233/150017634-af524b3f-45d6-4cb0-87b6-2cd2edb8eb59.png">
<img width="1189" alt="Screen Shot 2022-01-18 at 6 27 29 PM" src="https://user-images.githubusercontent.com/1742233/150035245-dbd48f05-829e-4c21-8f50-4b96a1b0c8c9.png">
<img width="1402" alt="Screen Shot 2022-01-18 at 6 28 00 PM" src="https://user-images.githubusercontent.com/1742233/150035176-9888923c-bb44-471b-936c-c37a8a27c65b.png">


