### PR TITLE
fix(db): changed method to insert jira-sprint-issue

### DIFF
--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -158,14 +158,15 @@ func CollectIssues(
 					IssueId:  jiraIssue.IssueId,
 				})
 
-				// spirnt / issue relationship
+				// sprint / issue relationship
 				for _, sprintId := range sprints {
-					err = lakeModels.Db.FirstOrCreate(
-						&models.JiraSprintIssue{
-							SourceId: source.ID,
-							SprintId: sprintId,
-							IssueId:  jiraIssue.IssueId,
-						}).Error
+					err = lakeModels.Db.Clauses(clause.OnConflict{
+						DoNothing: true,
+					}).Create(&models.JiraSprintIssue{
+						SourceId: source.ID,
+						SprintId: sprintId,
+						IssueId:  jiraIssue.IssueId,
+					}).Error
 					if err != nil {
 						logger.Error("jira collect issues: save sprint issue relationship failed", err)
 						return err


### PR DESCRIPTION
The previous method "lakeModels.Db.FirstOrCreate" has concurrency problems, so use "lakeModels.Db.Clauses(...).Create(...)" to fix the problem

issue#1067

### ⚠️ &nbsp;&nbsp;Pre Checklist

# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
close issue#1067

