### PR TITLE
fix(db): changed method to insert jira-sprint-issue

### DIFF
--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -158,14 +158,15 @@ func CollectIssues(
 					IssueId:  jiraIssue.IssueId,
 				})
 
-				// spirnt / issue relationship
+				// sprint / issue relationship
 				for _, sprintId := range sprints {
-					err = lakeModels.Db.FirstOrCreate(
-						&models.JiraSprintIssue{
-							SourceId: source.ID,
-							SprintId: sprintId,
-							IssueId:  jiraIssue.IssueId,
-						}).Error
+					err = lakeModels.Db.Clauses(clause.OnConflict{
+						DoNothing: true,
+					}).Create(&models.JiraSprintIssue{
+						SourceId: source.ID,
+						SprintId: sprintId,
+						IssueId:  jiraIssue.IssueId,
+					}).Error
 					if err != nil {
 						logger.Error("jira collect issues: save sprint issue relationship failed", err)
 						return err


### PR DESCRIPTION
use "lakeModels.Db.Clauses(...).Create(...)" to fix concurrency problems

issue #1067


### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
close issue #1067 

### Current Behavior
method 'lakeModels.Db.FirstOrCreate(...)' caused concurrency problems

### New Behavior
lakeModels.Db.Clauses(...).Create(...) fixed the problems above

