### PR TITLE
`feat` jira settings : add jira issue tag selector entries on blur | `1078`

### DIFF
--- a/config-ui/src/pages/configure/settings/jira/MappingTag.jsx
+++ b/config-ui/src/pages/configure/settings/jira/MappingTag.jsx
@@ -25,6 +25,7 @@ const MappingTag = ({ classNames, labelIntent, labelName, onChange, rightElement
             fill={true}
             onChange={value => setTimeout(() => onChange([...new Set(value)]), 0)}
             addOnPaste={true}
+            addOnBlur={true}
             rightElement={rightElement}
             onKeyDown={e => e.key === 'Enter' && e.preventDefault()}
             className='tagInput'


### PR DESCRIPTION
### Config - UI / Integrations / JIRA / Settings

- [x] Add the `addOnBlur` feature to Issue Types Tag Selectors

### Description
This PR performs a small usability enhancement to the JIRA Settings Issue Type Selectors, allowing entries to be added `onBlur` in case the user forgets to press `ENTER` key.

### Does this close any open issues?
#1078

