### PR TITLE
Refactor hide authinfo in log

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -59,26 +59,26 @@ function useConnectionManager ({
     ToastNotification.clear()
     // TODO: run Save first
     const runTest = async () => {
-      let queryParams = ``
+      let connectionPayload
       switch (activeProvider.id) {
-        case Providers.JENKINS:
-          queryParams = `?username=${username}&password=${password}&endpoint=${endpointUrl}`
-          break
-        case Providers.GITLAB:
-          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+        case Providers.JIRA:
+          connectionPayload = { endpoint: endpointUrl, auth: token }
           break
         case Providers.GITHUB:
-          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+          connectionPayload = { endpoint: endpointUrl, auth: token }
           break
-        case Providers.JIRA:
-          queryParams = `?auth=${token}&endpoint=${endpointUrl}`
+        case Providers.JENKINS:
+          connectionPayload = { endpoint: endpointUrl, username: username, password: password }
+          break
+        case Providers.GITLAB:
+          connectionPayload = { endpoint: endpointUrl, auth: token }
           break
       }
-      let testUrl = `${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/test`
-      let getUrl = testUrl + queryParams
-      console.log('INFO >>> GET URL for testing: ', getUrl);
-      let res = await request.get(getUrl)
-      console.log('res.data', res.data);
+
+      const testUrl = `${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/test`
+      console.log('INFO >>> POST URL for testing: ', testUrl)
+      const res = await request.post(testUrl, connectionPayload)
+      console.log('res.data', res.data)
       if (res?.data?.Success && res.status === 200) {
         setIsTesting(false)
         setTestStatus(1)
@@ -86,7 +86,7 @@ function useConnectionManager ({
       } else {
         setIsTesting(false)
         setTestStatus(2)
-        let errorMessage = 'Connection test FAILED. ' + res?.data?.Message
+        const errorMessage = 'Connection test FAILED. ' + res?.data?.Message
         ToastNotification.show({ message: errorMessage, intent: 'danger', icon: 'error' })
       }
     }

--- a/plugins/core/testConnection.go
+++ b/plugins/core/testConnection.go
@@ -15,14 +15,14 @@ func (testResult *TestResult) Set(success bool, message string) {
 func ValidateParams(input *ApiResourceInput, requiredParams []string) *TestResult {
 	message := "Missing params: "
 	missingParams := []string{}
-	if len(input.Query) == 0 {
+	if len(input.Body) == 0 {
 		for _, param := range requiredParams {
 			message += fmt.Sprintf(" %v", param)
 		}
 		return &TestResult{Success: false, Message: message}
 	} else {
 		for _, param := range requiredParams {
-			if input.Query.Get(param) == "" {
+			if input.Body[param] == "" {
 				missingParams = append(missingParams, param)
 			}
 		}

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -21,15 +21,15 @@ type PublicEmail struct {
 }
 
 /*
-GET /plugins/github/test
+POST /plugins/github/test
 */
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	ValidationResult := core.ValidateParams(input, []string{"endpoint", "auth"})
 	if !ValidationResult.Success {
 		return &core.ApiResourceOutput{Body: ValidationResult}, nil
 	}
-	endpoint := input.Query.Get("endpoint")
-	auth := input.Query.Get("auth")
+	endpoint := input.Body["endpoint"].(string)
+	auth := input.Body["auth"].(string)
 	tokens := strings.Split(auth, ",")
 
 	// PLEASE NOTE: This works because GitHub API Client rotates tokens on each request

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -217,7 +217,7 @@ func (plugin Github) RootPkgPath() string {
 func (plugin Github) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
 		"test": {
-			"GET": api.TestConnection,
+			"POST": api.TestConnection,
 		},
 		"sources": {
 			"GET":  api.ListSources,

--- a/plugins/gitlab/api/gitlab_connections.go
+++ b/plugins/gitlab/api/gitlab_connections.go
@@ -15,7 +15,7 @@ type ApiUserResponse struct {
 }
 
 /*
-GET /plugins/gitlab/test
+POST /plugins/gitlab/test
 */
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	gitlabApiClient := tasks.CreateApiClient()
@@ -24,9 +24,9 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	if !ValidationResult.Success {
 		return &core.ApiResourceOutput{Body: ValidationResult}, nil
 	}
-	endpoint := input.Query.Get("endpoint")
+	endpoint := input.Body["endpoint"].(string)
 	headers := map[string]string{
-		"Authorization": fmt.Sprintf("Bearer %v", input.Query.Get("auth")),
+		"Authorization": fmt.Sprintf("Bearer %v", input.Body["auth"].(string)),
 	}
 	gitlabApiClient.SetEndpoint(endpoint)
 	gitlabApiClient.SetHeaders(headers)

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -209,7 +209,7 @@ func (plugin Gitlab) RootPkgPath() string {
 func (plugin Gitlab) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
 		"test": {
-			"GET": api.TestConnection,
+			"POST": api.TestConnection,
 		},
 		"sources": {
 			"GET":  api.ListSources,

--- a/plugins/jenkins/api/jenkins_connections.go
+++ b/plugins/jenkins/api/jenkins_connections.go
@@ -15,10 +15,10 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		return &core.ApiResourceOutput{Body: ValidationResult}, nil
 	}
 
-	encodedToken := utils.GetEncodedToken(input.Query.Get("username"), input.Query.Get("password"))
+	encodedToken := utils.GetEncodedToken(input.Body["username"].(string), input.Body["password"].(string))
 	apiClient := &core.ApiClient{}
 	apiClient.Setup(
-		input.Query.Get("endpoint"),
+		input.Body["endpoint"].(string),
 		map[string]string{
 			"Authorization": fmt.Sprintf("Basic %v", encodedToken),
 		},

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -57,17 +57,17 @@ func (j Jenkins) Execute(options map[string]interface{}, progress chan<- float32
 	j.CleanData()
 	var worker = tasks.NewJenkinsWorker(nil, tasks.NewDefaultJenkinsStorage(lakeModels.Db), op.Host, op.Username, op.Password)
 	err = worker.SyncJobs(progress)
-	if err != nil{
+	if err != nil {
 		logger.Error("Fail to sync jobs", err)
 		return err
 	}
 	err = tasks.ConvertJobs()
-	if err != nil{
+	if err != nil {
 		logger.Error("Fail to convert jobs", err)
 		return err
 	}
 	err = tasks.ConvertBuilds()
-	if err != nil{
+	if err != nil {
 		logger.Error("Fail to convert builds", err)
 		return err
 	}
@@ -81,7 +81,7 @@ func (plugin Jenkins) RootPkgPath() string {
 func (plugin Jenkins) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
 		"test": {
-			"GET": api.TestConnection,
+			"POST": api.TestConnection,
 		},
 		"sources": {
 			"GET":  api.ListSources,

--- a/plugins/jira/api/jira_connections.go
+++ b/plugins/jira/api/jira_connections.go
@@ -16,9 +16,10 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	if !ValidationResult.Success {
 		return &core.ApiResourceOutput{Body: ValidationResult}, nil
 	}
-	endpoint := input.Query.Get("endpoint")
-	auth := input.Query.Get("auth")
-	jiraApiClient := tasks.NewJiraApiClient(endpoint, auth)
+	endpoint := input.Body["endpoint"]
+	auth := input.Body["auth"]
+
+	jiraApiClient := tasks.NewJiraApiClient(endpoint.(string), auth.(string))
 
 	res, err := jiraApiClient.Get("api/3/myself", nil, nil)
 	if err != nil || res.StatusCode != 200 {

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -251,7 +251,7 @@ func (plugin Jira) RootPkgPath() string {
 func (plugin Jira) ApiResources() map[string]map[string]core.ApiResourceHandler {
 	return map[string]map[string]core.ApiResourceHandler{
 		"test": {
-			"GET": api.TestConnection,
+			"POST": api.TestConnection,
 		},
 		"echo": {
 			"POST": func(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {


### PR DESCRIPTION



### Description
Changed previous GET method which used to do test connection into POST method for all plugins in order to hide auth info in log

### Does this close any open issues?
This will close issue #1066 

### Current Behavior
Used GET method to do test connections, this exposed auth info in log 

### New Behavior
Changed to POST method for all plugins, then no auth info will be showed in log

### Other Information
@e2corporation I changed request method of testConnection() in useConnectionManager.jsx, I used a connectionPayload to store infos, and passed it into POST method, could you spare a moment to review the code, thanks.


