### PR TITLE
feat(plugins-github): enrich pull request with labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,10 @@ FEISHU_APPSCRECT=
 GITHUB_ENDPOINT=https://api.github.com/
 GITHUB_AUTH=***
 GITHUB_PROXY=
+# GITHUB_PR_TYPE=type/(.*)$ the program will extract the value in (), in this example, you will get "refactor" from "type/refactor"
+GITHUB_PR_TYPE=
+# GITHUB_PR_COMPONENT=component/(.*)$ the program will extract the value in (), in this example, you will get "plugins" from "component/plugins"
+GITHUB_PR_COMPONENT=
 
 ##########################
 # ConfigUI configuration #

--- a/models/domainlayer/code/pull_request.go
+++ b/models/domainlayer/code/pull_request.go
@@ -15,4 +15,6 @@ type PullRequest struct {
 	CreatedDate time.Time
 	MergedDate  *time.Time
 	ClosedAt    *time.Time
+	Type        string
+	Component   string
 }

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -99,24 +99,25 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	if len(tasksToRun) == 0 {
 		tasksToRun = map[string]bool{
-			"collectRepo":          true,
-			"collectCommits":       true,
-			"collectIssues":        true,
-			"collectIssueEvents":   true,
-			"collectIssueComments": true,
-			"collectIssueLabels":   true,
-			"collectPrReviews":     true,
-			"collectPrLabels":      true,
-			"collectPrCommits":     true,
-			"collectPrComments":    true,
-			"enrichIssues":         true,
-			"convertRepos":         true,
-			"convertIssues":        true,
-			"convertPrs":           true,
-			"convertCommits":       true,
-			"convertPrCommits":     true,
-			"convertNotes":         true,
-			"convertUsers":         true,
+			"collectRepo":                true,
+			"collectCommits":             true,
+			"collectIssues":              true,
+			"collectIssueEvents":         true,
+			"collectIssueComments":       true,
+			"collectIssueLabels":         true,
+			"collectPullRequestReviews":  true,
+			"collectPullRequestLabels":   true,
+			"collectPullRequestCommits":  true,
+			"collectPullRequestComments": true,
+			"enrichIssues":               true,
+			"enrichPullRequests":         true,
+			"convertRepos":               true,
+			"convertIssues":              true,
+			"convertPullRequests":        true,
+			"convertCommits":             true,
+			"convertPullRequestCommits":  true,
+			"convertNotes":               true,
+			"convertUsers":               true,
 		}
 	}
 
@@ -133,7 +134,6 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		}
 		tasks.CollectChildrenOnCommits(ownerString, repositoryNameString, repoId, scheduler, githubApiClient)
 	}
-
 	if tasksToRun["collectIssues"] {
 		progress <- 0.1
 		fmt.Println("INFO >>> starting issues / PRs collection")
@@ -168,37 +168,37 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			return fmt.Errorf("Could not collect Issue Labels: %v", collectIssueLabelsErr)
 		}
 	}
-	if tasksToRun["collectPrReviews"] {
+	if tasksToRun["collectPullRequestReviews"] {
 		progress <- 0.5
 		fmt.Println("INFO >>> collecting PR Reviews collection")
-		collectPrReviewsErr := tasks.CollectPullRequestReviews(ownerString, repositoryNameString, scheduler, githubApiClient)
-		if collectPrReviewsErr != nil {
-			return fmt.Errorf("Could not collect PR Reviews: %v", collectPrReviewsErr)
+		collectPullRequestReviewsErr := tasks.CollectPullRequestReviews(ownerString, repositoryNameString, scheduler, githubApiClient)
+		if collectPullRequestReviewsErr != nil {
+			return fmt.Errorf("Could not collect PR Reviews: %v", collectPullRequestReviewsErr)
 		}
 	}
-	if tasksToRun["collectPrLabels"] {
+	if tasksToRun["collectPullRequestLabels"] {
 		progress <- 0.6
 		fmt.Println("INFO >>> starting Pr Labels collection")
-		collectPrLabelsErr := tasks.CollectPrLabels(ownerString, repositoryNameString, scheduler, githubApiClient)
-		if collectPrLabelsErr != nil {
-			return fmt.Errorf("Could not collect PR Labels: %v", collectPrLabelsErr)
+		collectPullRequestLabelsErr := tasks.CollectPrLabels(ownerString, repositoryNameString, scheduler, githubApiClient)
+		if collectPullRequestLabelsErr != nil {
+			return fmt.Errorf("Could not collect PR Labels: %v", collectPullRequestLabelsErr)
 		}
 	}
 
-	if tasksToRun["collectPrCommits"] {
+	if tasksToRun["collectPullRequestCommits"] {
 		progress <- 0.7
 		fmt.Println("INFO >>> starting PR Commits collection")
-		collectPrCommitsErr := tasks.CollectPullRequestCommits(ownerString, repositoryNameString, scheduler, githubApiClient)
-		if collectPrCommitsErr != nil {
-			return fmt.Errorf("Could not collect PR Commits: %v", collectPrCommitsErr)
+		collectPullRequestCommitsErr := tasks.CollectPullRequestCommits(ownerString, repositoryNameString, scheduler, githubApiClient)
+		if collectPullRequestCommitsErr != nil {
+			return fmt.Errorf("Could not collect PR Commits: %v", collectPullRequestCommitsErr)
 		}
 	}
-	if tasksToRun["collectPrComments"] {
+	if tasksToRun["collectPullRequestComments"] {
 		progress <- 0.8
 		fmt.Println("INFO >>> starting PR Comments collection")
-		collectPrCommentsErr := tasks.CollectPullRequestComments(ownerString, repositoryNameString, scheduler, githubApiClient)
-		if collectPrCommentsErr != nil {
-			return fmt.Errorf("Could not collect PR Comments: %v", collectPrCommentsErr)
+		collectPullRequestCommentsErr := tasks.CollectPullRequestComments(ownerString, repositoryNameString, scheduler, githubApiClient)
+		if collectPullRequestCommentsErr != nil {
+			return fmt.Errorf("Could not collect PR Comments: %v", collectPullRequestCommentsErr)
 		}
 	}
 	if tasksToRun["enrichIssues"] {
@@ -209,6 +209,14 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			return fmt.Errorf("could not enrich issues: %v", enrichmentError)
 		}
 
+	}
+	if tasksToRun["enrichPullRequests"] {
+		progress <- 0.9
+		fmt.Println("INFO >>> Enriching PullRequests")
+		enrichPullRequestsError := tasks.EnrichGithubPullRequestWithLabel()
+		if enrichPullRequestsError != nil {
+			return fmt.Errorf("could not enrich PullRequests: %v", enrichPullRequestsError)
+		}
 	}
 	if tasksToRun["convertRepos"] {
 		progress <- 0.9
@@ -224,7 +232,7 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			return err
 		}
 	}
-	if tasksToRun["convertPrs"] {
+	if tasksToRun["convertPullRequests"] {
 		progress <- 0.9
 		err = tasks.ConvertPullRequests()
 		if err != nil {
@@ -238,7 +246,7 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 			return err
 		}
 	}
-	if tasksToRun["convertPrCommits"] {
+	if tasksToRun["convertPullRequestCommits"] {
 		progress <- 0.9
 		err = tasks.PrCommitConvertor()
 		if err != nil {

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -332,7 +332,7 @@ func main() {
 				//"tasks": []string{"convertCommits"},
 				//"tasks": []string{"collectIssues"},
 				//"tasks": []string{"enrichIssues"},
-				"tasks": []string{"collectIssueLabels"},
+				"tasks": []string{"collectPullRequestLabels", "enrichPullRequests", "convertPullRequests"},
 			},
 			progress,
 			context.Background(),

--- a/plugins/github/models/github_issue_label.go
+++ b/plugins/github/models/github_issue_label.go
@@ -8,7 +8,7 @@ import (
 // Pull Requests are considered Issues in GitHub.
 
 type GithubIssueLabel struct {
-	IssueId        int    `gorm:"primaryKey;autoIncrement:false"`
-	IssueLabelName string `gorm:"primaryKey"`
+	IssueId   int    `gorm:"primaryKey;autoIncrement:false"`
+	LabelName string `gorm:"primaryKey"`
 	common.NoPKModel
 }

--- a/plugins/github/models/github_pull_request.go
+++ b/plugins/github/models/github_pull_request.go
@@ -21,5 +21,7 @@ type GithubPullRequest struct {
 	ReviewComments int
 	Merged         bool
 	MergedAt       *time.Time
+	Type           string
+	Component      string
 	common.NoPKModel
 }

--- a/plugins/github/tasks/github_issue_labels_collector.go
+++ b/plugins/github/tasks/github_issue_labels_collector.go
@@ -54,8 +54,8 @@ func processIssueLabelsCollection(owner string, repositoryName string, issue *mo
 				}
 				for _, label := range *githubApiResponse {
 					githubLabel := &models.GithubIssueLabel{
-						IssueId:        issue.GithubId,
-						IssueLabelName: label.Name,
+						IssueId:   issue.GithubId,
+						LabelName: label.Name,
 					}
 					err = lakeModels.Db.Clauses(clause.OnConflict{
 						UpdateAll: true,

--- a/plugins/github/tasks/github_issues_enrichment.go
+++ b/plugins/github/tasks/github_issues_enrichment.go
@@ -20,9 +20,8 @@ func buildLabelQuery(matches []string) (*sql.Rows, error) {
 
 	cursor, err := lakeModels.Db.Model(&models.GithubIssue{}).
 		Select("github_issue_labels.*, github_issues.*").
-		Joins("join github_issue_label_issues On github_issue_label_issues.issue_id = github_issues.github_id").
-		Joins("join github_issue_labels On github_issue_labels.github_id = github_issue_label_issues.issue_label_id").
-		Where(fmt.Sprintf("github_issue_labels.name rlike '.*(%v).*'", where)).
+		Joins("join github_issue_labels On github_issue_labels.issue_id = github_issues.github_id").
+		Where(fmt.Sprintf("github_issue_labels.label_name rlike '.*(%v).*'", where)).
 		Rows()
 
 	if err != nil {

--- a/plugins/github/tasks/github_pull_request_converter.go
+++ b/plugins/github/tasks/github_pull_request_converter.go
@@ -35,6 +35,8 @@ func convertToPullRequestModel(pr *githubModels.GithubPullRequest) *code.PullReq
 		CreatedDate: pr.GithubCreatedAt,
 		MergedDate:  pr.MergedAt,
 		ClosedAt:    pr.ClosedAt,
+		Type:        pr.Type,
+		Component:   pr.Component,
 	}
 	return domainPr
 }

--- a/plugins/github/tasks/github_pull_request_enricher.go
+++ b/plugins/github/tasks/github_pull_request_enricher.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"github.com/merico-dev/lake/config"
+	lakeModels "github.com/merico-dev/lake/models"
+	githubModels "github.com/merico-dev/lake/plugins/github/models"
+	"regexp"
+)
+
+var prType = config.V.GetString("GITHUB_PR_TYPE")
+var prComponent = config.V.GetString("GITHUB_PR_COMPONENT")
+
+func EnrichGithubPullRequestWithLabel() (err error) {
+	githubPullRequst := &githubModels.GithubPullRequest{}
+	cursor, err := lakeModels.Db.Model(&githubPullRequst).Rows()
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+	// iterate all rows
+	for cursor.Next() {
+		err = lakeModels.Db.ScanRows(cursor, githubPullRequst)
+		githubPullRequst.Type = ""
+		githubPullRequst.Component = ""
+		if err != nil {
+			return err
+		}
+		var pullRequestLabels []string
+
+		lakeModels.Db.Table("github_issue_labels").
+			Where("issue_id = ?", githubPullRequst.GithubId).Order("updated_at ASC").
+			Pluck("`label_name`", &pullRequestLabels)
+
+		for _, pullRequestLabel := range pullRequestLabels {
+			setPullRequestLabel(pullRequestLabel, githubPullRequst)
+		}
+
+		err = lakeModels.Db.Save(githubPullRequst).Error
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setPullRequestLabel(label string, pr *githubModels.GithubPullRequest) {
+	var labelRegex *regexp.Regexp
+	// if pr.Type has not been set and prType is set in .env, process the below
+	if prType != "" && pr.Type == "" {
+		labelRegex = regexp.MustCompile(prType)
+	}
+	if labelRegex != nil {
+		groups := labelRegex.FindStringSubmatch(label)
+		if len(groups) > 0 {
+			pr.Type = groups[1]
+			return
+		}
+	}
+
+	// if pr.Component has not been set and prComponent is set in .env, process
+	if prComponent != "" && pr.Component == "" {
+		labelRegex = regexp.MustCompile(prComponent)
+	}
+	if labelRegex != nil {
+		groups := labelRegex.FindStringSubmatch(label)
+		if len(groups) > 0 {
+			pr.Component = groups[1]
+			return
+		}
+	}
+}

--- a/plugins/github/tasks/github_pull_request_enricher.go
+++ b/plugins/github/tasks/github_pull_request_enricher.go
@@ -10,6 +10,14 @@ import (
 var prType = config.V.GetString("GITHUB_PR_TYPE")
 var prComponent = config.V.GetString("GITHUB_PR_COMPONENT")
 
+var labelTypeRegex *regexp.Regexp
+var labelComponentRegex *regexp.Regexp
+
+func init() {
+	labelTypeRegex = regexp.MustCompile(prType)
+	labelComponentRegex = regexp.MustCompile(prComponent)
+}
+
 func EnrichGithubPullRequestWithLabel() (err error) {
 	githubPullRequst := &githubModels.GithubPullRequest{}
 	cursor, err := lakeModels.Db.Model(&githubPullRequst).Rows()
@@ -20,16 +28,18 @@ func EnrichGithubPullRequestWithLabel() (err error) {
 	// iterate all rows
 	for cursor.Next() {
 		err = lakeModels.Db.ScanRows(cursor, githubPullRequst)
-		githubPullRequst.Type = ""
-		githubPullRequst.Component = ""
 		if err != nil {
 			return err
 		}
+		githubPullRequst.Type = ""
+		githubPullRequst.Component = ""
 		var pullRequestLabels []string
-
-		lakeModels.Db.Table("github_issue_labels").
-			Where("issue_id = ?", githubPullRequst.GithubId).Order("updated_at ASC").
-			Pluck("`label_name`", &pullRequestLabels)
+		err = lakeModels.Db.Table("github_issue_labels").
+			Where("issue_id = ?", githubPullRequst.GithubId).
+			Pluck("`label_name`", &pullRequestLabels).Error
+		if err != nil {
+			return err
+		}
 
 		for _, pullRequestLabel := range pullRequestLabels {
 			setPullRequestLabel(pullRequestLabel, githubPullRequst)
@@ -44,13 +54,9 @@ func EnrichGithubPullRequestWithLabel() (err error) {
 }
 
 func setPullRequestLabel(label string, pr *githubModels.GithubPullRequest) {
-	var labelRegex *regexp.Regexp
 	// if pr.Type has not been set and prType is set in .env, process the below
-	if prType != "" && pr.Type == "" {
-		labelRegex = regexp.MustCompile(prType)
-	}
-	if labelRegex != nil {
-		groups := labelRegex.FindStringSubmatch(label)
+	if labelTypeRegex != nil {
+		groups := labelTypeRegex.FindStringSubmatch(label)
 		if len(groups) > 0 {
 			pr.Type = groups[1]
 			return
@@ -58,11 +64,8 @@ func setPullRequestLabel(label string, pr *githubModels.GithubPullRequest) {
 	}
 
 	// if pr.Component has not been set and prComponent is set in .env, process
-	if prComponent != "" && pr.Component == "" {
-		labelRegex = regexp.MustCompile(prComponent)
-	}
-	if labelRegex != nil {
-		groups := labelRegex.FindStringSubmatch(label)
+	if labelComponentRegex != nil {
+		groups := labelComponentRegex.FindStringSubmatch(label)
 		if len(groups) > 0 {
 			pr.Component = groups[1]
 			return

--- a/plugins/github/tasks/github_pull_request_labels_collector.go
+++ b/plugins/github/tasks/github_pull_request_labels_collector.go
@@ -30,11 +30,6 @@ func CollectPrLabels(owner string, repositoryName string, scheduler *utils.Worke
 			logger.Error("Could not collect Pr labels", labelsErr)
 			return labelsErr
 		}
-		//labelsErr := processPrLabelsCollection(owner, repositoryName, &prs[i], scheduler, githubApiClient)
-		//if labelsErr != nil {
-		//	logger.Error("Could not collect Pr labels", labelsErr)
-		//	return labelsErr
-		//}
 	}
 	return nil
 }

--- a/plugins/github/tasks/github_pull_request_labels_collector.go
+++ b/plugins/github/tasks/github_pull_request_labels_collector.go
@@ -30,6 +30,11 @@ func CollectPrLabels(owner string, repositoryName string, scheduler *utils.Worke
 			logger.Error("Could not collect Pr labels", labelsErr)
 			return labelsErr
 		}
+		//labelsErr := processPrLabelsCollection(owner, repositoryName, &prs[i], scheduler, githubApiClient)
+		//if labelsErr != nil {
+		//	logger.Error("Could not collect Pr labels", labelsErr)
+		//	return labelsErr
+		//}
 	}
 	return nil
 }
@@ -47,8 +52,8 @@ func processPrLabelsCollection(owner string, repositoryName string, pr *models.G
 				}
 				for _, label := range *githubApiResponse {
 					githubIssueLabel := &models.GithubIssueLabel{
-						IssueId:        pr.GithubId,
-						IssueLabelName: label.Name,
+						IssueId:   pr.GithubId,
+						LabelName: label.Name,
 					}
 					err = lakeModels.Db.Clauses(clause.OnConflict{
 						UpdateAll: true,


### PR DESCRIPTION
Users can config regular expression for PR_TYPE and PR_COMPONENT
And the github plugin will enrich pull requests with labels which meet the expression configured

### Screenshots
type and component have been enriched:
![image](https://user-images.githubusercontent.com/39366025/150797548-2b2d3b5a-66a4-4ea3-808b-11bd431490cb.png)


### issue
will close issue #951
