### PR TITLE
fix: clean up previous collected/converted data for jira

### DIFF
--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -335,7 +335,7 @@ func main() {
 			map[string]interface{}{
 				"sourceId": sourceId,
 				"boardId":  boardId,
-				"tasks":    []string{"convertIssues"},
+				"tasks":    []string{"collectRemotelinks", "enrichRemotelinks", "convertIssueCommits"},
 			},
 			progress,
 			context.Background(),

--- a/plugins/jira/tasks/jira_remotelink_collector.go
+++ b/plugins/jira/tasks/jira_remotelink_collector.go
@@ -116,6 +116,13 @@ func collectRemotelinksByIssueId(
 	}
 
 	apiRemotelink := &JiraApiRemotelink{}
+
+	// delete previous collected remotelink
+	err = lakeModels.Db.Where("source_id = ? AND issue_id = ?", source.ID, issueId).Delete(apiRemotelink).Error
+	if err != nil {
+		return err
+	}
+
 	for _, apiRemotelinkRaw := range *apiRemotelinks {
 		// unmarshal to fetch id for primary key
 		err = json.Unmarshal(apiRemotelinkRaw, apiRemotelink)


### PR DESCRIPTION
# Summary

To fix problem: remotelinks/issue_commits still exist in devlake database even if they got removed on jira platform 

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
