### PR TITLE
fix: ref names of refs_commits_diffs are missing prefix

### DIFF
--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -61,7 +61,7 @@ func (rd RefDiff) Execute(options map[string]interface{}, progress chan<- float3
 		if refName == "" {
 			return "", fmt.Errorf("ref name is empty")
 		}
-		ref.Id = fmt.Sprintf("%s:%s",op.RepoId, refName)
+		ref.Id = fmt.Sprintf("%s:%s", op.RepoId, refName)
 		err = models.Db.First(ref).Error
 		if err != nil {
 			return "", fmt.Errorf("faild to load Ref info for repoId:%s, refName:%s", op.RepoId, refName)
@@ -117,8 +117,8 @@ func (rd RefDiff) Execute(options map[string]interface{}, progress chan<- float3
 		// ref might advance, keep commit sha for debugging
 		commitsDiff.NewCommitSha = pair[0]
 		commitsDiff.OldCommitSha = pair[1]
-		commitsDiff.NewRefName = pair[2]
-		commitsDiff.OldRefName = pair[3]
+		commitsDiff.NewRefName = fmt.Sprintf("%s:%s", op.RepoId, pair[2])
+		commitsDiff.OldRefName = fmt.Sprintf("%s:%s", op.RepoId, pair[3])
 
 		newCommit := cayley.StartPath(store, quad.String(commitsDiff.NewCommitSha)).FollowRecursive(ancestors, -1, []string{})
 		oldCommit := cayley.StartPath(store, quad.String(commitsDiff.OldCommitSha)).FollowRecursive(ancestors, -1, []string{})


### PR DESCRIPTION

# Summary

before
![middle_img_v2_bcabd40a-33c8-47ce-8edc-12b62c71aebg](https://user-images.githubusercontent.com/61080/151346377-031ebede-9b03-4caa-bade-6e189b71c677.png)

after
![image](https://user-images.githubusercontent.com/61080/151346486-3c01b5c4-24f5-43a6-b732-dadd38ca0b29.png)


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
