### PR TITLE
fix: fix too many connections

### DIFF
--- a/models/init.go
+++ b/models/init.go
@@ -43,6 +43,13 @@ func init() {
 		fmt.Println("ERROR: >>> Mysql failed to connect")
 		panic(err)
 	}
+	sqlDB, err := Db.DB()
+	if err != nil{
+		panic(err)
+	}
+	sqlDB.SetMaxIdleConns(10)
+	sqlDB.SetMaxOpenConns(100)
+	sqlDB.SetConnMaxLifetime(time.Hour)
 	migrateDB()
 }
 


### PR DESCRIPTION
# Summary
fix the "too many connections" error by setting up a connection pool 

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

