### PR TITLE
fix: added org as prefix to github repo name

### DIFF
--- a/plugins/github/tasks/github_repo_converter.go
+++ b/plugins/github/tasks/github_repo_converter.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
@@ -36,12 +37,13 @@ func ConvertRepos() error {
 
 	return nil
 }
+
 func convertToRepositoryModel(repository *githubModels.GithubRepo) *code.Repo {
 	domainRepository := &code.Repo{
 		DomainEntity: domainlayer.DomainEntity{
 			Id: didgen.NewDomainIdGenerator(repository).Generate(repository.GithubId),
 		},
-		Name:        repository.Name,
+		Name:        fmt.Sprintf("%s/%s", repository.OwnerLogin, repository.Name),
 		Url:         repository.HTMLUrl,
 		Description: repository.Description,
 		ForkedFrom:  repository.ParentHTMLUrl,
@@ -51,6 +53,7 @@ func convertToRepositoryModel(repository *githubModels.GithubRepo) *code.Repo {
 	}
 	return domainRepository
 }
+
 func convertToBoardModel(repository *githubModels.GithubRepo, domainIdGenerator *didgen.DomainIdGenerator) *ticket.Board {
 	domainBoard := &ticket.Board{
 		DomainEntity: domainlayer.DomainEntity{


### PR DESCRIPTION
# Summary
added org as prefix to github repo name when converted to domain layer `repo`
![image](https://user-images.githubusercontent.com/61080/151690446-3c11f45d-7e9f-4e76-9b78-56dbb217587a.png)

### Key Points

- [x] This is a breaking change
- [ ] New or existing documentation is updated
