### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: type/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation Issue
 about: Help improve our documentation
 title: ''
-labels: docs
+labels: type/docs
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -2,7 +2,7 @@
 name: Proposal
 about: Suggest an idea for this project
 title: ''
-labels: proposal
+labels: type/feature-request
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Ask a question
 title: ''
-labels: question
+labels: type/question
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,20 @@
+---
+name: Refactor
+about: Improve operation without altering functionality
+title: ''
+labels: type/refactor
+assignees: ''
+
+---
+
+## What and why to refactor
+What are you trying to refactor? Why should it be refactored now?
+
+## Describe the solution you'd like
+How to refactor?
+
+## Related issues
+Please link any other
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated

### Description
1. update issue templates so that labels can be automatically tagged after creation
2. add a template for the `refactor`-type of issues, the `proposal`-type of issues will only refer to feature-request in the future. 
 
### Does this close any open issues?
No