### PR TITLE
`feat`: setup multi-selectors for jira issue types w/ api proxy | `1064`

### DIFF
--- a/config-ui/src/components/ClearButton.jsx
+++ b/config-ui/src/components/ClearButton.jsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { Button } from '@blueprintjs/core'
+import { Button, Intent } from '@blueprintjs/core'
 
-const ClearButton = ({ onClick }) => {
+const ClearButton = ({ onClick, minimal = true, intent = Intent.NONE, disabled = false }) => {
   return (
     <Button
+      disabled={disabled}
+      intent={intent}
       icon='cross'
-      minimal={true}
+      minimal={minimal}
       onClick={onClick}
     />
   )

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import request from '@/utils/request'
 import { ToastNotification } from '@/components/Toast'
 
@@ -25,7 +25,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
-        setError(null)
+        // setError(null)
       }
       fetchIssueTypes()
     } catch (e) {
@@ -33,7 +33,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       setError(e)
       ToastNotification.show({ message: e.message, intent: 'danger', icon: 'error' })
     }
-  }, [issuesEndpoint])
+  }, [issuesEndpoint, apiProxyPath])
 
   const fetchFields = useCallback(() => {
     try {
@@ -50,7 +50,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
-        setError(null)
+        // setError(null)
       }
       fetchIssueFields()
     } catch (e) {
@@ -58,7 +58,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       setError(e)
       ToastNotification.show({ message: e.message, intent: 'danger', icon: 'error' })
     }
-  }, [fieldsEndpoint])
+  }, [fieldsEndpoint, apiProxyPath])
 
   const createListData = (data = [], titleProperty = 'name', valueProperty = 'name') => {
     return data.map((d, dIdx) => {

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -6,6 +6,8 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
   const [isFetching, setIsFetching] = useState(false)
   const [issueTypes, setIssueTypes] = useState([])
   const [fields, setFields] = useState([])
+  const [issueTypesResponse, setIssueTypesResponse] = useState([])
+  const [fieldsResponse, setFieldsResponse] = useState([])
   const [error, setError] = useState()
 
   const fetchIssueTypes = useCallback(() => {
@@ -13,7 +15,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       const fetchIssueTypes = async () => {
         const issues = await request.get(issuesEndpoint)
         console.log('>>> JIRA API PROXY: Issues Response...', issues)
-        setIssueTypes(issues.data)
+        setIssueTypesResponse(issues.data)
         setIsFetching(false)
         setError(null)
       }
@@ -30,7 +32,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       const fetchIssueFields = async () => {
         const fields = await request.get(fieldsEndpoint)
         console.log('>>> JIRA API PROXY: Fields Response...', fields)
-        setFields(fields.data)
+        setFieldsResponse(fields.data)
         setIsFetching(false)
         setError(null)
       }
@@ -42,10 +44,33 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
     }
   }, [fieldsEndpoint])
 
+  const createListData = (data = [], titleProperty = 'name', valueProperty = 'name') => {
+    return data.map((d, dIdx) => {
+      return {
+        ...d,
+        id: dIdx,
+        title: d[titleProperty],
+        value: d[valueProperty],
+        type: d.schema?.type || 'string'
+      }
+    })
+  }
+
+  useEffect(() => {
+    setIssueTypes(createListData(issueTypesResponse))
+  }, [issueTypesResponse])
+
+  useEffect(() => {
+    setFields(createListData(fieldsResponse))
+  }, [fieldsResponse])
+
   return {
     isFetching,
     fetchFields,
     fetchIssueTypes,
+    createListData,
+    issueTypesResponse,
+    fieldsResponse,
     issueTypes,
     fields,
     error

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState, useCallback } from 'react'
+import request from '@/utils/request'
+import { ToastNotification } from '@/components/Toast'
+
+const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
+  const [isFetching, setIsFetching] = useState(false)
+  const [issueTypes, setIssueTypes] = useState([])
+  const [fields, setFields] = useState([])
+  const [error, setError] = useState()
+
+  const fetchIssueTypes = useCallback(() => {
+    try {
+      const fetchIssueTypes = async () => {
+        const issues = await request.get(issuesEndpoint)
+        console.log('>>> JIRA API PROXY: Issues Response...', issues)
+        setIssueTypes(issues.data)
+        setIsFetching(false)
+        setError(null)
+      }
+      fetchIssueTypes()
+    } catch (e) {
+      setIsFetching(false)
+      setError(e)
+      ToastNotification.show({ message: e.message, intent: 'danger', icon: 'error' })
+    }
+  }, [issuesEndpoint])
+
+  const fetchFields = useCallback(() => {
+    try {
+      const fetchIssueFields = async () => {
+        const fields = await request.get(fieldsEndpoint)
+        console.log('>>> JIRA API PROXY: Fields Response...', fields)
+        setFields(fields.data)
+        setIsFetching(false)
+        setError(null)
+      }
+      fetchIssueFields()
+    } catch (e) {
+      setIsFetching(false)
+      setError(e)
+      ToastNotification.show({ message: e.message, intent: 'danger', icon: 'error' })
+    }
+  }, [fieldsEndpoint])
+
+  return {
+    isFetching,
+    fetchFields,
+    fetchIssueTypes,
+    issueTypes,
+    fields,
+    error
+  }
+}
+
+export default useJIRA

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -26,7 +26,6 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
-        // setError(null)
       }
       fetchIssueTypes()
     } catch (e) {
@@ -52,7 +51,6 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
-        // setError(null)
       }
       fetchIssueFields()
     } catch (e) {

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -16,7 +16,9 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         const issues = await request.get(issuesEndpoint)
         console.log('>>> JIRA API PROXY: Issues Response...', issues)
         setIssueTypesResponse(issues.data)
-        setIsFetching(false)
+        setTimeout(() => {
+          setIsFetching(false)
+        }, 1000)
         setError(null)
       }
       fetchIssueTypes()
@@ -33,7 +35,9 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
         const fields = await request.get(fieldsEndpoint)
         console.log('>>> JIRA API PROXY: Fields Response...', fields)
         setFieldsResponse(fields.data)
-        setIsFetching(false)
+        setTimeout(() => {
+          setIsFetching(false)
+        }, 1000)
         setError(null)
       }
       fetchIssueFields()
@@ -49,6 +53,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       return {
         ...d,
         id: dIdx,
+        key: d.key ? d.key : dIdx,
         title: d[titleProperty],
         value: d[valueProperty],
         type: d.schema?.type || 'string'
@@ -61,8 +66,12 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
   }, [issueTypesResponse])
 
   useEffect(() => {
-    setFields(createListData(fieldsResponse))
+    setFields(createListData(fieldsResponse, 'name', 'key'))
   }, [fieldsResponse])
+
+  useEffect(() => {
+    console.log('>>> JIRA API PROXY: FIELD SELECTOR LIST DATA', fields)
+  }, [fields])
 
   return {
     isFetching,

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -12,10 +12,16 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
 
   const fetchIssueTypes = useCallback(() => {
     try {
+      if (apiProxyPath.includes('null')) {
+        throw new Error('Connection Source ID is Null')
+      }
       const fetchIssueTypes = async () => {
-        const issues = await request.get(issuesEndpoint)
+        const issues = await
+        request
+          .get(issuesEndpoint)
+          .catch(e => setError(e))
         console.log('>>> JIRA API PROXY: Issues Response...', issues)
-        setIssueTypesResponse(issues.data)
+        setIssueTypesResponse(issues ? issues.data : [])
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
@@ -31,10 +37,16 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
 
   const fetchFields = useCallback(() => {
     try {
+      if (apiProxyPath.includes('null')) {
+        throw new Error('Connection Source ID is Null')
+      }
       const fetchIssueFields = async () => {
-        const fields = await request.get(fieldsEndpoint)
+        const fields = await
+        request
+          .get(fieldsEndpoint)
+          .catch(e => setError(e))
         console.log('>>> JIRA API PROXY: Fields Response...', fields)
-        setFieldsResponse(fields.data)
+        setFieldsResponse(fields ? fields.data : [])
         setTimeout(() => {
           setIsFetching(false)
         }, 1000)
@@ -72,6 +84,12 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
   useEffect(() => {
     console.log('>>> JIRA API PROXY: FIELD SELECTOR LIST DATA', fields)
   }, [fields])
+
+  useEffect(() => {
+    if (error) {
+      console.log('>>> JIRA PROXY API ERROR!', error)
+    }
+  }, [error])
 
   return {
     isFetching,

--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -15,6 +15,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       if (apiProxyPath.includes('null')) {
         throw new Error('Connection Source ID is Null')
       }
+      setError(null)
       const fetchIssueTypes = async () => {
         const issues = await
         request
@@ -40,6 +41,7 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
       if (apiProxyPath.includes('null')) {
         throw new Error('Connection Source ID is Null')
       }
+      setError(null)
       const fetchIssueFields = async () => {
         const fields = await
         request

--- a/config-ui/src/pages/configure/mock-data/jira/fields.js
+++ b/config-ui/src/pages/configure/mock-data/jira/fields.js
@@ -1,13 +1,213 @@
 const fieldsData = [
-  { id: 0, title: 'development', name: 'development', value: 'development', type: 'Dev Summary Custom Field' },
-  { id: 1, title: 'Epic Color', name: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
-  { id: 2, title: 'Epic Link', name: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
-  { id: 3, title: 'Epic Status', name: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
-  { id: 4, title: 'Flagged', name: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
-  { id: 5, title: 'Sprint', name: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
-  { id: 6, title: 'Team', name: 'Team', value: 'Team', type: 'Team' },
-  { id: 7, title: 'UUID', name: 'UUID', value: 'uuid', type: 'UUID Field' },
-  { id: 8, title: 'Rank', name: 'Rank', value: 'Rank', type: 'Global Rank' },
+  {
+    id: 0,
+    name: 'Description',
+    title: 'Description',
+    value: 'description',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 1,
+    name: 'Development',
+    title: 'development',
+    value: 'development',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 2,
+    name: 'Epic',
+    title: 'Epic',
+    value: 'Epic',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 3,
+    name: 'Epic Color',
+    title: 'Epic Color',
+    value: 'epic color',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 4,
+    name: 'Epic Link',
+    title: 'Epic Link',
+    value: 'epic link',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 5,
+    name: 'Epic Status',
+    title: 'Epic Status',
+    value: 'epic status',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 6,
+    name: 'Flagged',
+    title: 'Flagged',
+    value: 'flagged',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 7,
+    name: 'Sprint',
+    title: 'Sprint',
+    value: 'sprint',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 8,
+    name: 'Team',
+    title: 'Team',
+    value: 'team',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 9,
+    name: 'Rank',
+    title: 'Rank',
+    value: 'rank',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'number',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
+  {
+    id: 10,
+    name: 'UUID',
+    title: 'UUID',
+    value: 'uuid',
+    description: null,
+    custom: false,
+    orderable: true,
+    navigable: true,
+    searchable: true,
+    type: 'string',
+    clauseNames: [
+      'description'
+    ],
+    schema: {
+      type: 'string',
+      system: 'description'
+    }
+  },
 ]
 
 export {

--- a/config-ui/src/pages/configure/mock-data/jira/fields.js
+++ b/config-ui/src/pages/configure/mock-data/jira/fields.js
@@ -1,0 +1,15 @@
+const fieldsData = [
+  { id: 0, title: 'development', name: 'development', value: 'development', type: 'Dev Summary Custom Field' },
+  { id: 1, title: 'Epic Color', name: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
+  { id: 2, title: 'Epic Link', name: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
+  { id: 3, title: 'Epic Status', name: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
+  { id: 4, title: 'Flagged', name: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
+  { id: 5, title: 'Sprint', name: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
+  { id: 6, title: 'Team', name: 'Team', value: 'Team', type: 'Team' },
+  { id: 7, title: 'UUID', name: 'UUID', value: 'uuid', type: 'UUID Field' },
+  { id: 8, title: 'Rank', name: 'Rank', value: 'Rank', type: 'Global Rank' },
+]
+
+export {
+  fieldsData
+}

--- a/config-ui/src/pages/configure/mock-data/jira/issueTypes.js
+++ b/config-ui/src/pages/configure/mock-data/jira/issueTypes.js
@@ -1,0 +1,111 @@
+const issueTypesData = [
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/1',
+    id: 1,
+    description: 'A small, distinct piece of work.',
+    iconUrl: null,
+    name: 'Task',
+    title: 'Task',
+    value: 'Task',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/2',
+    id: 2,
+    description: 'A problem or error.',
+    iconUrl: null,
+    name: 'Bug',
+    title: 'Bug',
+    value: 'Bug',
+    subtask: false,
+    avatarId: 10002,
+    entityId: '9d7dd6f7-e8b6-4247-954b-7b2c9b2a5ba2',
+    hierarchyLevel: 0,
+    scope: {
+      type: 'PROJECT',
+      project: {
+        id: 10000,
+        key: 'KEY',
+        name: 'Next Gen Project'
+      }
+    }
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/3',
+    id: 3,
+    description: 'A product requirement or feature',
+    iconUrl: null,
+    name: 'Requirement',
+    title: 'Requirement',
+    value: 'Requirement',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/4',
+    id: 4,
+    description: 'A big user story that needs to be broken down',
+    iconUrl: null,
+    name: 'Epic',
+    title: 'Epic',
+    value: 'Epic',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/5',
+    id: 5,
+    description: 'A sub-task/child-task',
+    iconUrl: null,
+    name: 'Sub-task',
+    title: 'Sub-task',
+    value: 'Sub-task',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/5',
+    id: 6,
+    description: 'A P0 Incident/Event',
+    iconUrl: null,
+    name: 'P0',
+    title: 'P0',
+    value: 'P0',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/5',
+    id: 7,
+    description: 'A P1 Incident/Event',
+    iconUrl: null,
+    name: 'P1',
+    title: 'P1',
+    value: 'P1',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+  {
+    self: 'https://your-domain.atlassian.net/rest/api/3/issueType/5',
+    id: 8,
+    description: 'A P2 Incident/Event',
+    iconUrl: null,
+    name: 'P2',
+    title: 'P2',
+    value: 'P2',
+    subtask: false,
+    avatarId: 1,
+    hierarchyLevel: 0
+  },
+]
+
+export {
+  issueTypesData
+}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -3,12 +3,13 @@ import React, { useEffect, useState, Fragment } from 'react'
 import {
   // FormGroup,
   // InputGroup,
+  ButtonGroup,
   MenuItem,
   Button,
   Intent,
   Icon,
   Colors,
-  Tag
+  Tag,
 } from '@blueprintjs/core'
 import useJIRA from '@/hooks/useJIRA'
 import { Select, MultiSelect } from '@blueprintjs/select'
@@ -407,43 +408,50 @@ export default function JiraSettings (props) {
         </h3>
         <p className=''>Choose the JIRA field you’re using to represent the key of an Epic to which an issue belongs to.</p>
         <div style={{ display: 'flex', minWidth: '260px' }}>
-          <Select
-            className='select-epic-key'
-            inline={true}
-            fill={true}
-            items={fieldsList}
-            activeItem={jiraIssueEpicKeyField}
-            itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
-            itemRenderer={(item, { handleClick, modifiers }) => (
-              <MenuItem
-                active={false}
-                intent={modifiers.active ? Intent.NONE : Intent.NONE}
-                key={item.value}
-                label={item.value}
-                onClick={handleClick}
-                text={<><span>{item.title}</span> <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
-                style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
-              />
-            )}
-            noResults={<MenuItem disabled={true} text='No epic results.' />}
-            onItemSelect={(item) => {
-              setJiraIssueEpicKeyField(item)
-              // setSelectedEpicItem(item)
-            }}
-          >
-            <Button
+          <ButtonGroup>
+            <Select
+              className='select-epic-key'
+              inline={true}
               fill={true}
-              style={{ justifyContent: 'space-between', display: 'flex', maxWidth: '260px' }}
-              text={jiraIssueEpicKeyField ? `${jiraIssueEpicKeyField.title}` : '< None Specified >'}
-              rightIcon='double-caret-vertical'
-            />
-          </Select>
-          <div style={{ marginLeft: '3px' }}>
+              items={fieldsList}
+              activeItem={jiraIssueEpicKeyField}
+              itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
+              itemRenderer={(item, { handleClick, modifiers }) => (
+                <MenuItem
+                  active={false}
+                  intent={modifiers.active ? Intent.NONE : Intent.NONE}
+                  key={item.value}
+                  label={item.value}
+                  onClick={handleClick}
+                  text={<><span>{item.title}</span> <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
+                  style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                />
+              )}
+              noResults={<MenuItem disabled={true} text='No epic results.' />}
+              onItemSelect={(item) => {
+                setJiraIssueEpicKeyField(item)
+              // setSelectedEpicItem(item)
+              }}
+            >
+              <Button
+                fill={true}
+                style={{ justifyContent: 'space-between', display: 'flex', minWidth: '260px', maxWidth: '300px' }}
+                text={jiraIssueEpicKeyField ? `${jiraIssueEpicKeyField.title}` : '< None Specified >'}
+                rightIcon='double-caret-vertical'
+              />
+            </Select>
             <Button
               disabled={!jiraIssueEpicKeyField}
               icon='eraser'
               intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
             />
+          </ButtonGroup>
+          <div style={{ marginLeft: '3px' }}>
+            {/* <Button
+              disabled={!jiraIssueEpicKeyField}
+              icon='eraser'
+              intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
+            /> */}
           </div>
         </div>
       </div>
@@ -470,42 +478,49 @@ export default function JiraSettings (props) {
         <h3 className='headline'>Story Point Field (Optional)</h3>
         <p className=''>Choose the JIRA field you’re using to represent the granularity of a requirement-type issue.</p>
         <div style={{ display: 'flex', minWidth: '260px' }}>
-          <Select
-            className='select-story-key'
-            inline={true}
-            fill={true}
-            items={fieldsList}
-            activeItem={jiraIssueStoryPointField}
-            itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
-            itemRenderer={(item, { handleClick, modifiers }) => (
-              <MenuItem
-                active={false}
-                intent={modifiers.active ? Intent.NONE : Intent.NONE}
-                key={item.value}
-                label={item.value}
-                onClick={handleClick}
-                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
-                style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
-              />
-            )}
-            noResults={<MenuItem disabled={true} text='No epic results.' />}
-            onItemSelect={(item) => {
-              setJiraIssueStoryPointField(item)
-            }}
-          >
-            <Button
+          <ButtonGroup>
+            <Select
+              className='select-story-key'
+              inline={true}
               fill={true}
-              style={{ justifyContent: 'space-between', display: 'flex', maxWidth: '260px' }}
-              text={jiraIssueStoryPointField ? `${jiraIssueStoryPointField.title}` : '< None Specified >'}
-              rightIcon='double-caret-vertical'
-            />
-          </Select>
-          <div style={{ marginLeft: '3px' }}>
+              items={fieldsList}
+              activeItem={jiraIssueStoryPointField}
+              itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
+              itemRenderer={(item, { handleClick, modifiers }) => (
+                <MenuItem
+                  active={false}
+                  intent={modifiers.active ? Intent.NONE : Intent.NONE}
+                  key={item.value}
+                  label={item.value}
+                  onClick={handleClick}
+                  text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
+                  style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                />
+              )}
+              noResults={<MenuItem disabled={true} text='No epic results.' />}
+              onItemSelect={(item) => {
+                setJiraIssueStoryPointField(item)
+              }}
+            >
+              <Button
+                fill={true}
+                style={{ justifyContent: 'space-between', display: 'flex', minWidth: '260px', maxWidth: '300px' }}
+                text={jiraIssueStoryPointField ? `${jiraIssueStoryPointField.title}` : '< None Specified >'}
+                rightIcon='double-caret-vertical'
+              />
+            </Select>
             <Button
               disabled={!jiraIssueStoryPointField}
               icon='eraser'
               intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
             />
+          </ButtonGroup>
+          <div style={{ marginLeft: '3px' }}>
+            {/* <Button
+              disabled={!jiraIssueStoryPointField}
+              icon='eraser'
+              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
+            /> */}
           </div>
         </div>
       </div>

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Fragment } from 'react'
+import React, { useEffect, useState, useCallback, Fragment } from 'react'
 import {
   // FormGroup,
   // InputGroup,
@@ -72,7 +72,7 @@ export default function JiraSettings (props) {
       : null
   }
 
-  const parseTypeMappings = (mappings = []) => {
+  const parseTypeMappings = useCallback((mappings = []) => {
     const GroupedMappings = {
       [MAPPING_TYPES.Requirement]: [],
       [MAPPING_TYPES.Incident]: [],
@@ -90,7 +90,7 @@ export default function JiraSettings (props) {
     setBugTags(bugTagsList?.filter(t => GroupedMappings[MAPPING_TYPES.Bug].includes(t.value)))
     setIncidentTags(incidentTagsList?.filter(t => GroupedMappings[MAPPING_TYPES.Incident].includes(t.value)))
     return GroupedMappings
-  }
+  }, [requirementTagsList, bugTagsList, incidentTagsList])
 
   useEffect(() => {
     const settings = {
@@ -194,6 +194,10 @@ export default function JiraSettings (props) {
     setJiraIssueEpicKeyField(fieldsList.find(f => f.value === connection.epicKeyField))
     setJiraIssueStoryPointField(fieldsList.find(f => f.value === connection.storyPointField))
   }, [fieldsList, connection.epicKeyField, connection.storyPointField])
+
+  useEffect(() => {
+    parseTypeMappings(connection.typeMappings)
+  }, [requirementTagsList, bugTagsList, incidentTagsList, connection.typeMappings, parseTypeMappings])
 
   return (
     <>

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -214,6 +214,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
+            disabled={isSaving}
             placeholder='< Select one or more Requirement Tags >'
             popoverProps={{ usePortal: false, minimal: true, fill: true, style: { width: '100%' } }}
             className='multiselector-requirement-type'
@@ -253,7 +254,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
-            disabled={requirementTags.length === 0}
+            disabled={requirementTags.length === 0 || isSaving}
             intent={Intent.WARNING} minimal={false} onClick={() => setRequirementTags([])}
           />
         </div>
@@ -269,6 +270,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
+            disabled={isSaving}
             placeholder='< Select one or more Bug Tags >'
             popoverProps={{ usePortal: false, minimal: true }}
             className='multiselector-bug-type'
@@ -308,7 +310,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
-            disabled={bugTags.length === 0}
+            disabled={bugTags.length === 0 || isSaving}
             intent={Intent.WARNING} minimal={false} onClick={() => setBugTags([])}
           />
         </div>
@@ -324,6 +326,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
+            disabled={isSaving}
             placeholder='< Select one or more Incident Tags >'
             popoverProps={{ usePortal: false, minimal: true }}
             className='multiselector-incident-type'
@@ -363,7 +366,7 @@ export default function JiraSettings (props) {
         </div>
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
-            disabled={incidentTags.length === 0}
+            disabled={incidentTags.length === 0 || isSaving}
             intent={Intent.WARNING} minimal={false} onClick={() => setIncidentTags([])}
           />
         </div>
@@ -408,8 +411,9 @@ export default function JiraSettings (props) {
         </h3>
         <p className=''>Choose the JIRA field you’re using to represent the key of an Epic to which an issue belongs to.</p>
         <div style={{ display: 'flex', minWidth: '260px' }}>
-          <ButtonGroup>
+          <ButtonGroup disabled={isSaving}>
             <Select
+              disabled={isSaving}
               className='select-epic-key'
               inline={true}
               fill={true}
@@ -435,6 +439,7 @@ export default function JiraSettings (props) {
               }}
             >
               <Button
+                disabled={isSaving}
                 fill={true}
                 style={{ justifyContent: 'space-between', display: 'flex', minWidth: '260px', maxWidth: '300px' }}
                 text={jiraIssueEpicKeyField ? `${jiraIssueEpicKeyField.title}` : '< None Specified >'}
@@ -442,7 +447,7 @@ export default function JiraSettings (props) {
               />
             </Select>
             <Button
-              disabled={!jiraIssueEpicKeyField}
+              disabled={!jiraIssueEpicKeyField || isSaving}
               icon='eraser'
               intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
             />
@@ -479,8 +484,9 @@ export default function JiraSettings (props) {
         <h3 className='headline'>Story Point Field (Optional)</h3>
         <p className=''>Choose the JIRA field you’re using to represent the granularity of a requirement-type issue.</p>
         <div style={{ display: 'flex', minWidth: '260px' }}>
-          <ButtonGroup>
+          <ButtonGroup disabled={isSaving}>
             <Select
+              disabled={isSaving}
               className='select-story-key'
               inline={true}
               fill={true}
@@ -505,6 +511,7 @@ export default function JiraSettings (props) {
               }}
             >
               <Button
+                disabled={isSaving}
                 fill={true}
                 style={{ justifyContent: 'space-between', display: 'flex', minWidth: '260px', maxWidth: '300px' }}
                 text={jiraIssueStoryPointField ? `${jiraIssueStoryPointField.title}` : '< None Specified >'}
@@ -512,7 +519,7 @@ export default function JiraSettings (props) {
               />
             </Select>
             <Button
-              disabled={!jiraIssueStoryPointField}
+              disabled={!jiraIssueStoryPointField || isSaving}
               icon='eraser'
               intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
             />

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -1,17 +1,18 @@
 import React, { useEffect, useState, Fragment } from 'react'
-import request from '@/utils/request'
+// import request from '@/utils/request'
 import {
-  FormGroup,
-  InputGroup,
+  // FormGroup,
+  // InputGroup,
   MenuItem,
   Button,
   Intent,
   Icon,
-  Colors
+  Colors,
+  Tag
 } from '@blueprintjs/core'
 import useJIRA from '@/hooks/useJIRA'
-import { MultiSelect } from '@blueprintjs/select'
-import MappingTag from '@/pages/configure/settings/jira/MappingTag'
+import { Select, MultiSelect } from '@blueprintjs/select'
+// import MappingTag from '@/pages/configure/settings/jira/MappingTag'
 import ClearButton from '@/components/ClearButton'
 import '@/styles/integration.scss'
 import '@/styles/connections.scss'
@@ -68,15 +69,15 @@ export default function JiraSettings (props) {
   ])
 
   const [fieldsList, setFieldsList] = useState([
-    { id: 0, title: 'development', value: 'development', type: 'Dev Summary Custom Field' },
-    { id: 1, title: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
-    { id: 2, title: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
-    { id: 3, title: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
-    { id: 4, title: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
-    { id: 5, title: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
-    { id: 6, title: 'Team', value: 'Team', type: 'Team' },
-    { id: 7, title: 'uuid', value: 'Flagged', type: 'UUID Field' },
-    { id: 8, title: 'Rank', value: 'Rank', type: 'Global Rank' },
+    { id: 0, title: 'development', name: 'development', value: 'development', type: 'Dev Summary Custom Field' },
+    { id: 1, title: 'Epic Color', name: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
+    { id: 2, title: 'Epic Link', name: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
+    { id: 3, title: 'Epic Status', name: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
+    { id: 4, title: 'Flagged', name: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
+    { id: 5, title: 'Sprint', name: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
+    { id: 6, title: 'Team', name: 'Team', value: 'Team', type: 'Team' },
+    { id: 7, title: 'UUID', name: 'UUID', value: 'uuid', type: 'UUID Field' },
+    { id: 8, title: 'Rank', name: 'Rank', value: 'Rank', type: 'Global Rank' },
   ])
 
   const createTypeMapObject = (customType, standardType) => {
@@ -111,9 +112,9 @@ export default function JiraSettings (props) {
 
   useEffect(() => {
     const settings = {
-      epicKeyField: jiraIssueEpicKeyField,
+      epicKeyField: jiraIssueEpicKeyField?.value,
       typeMappings: typeMappingAll,
-      storyPointField: jiraIssueStoryPointField,
+      storyPointField: jiraIssueStoryPointField?.value,
     }
     onSettingsChange(settings)
     console.log('>> JIRA INSTANCE SETTINGS FIELDS CHANGED!', settings)
@@ -171,8 +172,8 @@ export default function JiraSettings (props) {
       // Parse Type Mappings (V2)
       parseTypeMappings(connection.typeMappings)
       setStatusMappings([])
-      setJiraIssueEpicKeyField(connection.epicKeyField)
-      setJiraIssueStoryPointField(connection.storyPointField)
+      setJiraIssueEpicKeyField(fieldsList.find(f => f.value === connection.epicKeyField))
+      setJiraIssueStoryPointField(fieldsList.find(f => f.value === connection.storyPointField))
     }
   }, [connection/*, epics, granularities, boards */])
 
@@ -252,7 +253,7 @@ export default function JiraSettings (props) {
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={requirementTags.length === 0}
-            intent={Intent.PRIMARY} minimal={false} onClick={() => setRequirementTags([])}
+            intent={Intent.WARNING} minimal={false} onClick={() => setRequirementTags([])}
           />
         </div>
       </div>
@@ -307,7 +308,7 @@ export default function JiraSettings (props) {
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={bugTags.length === 0}
-            intent={Intent.PRIMARY} minimal={false} onClick={() => setBugTags([])}
+            intent={Intent.WARNING} minimal={false} onClick={() => setBugTags([])}
           />
         </div>
       </div>
@@ -362,7 +363,7 @@ export default function JiraSettings (props) {
         <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={incidentTags.length === 0}
-            intent={Intent.PRIMARY} minimal={false} onClick={() => setIncidentTags([])}
+            intent={Intent.WARNING} minimal={false} onClick={() => setIncidentTags([])}
           />
         </div>
       </div>
@@ -405,96 +406,110 @@ export default function JiraSettings (props) {
           Epic Key<span className='requiredStar'>*</span>
         </h3>
         <p className=''>Choose the JIRA field you’re using to represent the key of an Epic to which an issue belongs to.</p>
-        {/* <span style={{ display: 'inline-block' }}>
+        <div style={{ display: 'flex', minWidth: '260px' }}>
           <Select
             className='select-epic-key'
             inline={true}
-            fill={false}
-            items={epics}
-            activeItem={selectedEpicItem}
+            fill={true}
+            items={fieldsList}
+            activeItem={jiraIssueEpicKeyField}
             itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
             itemRenderer={(item, { handleClick, modifiers }) => (
               <MenuItem
-                active={modifiers.active}
+                active={false}
+                intent={modifiers.active ? Intent.NONE : Intent.NONE}
                 key={item.value}
                 label={item.value}
                 onClick={handleClick}
-                text={item.title}
+                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag></>}
+                style={{ fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
               />
             )}
             noResults={<MenuItem disabled={true} text='No epic results.' />}
             onItemSelect={(item) => {
-              // @todo SET/VERIFY ENV FIELD FOR EPIC KEY
-              setJiraIssueEpicKeyField(item.value)
-              setSelectedEpicItem(item)
+              setJiraIssueEpicKeyField(item)
+              // setSelectedEpicItem(item)
             }}
           >
             <Button
-              style={{ maxWidth: '260px' }}
-              text={selectedEpicItem ? `${selectedEpicItem.title}` : epics[0].title}
+              fill={true}
+              style={{ justifyContent: 'space-between', display: 'flex', maxWidth: '260px' }}
+              text={jiraIssueEpicKeyField ? `${jiraIssueEpicKeyField.title}` : '< None Specified >'}
               rightIcon='double-caret-vertical'
             />
           </Select>
-        </span> */}
+          <div style={{ marginLeft: '3px' }}>
+            <Button
+              disabled={!jiraIssueEpicKeyField}
+              icon='eraser'
+              intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
+            />
+          </div>
+        </div>
       </div>
-      <div className='formContainer' style={{ maxWidth: '250px' }}>
+      {/* <div className='formContainer' style={{ maxWidth: '250px' }}>
         <FormGroup
           disabled={isSaving}
-          // readOnly={['gitlab', 'jenkins'].includes(activeProvider.id)}
           label=''
           inline={true}
           labelFor='epic-key-field'
-          // helperText='NAME'
           className='formGroup'
           contentClassName='formGroupContent'
         >
           <InputGroup
             id='epic-key-field'
             disabled={isSaving}
-            // readOnly={['gitlab', 'jenkins'].includes(activeProvider.id)}
             placeholder='eg. 1000'
             value={jiraIssueEpicKeyField}
             onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
             className='input epic-key-field'
           />
         </FormGroup>
-      </div>
+      </div> */}
       <div className='headlineContainer'>
         <h3 className='headline'>Story Point Field (Optional)</h3>
         <p className=''>Choose the JIRA field you’re using to represent the granularity of a requirement-type issue.</p>
-        {/* <span style={{ display: 'inline-block' }}>
+        <div style={{ display: 'flex', minWidth: '260px' }}>
           <Select
-            className='select-board-key'
+            className='select-story-key'
             inline={true}
-            fill={false}
-            items={boards}
-            activeItem={selectedBoardItem}
+            fill={true}
+            items={fieldsList}
+            activeItem={jiraIssueStoryPointField}
             itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
             itemRenderer={(item, { handleClick, modifiers }) => (
               <MenuItem
-                active={modifiers.active}
+                active={false}
+                intent={modifiers.active ? Intent.NONE : Intent.NONE}
                 key={item.value}
                 label={item.value}
                 onClick={handleClick}
-                text={item.title}
+                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag></>}
+                style={{ fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
               />
             )}
-            noResults={<MenuItem disabled={true} text='No board results.' />}
+            noResults={<MenuItem disabled={true} text='No epic results.' />}
             onItemSelect={(item) => {
-              // @todo SET/VERIFY ENV FIELD FOR BOARD ID
-              setJiraIssueStoryPointField(item.value)
-              setSelectedBoardItem(item)
+              setJiraIssueStoryPointField(item)
             }}
           >
             <Button
-              style={{ maxWidth: '260px' }}
-              text={selectedBoardItem ? `${selectedBoardItem.title}` : boards[0].title}
+              fill={true}
+              style={{ justifyContent: 'space-between', display: 'flex', maxWidth: '260px' }}
+              text={jiraIssueStoryPointField ? `${jiraIssueStoryPointField.title}` : '< None Specified >'}
               rightIcon='double-caret-vertical'
             />
           </Select>
-        </span> */}
+          <div style={{ marginLeft: '3px' }}>
+            <Button
+              disabled={!jiraIssueStoryPointField}
+              icon='eraser'
+              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
+            />
+          </div>
+        </div>
       </div>
-      <div className='formContainer' style={{ maxWidth: '250px' }}>
+      {/* <div className='formContainer' style={{ maxWidth: '250px' }}>
         <FormGroup
           disabled={isSaving}
           label=''
@@ -512,7 +527,7 @@ export default function JiraSettings (props) {
             className='input board-id'
           />
         </FormGroup>
-      </div>
+      </div> */}
     </>
   )
 }

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -31,7 +31,7 @@ export default function JiraSettings (props) {
   const ISSUE_TYPES_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/issuetype`
   const ISSUE_FIELDS_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/field`
 
-  const { fetchIssueTypes, fetchFields, issueTypes, fields, isFetching: isFetchingJIRA } = useJIRA({
+  const { fetchIssueTypes, fetchFields, issueTypes, fields, isFetching: isFetchingJIRA, error: jiraProxyError } = useJIRA({
     apiProxyPath: API_PROXY_ENDPOINT,
     issuesEndpoint: ISSUE_TYPES_ENDPOINT,
     fieldsEndpoint: ISSUE_FIELDS_ENDPOINT

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -352,39 +352,6 @@ export default function JiraSettings (props) {
         </div>
       </div>
 
-      {/* <MappingTag
-        labelName='Requirement'
-        classNames='tag-requirement'
-        typeOrStatus='type'
-        placeholderText='Add Issue Types...'
-        values={typeMappingRequirement}
-        rightElement={<ClearButton onClick={() => setTypeMappingRequirement([])} />}
-        onChange={(values) => setTypeMappingRequirement(values)}
-        disabled={isSaving}
-      /> */}
-
-      {/* <MappingTag
-        labelName='Bug'
-        classNames='tag-bug'
-        typeOrStatus='type'
-        placeholderText='Add Issue Types...'
-        values={typeMappingBug}
-        rightElement={<ClearButton onClick={() => setTypeMappingBug([])} />}
-        onChange={(values) => setTypeMappingBug(values)}
-        disabled={isSaving}
-      /> */}
-
-      {/* <MappingTag
-        labelName='Incident'
-        classNames='tag-incident'
-        typeOrStatus='type'
-        placeholderText='Add Issue Types...'
-        values={typeMappingIncident}
-        rightElement={<ClearButton onClick={() => setTypeMappingIncident([])} />}
-        onChange={(values) => setTypeMappingIncident(values)}
-        disabled={isSaving}
-      /> */}
-
       <div className='headlineContainer'>
         <h3 className='headline'>
           Epic Key<span className='requiredStar'>*</span>
@@ -415,7 +382,6 @@ export default function JiraSettings (props) {
               noResults={<MenuItem disabled={true} text='No epic results.' />}
               onItemSelect={(item) => {
                 setJiraIssueEpicKeyField(item)
-              // setSelectedEpicItem(item)
               }}
             >
               <Button

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -458,12 +458,13 @@ export default function JiraSettings (props) {
               intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField('')}
             />
           </ButtonGroup>
-          <div style={{ marginLeft: '3px' }}>
-            {/* <Button
-              disabled={!jiraIssueEpicKeyField}
-              icon='eraser'
-              intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
-            /> */}
+          <div style={{ marginLeft: '10px' }}>
+            {jiraProxyError && (
+              <p style={{ color: Colors.GRAY4 }}>
+                <Icon icon='warning-sign' color={Colors.RED5} size={12} style={{ marginBottom: '2px' }} />{' '}
+                {jiraProxyError.toString() || 'JIRA API not accessible.'}
+              </p>
+            )}
           </div>
         </div>
       </div>
@@ -535,12 +536,13 @@ export default function JiraSettings (props) {
               intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField('')}
             />
           </ButtonGroup>
-          <div style={{ marginLeft: '3px' }}>
-            {/* <Button
-              disabled={!jiraIssueStoryPointField}
-              icon='eraser'
-              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
-            /> */}
+          <div style={{ marginLeft: '10px' }}>
+            {jiraProxyError && (
+              <p style={{ color: Colors.GRAY4 }}>
+                <Icon icon='warning-sign' color={Colors.RED5} size={12} style={{ marginBottom: '2px' }} />{' '}
+                {jiraProxyError.toString() || 'JIRA API not accessible.'}
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -170,7 +170,7 @@ export default function JiraSettings (props) {
     // Fetch Issue Types & Fields from JIRA API Proxy
     fetchIssueTypes()
     fetchFields()
-  }, [])
+  }, [connection.UpdatedAt])
 
   useEffect(() => {
     console.log('>>> JIRA SETTINGS :: FIELDS LIST DATA CHANGED!', fields)

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -421,8 +421,8 @@ export default function JiraSettings (props) {
                 key={item.value}
                 label={item.value}
                 onClick={handleClick}
-                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag></>}
-                style={{ fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                text={<><span>{item.title}</span> <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
+                style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
               />
             )}
             noResults={<MenuItem disabled={true} text='No epic results.' />}
@@ -484,8 +484,8 @@ export default function JiraSettings (props) {
                 key={item.value}
                 label={item.value}
                 onClick={handleClick}
-                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag></>}
-                style={{ fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
+                style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
               />
             )}
             noResults={<MenuItem disabled={true} text='No epic results.' />}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -170,7 +170,7 @@ export default function JiraSettings (props) {
     // Fetch Issue Types & Fields from JIRA API Proxy
     fetchIssueTypes()
     fetchFields()
-  }, [connection.UpdatedAt])
+  }, [connection.UpdatedAt, fetchIssueTypes, fetchFields])
 
   useEffect(() => {
     console.log('>>> JIRA SETTINGS :: FIELDS LIST DATA CHANGED!', fields)
@@ -468,25 +468,6 @@ export default function JiraSettings (props) {
           </div>
         </div>
       </div>
-      {/* <div className='formContainer' style={{ maxWidth: '250px' }}>
-        <FormGroup
-          disabled={isSaving}
-          label=''
-          inline={true}
-          labelFor='epic-key-field'
-          className='formGroup'
-          contentClassName='formGroupContent'
-        >
-          <InputGroup
-            id='epic-key-field'
-            disabled={isSaving}
-            placeholder='eg. 1000'
-            value={jiraIssueEpicKeyField}
-            onChange={(e) => setJiraIssueEpicKeyField(e.target.value)}
-            className='input epic-key-field'
-          />
-        </FormGroup>
-      </div> */}
       <div className='headlineContainer'>
         <h3 className='headline'>Story Point Field (Optional)</h3>
         <p className=''>Choose the JIRA field you’re using to represent the granularity of a requirement-type issue.</p>
@@ -508,8 +489,18 @@ export default function JiraSettings (props) {
                   key={item.value}
                   label={item.value}
                   onClick={handleClick}
-                  text={<>{item.title} <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
-                  style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                  text={
+                    <>
+                      {item.title}{' '}
+                      <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag>{' '}
+                      {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}
+                    </>
+                  }
+                  style={{
+                    fontSize: '11px',
+                    fontWeight: modifiers.active ? 800 : 'normal',
+                    backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none'
+                  }}
                 />
               )}
               noResults={<MenuItem disabled={true} text='No epic results.' />}
@@ -533,7 +524,9 @@ export default function JiraSettings (props) {
               loading={isFetchingJIRA}
               disabled={!jiraIssueStoryPointField || isSaving}
               icon='eraser'
-              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField('')}
+              intent={jiraIssueStoryPointField
+                ? Intent.WARNING
+                : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField('')}
             />
           </ButtonGroup>
           <div style={{ marginLeft: '10px' }}>
@@ -546,25 +539,6 @@ export default function JiraSettings (props) {
           </div>
         </div>
       </div>
-      {/* <div className='formContainer' style={{ maxWidth: '250px' }}>
-        <FormGroup
-          disabled={isSaving}
-          label=''
-          inline={true}
-          labelFor='board-id-field'
-          className='formGroup'
-          contentClassName='formGroupContent'
-        >
-          <InputGroup
-            id='board-id'
-            disabled={isSaving}
-            placeholder='eg. 3000'
-            value={jiraIssueStoryPointField}
-            onChange={(e) => setJiraIssueStoryPointField(e.target.value)}
-            className='input board-id'
-          />
-        </FormGroup>
-      </div> */}
     </>
   )
 }

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, Fragment } from 'react'
-// import request from '@/utils/request'
 import {
   // FormGroup,
   // InputGroup,
@@ -14,6 +13,9 @@ import {
 import useJIRA from '@/hooks/useJIRA'
 import { Select, MultiSelect } from '@blueprintjs/select'
 // import MappingTag from '@/pages/configure/settings/jira/MappingTag'
+import { fieldsData } from '@/pages/configure/mock-data/jira/fields'
+import { issueTypesData } from '@/pages/configure/mock-data/jira/issueTypes'
+
 import ClearButton from '@/components/ClearButton'
 import '@/styles/integration.scss'
 import '@/styles/connections.scss'
@@ -53,33 +55,11 @@ export default function JiraSettings (props) {
   const [incidentTags, setIncidentTags] = useState([])
 
   // @todo: remove tags list initial state mock data
-  const [requirementTagsList, setRequirementTagsList] = useState([
-    { id: 0, title: 'REQ TAG 100', value: 'REQ-100' },
-    { id: 1, title: 'REQ TAG 200', value: 'REQ-200' },
-    { id: 2, title: 'REQ TAG 300', value: 'REQ-300' }
-  ])
-  const [bugTagsList, setBugTagsList] = useState([
-    { id: 0, title: 'BUG-100', value: 'BUG-100' },
-    { id: 1, title: 'BUG-200', value: 'BUG-200' },
-    { id: 2, title: 'BUG-300', value: 'BUG-300' }
-  ])
-  const [incidentTagsList, setIncidentTagsList] = useState([
-    { id: 0, title: 'INCIDENT TAG 100', value: 'INCIDENT-100' },
-    { id: 1, title: 'INCIDENT TAG 200', value: 'INCIDENT-200' },
-    { id: 2, title: 'INCIDENT TAG 300', value: 'INCIDENT-300' }
-  ])
+  const [requirementTagsList, setRequirementTagsList] = useState(issueTypesData)
+  const [bugTagsList, setBugTagsList] = useState(issueTypesData)
+  const [incidentTagsList, setIncidentTagsList] = useState(issueTypesData)
 
-  const [fieldsList, setFieldsList] = useState([
-    { id: 0, title: 'development', name: 'development', value: 'development', type: 'Dev Summary Custom Field' },
-    { id: 1, title: 'Epic Color', name: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
-    { id: 2, title: 'Epic Link', name: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
-    { id: 3, title: 'Epic Status', name: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
-    { id: 4, title: 'Flagged', name: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
-    { id: 5, title: 'Sprint', name: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
-    { id: 6, title: 'Team', name: 'Team', value: 'Team', type: 'Team' },
-    { id: 7, title: 'UUID', name: 'UUID', value: 'uuid', type: 'UUID Field' },
-    { id: 8, title: 'Rank', name: 'Rank', value: 'Rank', type: 'Global Rank' },
-  ])
+  const [fieldsList, setFieldsList] = useState(fieldsData)
 
   const createTypeMapObject = (customType, standardType) => {
     return customType && standardType
@@ -105,9 +85,9 @@ export default function JiraSettings (props) {
     setTypeMappingRequirement(GroupedMappings[MAPPING_TYPES.Requirement])
     setTypeMappingBug(GroupedMappings[MAPPING_TYPES.Bug])
     setTypeMappingIncident(GroupedMappings[MAPPING_TYPES.Incident])
-    setRequirementTags(requirementTagsList.filter(t => GroupedMappings[MAPPING_TYPES.Requirement].includes(t.value)))
-    setBugTags(bugTagsList.filter(t => GroupedMappings[MAPPING_TYPES.Bug].includes(t.value)))
-    setIncidentTags(incidentTagsList.filter(t => GroupedMappings[MAPPING_TYPES.Incident].includes(t.value)))
+    setRequirementTags(requirementTagsList?.filter(t => GroupedMappings[MAPPING_TYPES.Requirement].includes(t.value)))
+    setBugTags(bugTagsList?.filter(t => GroupedMappings[MAPPING_TYPES.Bug].includes(t.value)))
+    setIncidentTags(incidentTagsList?.filter(t => GroupedMappings[MAPPING_TYPES.Incident].includes(t.value)))
     return GroupedMappings
   }
 
@@ -229,10 +209,10 @@ export default function JiraSettings (props) {
                 active={modifiers.active || requirementTags.includes(item)}
                 disabled={requirementTags.includes(item)}
                 key={item.value}
-                label={item.value}
+                label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={requirementTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : item.title}
-                style={{ marginBottom: '2px', fontWeight: requirementTags.includes(item) ? 'normal' : '700' }}
+                text={requirementTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}>{item.title}</span>}
+                style={{ marginBottom: '2px', fontWeight: requirementTags.includes(item) ? 700 : 'normal' }}
               />
             )}
             tagRenderer={(item) => item.title}
@@ -285,10 +265,10 @@ export default function JiraSettings (props) {
                 active={modifiers.active || bugTags.includes(item)}
                 disabled={bugTags.includes(item)}
                 key={item.value}
-                label={item.value}
+                label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={bugTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : item.title}
-                style={{ marginBottom: '2px', fontWeight: bugTags.includes(item) ? 'normal' : '700' }}
+                text={bugTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}>{item.title}</span>}
+                style={{ marginBottom: '2px', fontWeight: bugTags.includes(item) ? 700 : 'normal' }}
               />
             )}
             tagRenderer={(item) => item.title}
@@ -341,10 +321,10 @@ export default function JiraSettings (props) {
                 active={modifiers.active || incidentTags.includes(item)}
                 disabled={incidentTags.includes(item)}
                 key={item.value}
-                label={item.value}
+                label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={incidentTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : item.title}
-                style={{ marginBottom: '2px', fontWeight: incidentTags.includes(item) ? 'normal' : '700' }}
+                text={incidentTags.includes(item) ? (<>{item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}>{item.title}</span>}
+                style={{ marginBottom: '2px', fontWeight: incidentTags.includes(item) ? 700 : 'normal' }}
               />
             )}
             tagRenderer={(item) => item.title}
@@ -413,7 +393,7 @@ export default function JiraSettings (props) {
         <div style={{ display: 'flex', minWidth: '260px' }}>
           <ButtonGroup disabled={isSaving}>
             <Select
-              disabled={isSaving}
+              disabled={isSaving || fieldsList.length === 0}
               className='select-epic-key'
               inline={true}
               fill={true}
@@ -486,7 +466,7 @@ export default function JiraSettings (props) {
         <div style={{ display: 'flex', minWidth: '260px' }}>
           <ButtonGroup disabled={isSaving}>
             <Select
-              disabled={isSaving}
+              disabled={isSaving || fieldsList.length === 0}
               className='select-story-key'
               inline={true}
               fill={true}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -249,7 +249,7 @@ export default function JiraSettings (props) {
             }}
           />
         </div>
-        <div className='multiselect-clear-action' style={{ marginLeft: '2px' }}>
+        <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={requirementTags.length === 0}
             intent={Intent.PRIMARY} minimal={false} onClick={() => setRequirementTags([])}
@@ -304,7 +304,7 @@ export default function JiraSettings (props) {
             }}
           />
         </div>
-        <div className='multiselect-clear-action' style={{ marginLeft: '2px' }}>
+        <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={bugTags.length === 0}
             intent={Intent.PRIMARY} minimal={false} onClick={() => setBugTags([])}
@@ -359,7 +359,7 @@ export default function JiraSettings (props) {
             }}
           />
         </div>
-        <div className='multiselect-clear-action' style={{ marginLeft: '2px' }}>
+        <div className='multiselect-clear-action' style={{ marginLeft: '5px' }}>
           <ClearButton
             disabled={incidentTags.length === 0}
             intent={Intent.PRIMARY} minimal={false} onClick={() => setIncidentTags([])}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -9,6 +9,7 @@ import {
   Icon,
   Colors
 } from '@blueprintjs/core'
+import useJIRA from '@/hooks/useJIRA'
 import { MultiSelect } from '@blueprintjs/select'
 import MappingTag from '@/pages/configure/settings/jira/MappingTag'
 import ClearButton from '@/components/ClearButton'
@@ -29,6 +30,12 @@ export default function JiraSettings (props) {
   const API_PROXY_ENDPOINT = `/plugins/jira/sources/${connection?.ID}/proxy/rest`
   const ISSUE_TYPES_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/issuetype`
   const ISSUE_FIELDS_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/field`
+
+  const { fetchIssueTypes, fetchFields, issueTypes, fields } = useJIRA({
+    apiProxyPath: API_PROXY_ENDPOINT,
+    issuesEndpoint: ISSUE_TYPES_ENDPOINT,
+    fieldsEndpoint: ISSUE_FIELDS_ENDPOINT
+  })
 
   const [typeMappingBug, setTypeMappingBug] = useState([])
   const [typeMappingIncident, setTypeMappingIncident] = useState([])
@@ -58,6 +65,18 @@ export default function JiraSettings (props) {
     { id: 0, title: 'INCIDENT TAG 100', value: 'INCIDENT-100' },
     { id: 1, title: 'INCIDENT TAG 200', value: 'INCIDENT-200' },
     { id: 2, title: 'INCIDENT TAG 300', value: 'INCIDENT-300' }
+  ])
+
+  const [fieldsList, setFieldsList] = useState([
+    { id: 0, title: 'development', value: 'development', type: 'Dev Summary Custom Field' },
+    { id: 1, title: 'Epic Color', value: 'Epic Color', type: 'Color of Epic' },
+    { id: 2, title: 'Epic Link', value: 'Epic Link', type: 'Epic Link Relationship' },
+    { id: 3, title: 'Epic Status', value: 'Epic Status', type: 'Status of Epic' },
+    { id: 4, title: 'Flagged', value: 'Flagged', type: 'Checkboxes' },
+    { id: 5, title: 'Sprint', value: 'Sprint', type: 'Jira Sprint Field' },
+    { id: 6, title: 'Team', value: 'Team', type: 'Team' },
+    { id: 7, title: 'uuid', value: 'Flagged', type: 'UUID Field' },
+    { id: 8, title: 'Rank', value: 'Rank', type: 'Global Rank' },
   ])
 
   const createTypeMapObject = (customType, standardType) => {
@@ -147,53 +166,13 @@ export default function JiraSettings (props) {
   }, [typeMappingBug, typeMappingIncident, typeMappingRequirement])
 
   useEffect(() => {
-    // @todo Fetch EPICS, GRANULARITES and BOARDS from API
     console.log('>> CONN SETTINGS OBJECT ', connection)
-    // setEpics([])
-    // setBoards([])
-    // setGranularities([])
-    // let mappings = {
-    //   Bug: [],
-    //   Incident: [],
-    //   Requirement: []
-    // }
     if (connection && connection.ID) {
       // Parse Type Mappings (V2)
       parseTypeMappings(connection.typeMappings)
-
-      // LEGACY TYPE MAPPINGS (Disabled)
-      // const types = connection.JIRA_ISSUE_TYPE_MAPPING ? connection.JIRA_ISSUE_TYPE_MAPPING.split(';').map(t => t.split(':')[0]) : []
-      // if (types.lastIndexOf('') !== -1) {
-      //   types.pop()
-      // }
-      // const tags = connection.JIRA_ISSUE_TYPE_MAPPING ? connection.JIRA_ISSUE_TYPE_MAPPING.split(';').map(t => t.split(':')[1]) : []
-      // types.forEach((type, idx) => {
-      //   if (type) {
-      //     mappings = {
-      //       ...mappings,
-      //       [type]: tags[idx] ? tags[idx].split(',') : []
-      //     }
-      //   }
-      // })
-      // console.log('>> RE-CREATED ISSUE TYPE MAPPINGS OBJ...', mappings)
-      // setTypeMappingRequirement(mappings.Requirement)
-      // setTypeMappingBug(mappings.Bug)
-      // setTypeMappingIncident(mappings.Incident)
       setStatusMappings([])
       setJiraIssueEpicKeyField(connection.epicKeyField)
       setJiraIssueStoryPointField(connection.storyPointField)
-
-      // @todo RE-ENABLE SELECTORS!
-      // @todo FETCH & SET EPIC KEY
-      // const selectedEpic = epics.find(e => e.value === connection.JIRA_ISSUE_EPIC_KEY_FIELD)
-      // console.log('>>> EPIC ITEM = ', selectedEpic)
-      // setSelectedEpicItem(selectedEpic)
-
-      // @todo FETCH & SET BOARD ID
-      // setSelectedBoardItem(boards.find(b => b.value === connection.JIRA_ISSUES_BOARD_ID???))
-
-      // @todo FETCH & SET GRANULARITY KEY
-      // setSelectedGranularityItem(granularities.find(g => g.value === connection.JIRA_ISSUE_STORYPOINT_FIELD))
     }
   }, [connection/*, epics, granularities, boards */])
 
@@ -210,27 +189,11 @@ export default function JiraSettings (props) {
   }, [incidentTags])
 
   useEffect(() => {
-    const fetchIssueTypes = async () => {
-      const issues = await request.get(ISSUE_TYPES_ENDPOINT)
-      console.log('>>> JIRA API PROXY: Issues Response...', issues)
-
-      // @todo: set issue types lists from proxy api response data
-      // if (issues && issues.status === 200 && issues.data) {
-      //   setRequirementTagsList()
-      //   setBugTagsList()
-      //   setIncidentTagsList()
-      // }
-    }
-
-    const fetchIssueFields = async () => {
-      const fields = await request.get(ISSUE_FIELDS_ENDPOINT)
-      console.log('>>> JIRA API PROXY: Fields Response...', fields)
-      // @todo: set issue fields list from proxy api response data
-    }
-
+    // @todo: set issue types lists from proxy api response data
+    // @todo: set issue fields list from proxy api response data
     fetchIssueTypes()
-    fetchIssueFields()
-  }, [ISSUE_TYPES_ENDPOINT, ISSUE_FIELDS_ENDPOINT])
+    fetchFields()
+  }, [])
 
   return (
     <>

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -77,7 +77,6 @@ export default function JiraSettings (props) {
       GroupedMappings[typeObj.standardType].push(tag)
     })
     console.log('>>>> PARSED TYPE MAPPINGS ....', GroupedMappings)
-    // @todo: fix parsed type mappings w/ list filters
     setTypeMappingRequirement(GroupedMappings[MAPPING_TYPES.Requirement])
     setTypeMappingBug(GroupedMappings[MAPPING_TYPES.Bug])
     setTypeMappingIncident(GroupedMappings[MAPPING_TYPES.Incident])
@@ -119,12 +118,6 @@ export default function JiraSettings (props) {
 
   useEffect(() => {
     if (typeMappingBug && typeMappingIncident && typeMappingRequirement) {
-      // LEGACY MAPPING FORMAT (DISABLED)
-      // const typeBug = 'Bug:' + typeMappingBug.toString() + ';'
-      // const typeIncident = 'Incident:' + typeMappingIncident.toString() + ';'
-      // const typeRequirement = 'Requirement:' + typeMappingIncident.toString() + ';'
-      // const all = typeBug + typeIncident + typeRequirement
-      // setTypeMappingAll(all)
       const RequirementMappings = typeMappingRequirement !== ''
         ? typeMappingRequirement.map(r => createTypeMapObject(r.value, MAPPING_TYPES.Requirement))
         : []

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -46,9 +46,9 @@ export default function JiraSettings (props) {
   const [typeMappingRequirement, setTypeMappingRequirement] = useState([])
   const [typeMappingAll, setTypeMappingAll] = useState({})
   const [statusMappings, setStatusMappings] = useState()
-  const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState()
+  const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState('')
   const [jiraIssueStoryCoefficient, setJiraIssueStoryCoefficient] = useState(1)
-  const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState()
+  const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState('')
 
   const [requirementTags, setRequirementTags] = useState([])
   const [bugTags, setBugTags] = useState([])
@@ -93,9 +93,9 @@ export default function JiraSettings (props) {
 
   useEffect(() => {
     const settings = {
-      epicKeyField: jiraIssueEpicKeyField?.value,
+      epicKeyField: jiraIssueEpicKeyField?.value || '',
       typeMappings: typeMappingAll,
-      storyPointField: jiraIssueStoryPointField?.value,
+      storyPointField: jiraIssueStoryPointField?.value || '',
     }
     onSettingsChange(settings)
     console.log('>> JIRA INSTANCE SETTINGS FIELDS CHANGED!', settings)
@@ -395,7 +395,7 @@ export default function JiraSettings (props) {
             <Button
               disabled={!jiraIssueEpicKeyField || isSaving}
               icon='eraser'
-              intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField(null)}
+              intent={jiraIssueEpicKeyField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueEpicKeyField('')}
             />
           </ButtonGroup>
           <div style={{ marginLeft: '3px' }}>
@@ -467,7 +467,7 @@ export default function JiraSettings (props) {
             <Button
               disabled={!jiraIssueStoryPointField || isSaving}
               icon='eraser'
-              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField(null)}
+              intent={jiraIssueStoryPointField ? Intent.WARNING : Intent.NONE} minimal={false} onClick={() => setJiraIssueStoryPointField('')}
             />
           </ButtonGroup>
           <div style={{ marginLeft: '3px' }}>

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState, useCallback, Fragment } from 'react'
 import {
-  // FormGroup,
-  // InputGroup,
   ButtonGroup,
   MenuItem,
   Position,
@@ -13,9 +11,6 @@ import {
 } from '@blueprintjs/core'
 import useJIRA from '@/hooks/useJIRA'
 import { Select, MultiSelect } from '@blueprintjs/select'
-// import MappingTag from '@/pages/configure/settings/jira/MappingTag'
-import { fieldsData } from '@/pages/configure/mock-data/jira/fields'
-import { issueTypesData } from '@/pages/configure/mock-data/jira/issueTypes'
 
 import ClearButton from '@/components/ClearButton'
 import '@/styles/integration.scss'
@@ -157,7 +152,7 @@ export default function JiraSettings (props) {
       // setJiraIssueEpicKeyField(fieldsList.find(f => f.value === connection.epicKeyField))
       // setJiraIssueStoryPointField(fieldsList.find(f => f.value === connection.storyPointField))
     }
-  }, [connection/*, epics, granularities, boards */])
+  }, [connection, parseTypeMappings])
 
   useEffect(() => {
     setTypeMappingRequirement(requirementTags)
@@ -233,7 +228,17 @@ export default function JiraSettings (props) {
                 key={item.value}
                 label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={requirementTags.includes(item) ? (<><img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}><img src={item.iconUrl} width={12} height={12} /> {item.title}</span>}
+                text={requirementTags.includes(item)
+                  ? (
+                    <>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} />
+                    </>
+                    )
+                  : (
+                    <span style={{ fontWeight: 700 }}>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title}
+                    </span>
+                    )}
                 style={{ marginBottom: '2px', fontWeight: requirementTags.includes(item) ? 700 : 'normal' }}
               />
             )}
@@ -289,7 +294,17 @@ export default function JiraSettings (props) {
                 key={item.value}
                 label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={bugTags.includes(item) ? (<><img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}><img src={item.iconUrl} width={12} height={12} /> {item.title}</span>}
+                text={bugTags.includes(item)
+                  ? (
+                    <>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} />
+                    </>
+                    )
+                  : (
+                    <span style={{ fontWeight: 700 }}>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title}
+                    </span>
+                    )}
                 style={{ marginBottom: '2px', fontWeight: bugTags.includes(item) ? 700 : 'normal' }}
               />
             )}
@@ -345,7 +360,17 @@ export default function JiraSettings (props) {
                 key={item.value}
                 label={<span style={{ marginLeft: '20px' }}>{item.description || item.value}</span>}
                 onClick={handleClick}
-                text={incidentTags.includes(item) ? (<><img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} /></>) : <span style={{ fontWeight: 700 }}><img src={item.iconUrl} width={12} height={12} /> {item.title}</span>}
+                text={incidentTags.includes(item)
+                  ? (
+                    <>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title} <Icon icon='small-tick' color={Colors.GREEN5} />
+                    </>
+                    )
+                  : (
+                    <span style={{ fontWeight: 700 }}>
+                      <img src={item.iconUrl} width={12} height={12} /> {item.title}
+                    </span>
+                    )}
                 style={{ marginBottom: '2px', fontWeight: incidentTags.includes(item) ? 700 : 'normal' }}
               />
             )}
@@ -397,8 +422,18 @@ export default function JiraSettings (props) {
                   key={item.value}
                   label={item.value}
                   onClick={handleClick}
-                  text={<><span>{item.title}</span> <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag> {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}</>}
-                  style={{ fontSize: '11px', fontWeight: modifiers.active ? 800 : 'normal', backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none' }}
+                  text={
+                    <>
+                      <span>{item.title}</span>{' '}
+                      <Tag minimal intent={Intent.PRIMARY} style={{ fontSize: '9px' }}>{item.type}</Tag>{' '}
+                      {modifiers.active && (<Icon icon='small-tick' color={Colors.GREEN5} size={14} />)}
+                    </>
+                  }
+                  style={{
+                    fontSize: '11px',
+                    fontWeight: modifiers.active ? 800 : 'normal',
+                    backgroundColor: modifiers.active ? Colors.LIGHT_GRAY4 : 'none'
+                  }}
                 />
               )}
               noResults={<MenuItem disabled={true} text='No epic results.' />}

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -418,6 +418,7 @@ export default function JiraSettings (props) {
               itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
               itemRenderer={(item, { handleClick, modifiers }) => (
                 <MenuItem
+                  disabled={jiraIssueStoryPointField?.value === item.value}
                   active={false}
                   intent={modifiers.active ? Intent.NONE : Intent.NONE}
                   key={item.value}
@@ -488,6 +489,7 @@ export default function JiraSettings (props) {
               itemPredicate={(query, item) => item.title.toLowerCase().indexOf(query.toLowerCase()) >= 0}
               itemRenderer={(item, { handleClick, modifiers }) => (
                 <MenuItem
+                  disabled={jiraIssueEpicKeyField?.value === item.value}
                   active={false}
                   intent={modifiers.active ? Intent.NONE : Intent.NONE}
                   key={item.value}

--- a/config-ui/src/styles/libraries/blueprint.scss
+++ b/config-ui/src/styles/libraries/blueprint.scss
@@ -101,7 +101,7 @@ button, .bp3-button {
 .bp3-popover-wrapper {
   &.select-epic-key, &.select-story-key {
     width: auto;
-    min-width: 260px;
+    // min-width: 260px;
     max-width: 300px;
   }
 }

--- a/config-ui/src/styles/libraries/blueprint.scss
+++ b/config-ui/src/styles/libraries/blueprint.scss
@@ -97,3 +97,11 @@ button, .bp3-button {
 .bp3-toast-message {
   padding: 13px;
 }
+
+.bp3-popover-wrapper {
+  &.select-epic-key, &.select-story-key {
+    width: auto;
+    min-width: 260px;
+    max-width: 300px;
+  }
+}

--- a/config-ui/src/styles/libraries/blueprint.scss
+++ b/config-ui/src/styles/libraries/blueprint.scss
@@ -105,3 +105,24 @@ button, .bp3-button {
     max-width: 300px;
   }
 }
+
+.bp3-select-popover {
+  .bp3-menu {
+    max-height: calc(10 * 32px);
+    overflow: auto;
+  }
+}
+
+.bp3-multi-select-popover {
+  max-width: 600px;
+  overflow: auto;
+  text-overflow: ellipsis;
+  .bp3-menu-item {
+    .bp3-menu-item-label {
+      max-width: 70%;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+  }
+}


### PR DESCRIPTION
### Config-UI / Data Integrations / JIRA / Issue Type Mappings

- [x] Implement **Multiselect** Component for **Type Mappings**
   - Requirement Tags
   - Bug Tags
   - Incident Tags
- [x] Implement **Select** Component for **Epic Key**
- [x] Implement **Select** Component for **Story Point Field**
- [x] Fetch **Issue Types** and Fields using **JIRA API Proxy**
- [x] Test/Verify Issue Type Mappings Object
- [x] Test Save Settings
- [x] Test READ Settings

### Description
This PR adds usability improvements to JIRA settings by converting the multi-tag input widgets to Multiselect widgets for **JIRA's Issue Type Mappings**. This will allow the user to select tags from a predefined list using the JIRA API Proxy, rather than manual entry. The list options for Issue Type Mappings will be provided by the available list of `Issue Types`, whereas the options for Epic Key and Story Points will be provided by `Custom Fields`. 

It is expected that the JIRA Source Connection is properly working with a valid Authentication Token and a successful Connection Test.

**Additional Notes and Constraints**
- **Epic** and **Story Point** fields may not have the same value.
- For _New_ or _Invalid_ JIRA Connection Sources (ie bad auth token), selectors will be disabled.

### Does this close any open issues?
#1064

### Screenshots
<img width="1185" alt="Screen Shot 2022-02-04 at 10 56 44 PM" src="https://user-images.githubusercontent.com/1742233/152628140-4c9ca1fc-6c32-4822-99aa-1045d7140113.png">
<img width="1185" alt="Screen Shot 2022-02-04 at 10 57 10 PM" src="https://user-images.githubusercontent.com/1742233/152628139-e85f7bc4-d893-4631-bb04-2736f07538c9.png">
<img width="1184" alt="Screen Shot 2022-02-04 at 10 57 18 PM" src="https://user-images.githubusercontent.com/1742233/152628138-c7b605c6-b48f-4c70-b238-8f725ecc45ea.png">
<img width="1184" alt="Screen Shot 2022-02-04 at 10 57 30 PM" src="https://user-images.githubusercontent.com/1742233/152628136-ac187324-82a6-42ea-9fb8-d4fb0e090fa7.png">
<img width="1185" alt="Screen Shot 2022-02-04 at 10 57 39 PM" src="https://user-images.githubusercontent.com/1742233/152628135-b0e372ad-e378-44fd-b421-e16f177816d6.png">
<img width="1343" alt="Screen Shot 2022-02-05 at 12 04 40 PM" src="https://user-images.githubusercontent.com/1742233/152917230-2a9f0391-86bc-4c9b-8247-832125fd5b3c.png">


