### PR TITLE
refactor(domain layer,plugins): indicate which sub task failed

### DIFF
--- a/errors/sub_task_error.go
+++ b/errors/sub_task_error.go
@@ -1,0 +1,16 @@
+package errors
+
+var _ error = (*SubTaskError)(nil)
+
+type SubTaskError struct {
+	SubTaskName string
+	Message     string
+}
+
+func (e *SubTaskError) Error() string {
+	return e.Message
+}
+
+func (e *SubTaskError) GetSubTaskName() string {
+	return e.SubTaskName
+}

--- a/models/task.go
+++ b/models/task.go
@@ -16,17 +16,18 @@ const (
 
 type Task struct {
 	common.Model
-	Plugin       string         `json:"plugin" gorm:"index"`
-	Options      datatypes.JSON `json:"options"`
-	Status       string         `json:"status"`
-	Message      string         `json:"message"`
-	Progress     float32        `json:"progress"`
-	PipelineId   uint64         `json:"pipelineId" gorm:"index"`
-	PipelineRow  int            `json:"pipelineRow"`
-	PipelineCol  int            `json:"pipelineCol"`
-	BeganAt      *time.Time     `json:"beganAt"`
-	FinishedAt   *time.Time     `json:"finishedAt" gorm:"index"`
-	SpentSeconds int            `json:"spentSeconds"`
+	Plugin        string         `json:"plugin" gorm:"index"`
+	Options       datatypes.JSON `json:"options"`
+	Status        string         `json:"status"`
+	Message       string         `json:"message"`
+	Progress      float32        `json:"progress"`
+	FailedSubTask string         `json:"failedSubTask"`
+	PipelineId    uint64         `json:"pipelineId" gorm:"index"`
+	PipelineRow   int            `json:"pipelineRow"`
+	PipelineCol   int            `json:"pipelineCol"`
+	BeganAt       *time.Time     `json:"beganAt"`
+	FinishedAt    *time.Time     `json:"finishedAt" gorm:"index"`
+	SpentSeconds  int            `json:"spentSeconds"`
 }
 
 type NewTask struct {

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -3,6 +3,7 @@ package main // must be main for plugin entry point
 import (
 	"context"
 	"fmt"
+	"github.com/merico-dev/lake/errors"
 	"os"
 	"strings"
 
@@ -136,7 +137,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting commits collection")
 		err = tasks.CollectCommits(op.Owner, op.Repo, repoId, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect commits: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect commits: %v", err).Error(),
+				SubTaskName: "collectCommits",
+			}
 		}
 	}
 	if tasksToRun["collectCommitsStat"] {
@@ -144,7 +148,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting commits stat collection")
 		err = tasks.CollectCommitsStat(op.Owner, op.Repo, repoId, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect commits: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect commits: %v", err).Error(),
+				SubTaskName: "collectCommitsStat",
+			}
 		}
 	}
 	if tasksToRun["collectIssues"] {
@@ -152,7 +159,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting issues collection")
 		err = tasks.CollectIssues(op.Owner, op.Repo, repoId, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect issues: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect issues: %v", err).Error(),
+				SubTaskName: "collectIssues",
+			}
 		}
 	}
 	if tasksToRun["collectIssueEvents"] {
@@ -160,7 +170,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting Issue Events collection")
 		err = tasks.CollectIssueEvents(op.Owner, op.Repo, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect Issue Events: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect Issue Events: %v", err).Error(),
+				SubTaskName: "collectIssueEvents",
+			}
 		}
 	}
 
@@ -169,7 +182,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting Issue Comments collection")
 		err = tasks.CollectIssueComments(op.Owner, op.Repo, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect Issue Comments: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect Issue Comments: %v", err).Error(),
+				SubTaskName: "collectIssueComments",
+			}
 		}
 	}
 
@@ -178,7 +194,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> collecting PR collection")
 		err = tasks.CollectPullRequests(op.Owner, op.Repo, repoId, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect PR: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect PR: %v", err).Error(),
+				SubTaskName: "collectPullRequests",
+			}
 		}
 	}
 
@@ -187,7 +206,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> collecting PR Reviews collection")
 		err = tasks.CollectPullRequestReviews(op.Owner, op.Repo, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect PR Reviews: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect PR Reviews: %v", err).Error(),
+				SubTaskName: "collectPullRequestReviews",
+			}
 		}
 	}
 
@@ -196,7 +218,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting PR Commits collection")
 		err = tasks.CollectPullRequestCommits(op.Owner, op.Repo, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect PR Commits: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect PR Commits: %v", err).Error(),
+				SubTaskName: "collectPullRequestCommits",
+			}
 		}
 	}
 
@@ -205,7 +230,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> starting PR Comments collection")
 		err = tasks.CollectPullRequestComments(op.Owner, op.Repo, scheduler, apiClient)
 		if err != nil {
-			return fmt.Errorf("Could not collect PR Comments: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("Could not collect PR Comments: %v", err).Error(),
+				SubTaskName: "collectPullRequestComments",
+			}
 		}
 	}
 
@@ -214,7 +242,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> Enriching Issues")
 		err = tasks.EnrichGithubIssues()
 		if err != nil {
-			return fmt.Errorf("could not enrich issues: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not enrich issues: %v", err).Error(),
+				SubTaskName: "enrichIssues",
+			}
 		}
 	}
 	if tasksToRun["enrichPullRequests"] {
@@ -222,35 +253,50 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		fmt.Println("INFO >>> Enriching PullRequests")
 		err = tasks.EnrichGithubPullRequests(repoId)
 		if err != nil {
-			return fmt.Errorf("could not enrich PullRequests: %v", err)
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not enrich PullRequests: %v", err).Error(),
+				SubTaskName: "enrichPullRequests",
+			}
 		}
 	}
 	if tasksToRun["convertRepos"] {
 		progress <- 0.93
 		err = tasks.ConvertRepos()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert Repos: %v", err).Error(),
+				SubTaskName: "convertRepos",
+			}
 		}
 	}
 	if tasksToRun["convertIssues"] {
 		progress <- 0.94
 		err = tasks.ConvertIssues(repoId)
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert Issues: %v", err).Error(),
+				SubTaskName: "convertIssues",
+			}
 		}
 	}
 	if tasksToRun["convertIssueLabels"] {
 		progress <- 0.94
 		err = tasks.ConvertIssueLabels()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert IssueLabels: %v", err).Error(),
+				SubTaskName: "convertIssueLabels",
+			}
 		}
 	}
 	if tasksToRun["convertPullRequests"] {
 		progress <- 0.95
 		err = tasks.ConvertPullRequests()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert PullRequests: %v", err).Error(),
+				SubTaskName: "convertPullRequests",
+			}
 		}
 	}
 	if tasksToRun["convertPullRequestLabels"] {
@@ -264,21 +310,30 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		progress <- 0.96
 		err = tasks.ConvertCommits(repoId)
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert Commits: %v", err).Error(),
+				SubTaskName: "convertCommits",
+			}
 		}
 	}
 	if tasksToRun["convertPullRequestCommits"] {
 		progress <- 0.97
 		err = tasks.PrCommitConvertor()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert PullRequestCommits: %v", err).Error(),
+				SubTaskName: "convertPullRequestCommits",
+			}
 		}
 	}
 	if tasksToRun["convertNotes"] {
 		progress <- 0.98
 		err = tasks.ConvertNotes()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert Notes: %v", err).Error(),
+				SubTaskName: "convertNotes",
+			}
 		}
 	}
 	if tasksToRun["convertUsers"] {
@@ -286,7 +341,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		err = tasks.ConvertUsers()
 
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				Message:     fmt.Errorf("could not convert Users: %v", err).Error(),
+				SubTaskName: "convertUsers",
+			}
 		}
 	}
 

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -3,6 +3,7 @@ package main // must be main for plugin entry point
 import (
 	"context"
 	"fmt"
+	errors "github.com/merico-dev/lake/errors"
 	"os"
 	"strconv"
 
@@ -103,14 +104,20 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	if tasksToRun["collectCommits"] {
 		progress <- 0.25
 		if err := tasks.CollectCommits(projectIdInt, scheduler); err != nil {
-			return fmt.Errorf("could not collect commits: %v", err)
+			return &errors.SubTaskError{
+				SubTaskName: "collectCommits",
+				Message:     fmt.Errorf("could not collect commits: %v", err).Error(),
+			}
 		}
 	}
 	if tasksToRun["collectMrs"] {
 		progress <- 0.3
 		mergeRequestErr := tasks.CollectMergeRequests(projectIdInt, scheduler)
 		if mergeRequestErr != nil {
-			return fmt.Errorf("could not collect merge requests: %v", mergeRequestErr)
+			return &errors.SubTaskError{
+				SubTaskName: "collectMrs",
+				Message:     fmt.Errorf("could not collect merge requests: %v", mergeRequestErr).Error(),
+			}
 		}
 		progress <- 0.4
 		collectChildrenOnMergeRequests(projectIdInt, scheduler)
@@ -119,42 +126,65 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 		progress <- 0.5
 		enrichErr := tasks.EnrichMergeRequests()
 		if enrichErr != nil {
-			return fmt.Errorf("could not enrich merge requests: %v", enrichErr)
+			return &errors.SubTaskError{
+				SubTaskName: "enrichMrs",
+				Message:     fmt.Errorf("could not enrich merge requests: %v", enrichErr).Error(),
+			}
 		}
 	}
 	if tasksToRun["collectPipelines"] {
 		progress <- 0.6
 		if err := tasks.CollectAllPipelines(projectIdInt, scheduler); err != nil {
-			return fmt.Errorf("could not collect projects: %v", err)
+			return &errors.SubTaskError{
+				SubTaskName: "collectPipelines",
+				Message:     fmt.Errorf("could not collect pipelines: %v", err).Error(),
+			}
 		}
-		tasks.CollectChildrenOnPipelines(projectIdInt, scheduler)
+		if err := tasks.CollectChildrenOnPipelines(projectIdInt, scheduler); err != nil {
+			return &errors.SubTaskError{
+				SubTaskName: "collectChildrenOnPipelines",
+				Message:     fmt.Errorf("could not collect children pipelines: %v", err).Error(),
+			}
+		}
 	}
 	if tasksToRun["convertProjects"] {
 		progress <- 0.7
 		err = tasks.ConvertProjects()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				SubTaskName: "convertProjects",
+				Message:     err.Error(),
+			}
 		}
 	}
 	if tasksToRun["convertMrs"] {
 		progress <- 0.75
 		err = tasks.ConvertPrs()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				SubTaskName: "convertMrs",
+				Message:     err.Error(),
+			}
 		}
 	}
 	if tasksToRun["convertCommits"] {
 		progress <- 0.8
 		err = tasks.ConvertCommits(projectIdInt)
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				SubTaskName: "convertCommits",
+				Message:     err.Error(),
+			}
 		}
 	}
 	if tasksToRun["convertNotes"] {
 		progress <- 0.9
 		err = tasks.ConvertNotes()
 		if err != nil {
-			return err
+			return &errors.SubTaskError{
+				SubTaskName: "convertNotes",
+				Message:     err.Error(),
+			}
 		}
 	}
 	progress <- 1

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -3,6 +3,7 @@ package main // must be main for plugin entry point
 import (
 	"context"
 	"fmt"
+	errors "github.com/merico-dev/lake/errors"
 	"os"
 	"strconv"
 	"time"
@@ -140,94 +141,136 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 		if tasksToRun["collectProjects"] {
 			err := tasks.CollectProjects(jiraApiClient, op.SourceId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectProjects",
+					Message:     err.Error(),
+				}
 			}
 		}
 		if tasksToRun["collectUsers"] {
 			err := tasks.CollectUsers(jiraApiClient, op.SourceId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectUsers",
+					Message:     err.Error(),
+				}
 			}
 		}
 		if tasksToRun["collectBoard"] {
 			err := tasks.CollectBoard(jiraApiClient, source, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectBoard",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.01)
 		if tasksToRun["collectIssues"] {
 			err = tasks.CollectIssues(jiraApiClient, source, boardId, since, rateLimitPerSecondInt, ctx)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectIssues",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.1)
 		if tasksToRun["collectChangelogs"] {
 			err = tasks.CollectChangelogs(jiraApiClient, source, boardId, rateLimitPerSecondInt, ctx)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectChangelogs",
+					Message:     err.Error(),
+				}
 			}
 		}
 		if tasksToRun["collectRemotelinks"] {
 			err = tasks.CollectRemoteLinks(jiraApiClient, source, boardId, rateLimitPerSecondInt, ctx)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectRemotelinks",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.2)
 		if tasksToRun["enrichIssues"] {
 			err = tasks.EnrichIssues(source, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "enrichIssues",
+					Message:     err.Error(),
+				}
 			}
 		}
 		if tasksToRun["enrichRemotelinks"] {
 			err = tasks.EnrichRemotelinks(source, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "enrichRemotelinks",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.3)
 		if tasksToRun["collectSprints"] {
 			err = tasks.CollectSprint(jiraApiClient, source, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "collectSprints",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.4)
 		if tasksToRun["convertBoard"] {
 			err := tasks.ConvertBoard(op.SourceId, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertBoard",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.5)
 		if tasksToRun["convertUsers"] {
 			err := tasks.ConvertUsers(op.SourceId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertUsers",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.6)
 		if tasksToRun["convertIssues"] {
 			err = tasks.ConvertIssues(op.SourceId, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertIssues",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.7)
 		if tasksToRun["convertWorklogs"] {
 			err = tasks.ConvertWorklog(op.SourceId, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertWorklogs",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.8)
 		if tasksToRun["convertChangelogs"] {
 			err = tasks.ConvertChangelogs(op.SourceId, boardId)
 			if err != nil {
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertChangelogs",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 0.9)
@@ -235,14 +278,20 @@ func (plugin Jira) Execute(options map[string]interface{}, progress chan<- float
 			err = tasks.ConvertSprint(op.SourceId, boardId)
 			if err != nil {
 				logger.Error("convertSprints", err)
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertSprints",
+					Message:     err.Error(),
+				}
 			}
 		}
 		if tasksToRun["convertIssueCommits"] {
 			err = tasks.ConvertIssueCommits(op.SourceId, boardId)
 			if err != nil {
 				logger.Error("convertIssueCommits", err)
-				return err
+				return &errors.SubTaskError{
+					SubTaskName: "convertIssueCommits",
+					Message:     err.Error(),
+				}
 			}
 		}
 		setBoardProgress(i, 1.0)

--- a/services/task.go
+++ b/services/task.go
@@ -154,11 +154,16 @@ func RunTask(taskId uint64) error {
 			finishedAt := time.Now()
 			spentSeconds := finishedAt.Unix() - beganAt.Unix()
 			if err != nil {
+				subTaskName := ""
+				if pluginErr, ok := err.(*errors.SubTaskError); ok {
+					subTaskName = pluginErr.GetSubTaskName()
+				}
 				dbe := models.Db.Model(task).Updates(map[string]interface{}{
-					"status":        models.TASK_FAILED,
-					"message":       err.Error(),
-					"finished_at":   finishedAt,
-					"spent_seconds": spentSeconds,
+					"status":          models.TASK_FAILED,
+					"message":         err.Error(),
+					"finished_at":     finishedAt,
+					"spent_seconds":   spentSeconds,
+					"failed_sub_task": subTaskName,
 				}).Error
 				if dbe != nil {
 					logger.Error("eror is not nil", err)


### PR DESCRIPTION
# Summary

To improve pipeline debugging experience, this change will indicate which sub task failed
1. added an extra field(failed_sub_task) in table.tasks
2. let all plugin.execute return SubTaskError if sub task failed
3. in services/task.RunTask, check if error is SubTaskError

###Todo
let other plugins.execute to return SubTaskError

### Does this close any open issues?
closes #1050

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/152758779-3b72e253-7fb4-4f68-bf05-879bdc9a66a7.png)

