### PR TITLE
fix(plugins): pass pointer instead value

### DIFF
--- a/plugins/gitlab/tasks/gitlab_note_converter.go
+++ b/plugins/gitlab/tasks/gitlab_note_converter.go
@@ -15,7 +15,7 @@ func ConvertNotes() error {
 	if err != nil {
 		return err
 	}
-	domainIdGeneratorNote := didgen.NewDomainIdGenerator(gitlabModels.GitlabMergeRequestNote{})
+	domainIdGeneratorNote := didgen.NewDomainIdGenerator(&gitlabModels.GitlabMergeRequestNote{})
 	for _, note := range gitlabMergeRequestNotes {
 		domainNote := convertToNoteModel(&note, domainIdGeneratorNote)
 		err := lakeModels.Db.Clauses(clause.OnConflict{UpdateAll: true}).Create(domainNote).Error


### PR DESCRIPTION
# Summary

By mistaken, previously passed a value to the didgen.NewDomainIdGenerator func
Now prepend "&" on gitlabModels.GitlabMergeRequestNote{} in gitlab_note_converter.go


### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Closes issue #1182 


### Screenshots

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/39366025/152922293-f8306918-22b2-4530-bc42-5e93c4a64735.png">

### Other Information
Any other information that is important to this PR.
