### PR TITLE
`Docs`: Use curl instead of git-clone to prepare the configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,11 @@ NOTE: After installing docker, you may need to run the docker application and re
 
 #### Commands to run in your terminal<a id="user-setup-commands"></a>
 
-1. Clone repository:
+1. Prepare the configuration file(.env & docker-compose.yml):
 
    ```sh
-   git clone https://github.com/merico-dev/lake.git devlake
-   cd devlake
-   cp .env.example .env
+   curl -o .env https://raw.githubusercontent.com/merico-dev/lake/main/.env.example
+   curl -o docker-compose.yml https://raw.githubusercontent.com/merico-dev/lake/main/docker-compose.yml
    ```
 2. Start Docker on your machine, then run `docker compose up -d` to start the services.
 


### PR DESCRIPTION
Signed-off-by: Daniel Hu <tao.hu@merico.dev>


# Summary

Use curl instead of git-clone to prepare the `.env & docker-compose.yml` files

### Key Points

- [x] New or existing documentation is updated

### Description

It's too heavy to let users clone the whole repo to get the two configuration files, just `curl` them.

### Screenshots

![image](https://user-images.githubusercontent.com/18692628/152927441-6706c72c-f873-4262-ae1a-8018ed8ede11.png)

