### PR TITLE
`hotfix`: config-ui - fix create pipeline page | `Draft`

### DIFF
--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -23,7 +23,7 @@ const ProviderSettings = (props) => {
     sources = [],
     boardId = [],
     owner,
-    repo,
+    repositoryName,
     setProjectId = () => {},
     setSourceId = () => {},
     setSelectedSource = () => {},
@@ -199,7 +199,7 @@ const ProviderSettings = (props) => {
               id='repository-name'
               disabled={isRunning || !isEnabled(providerId)}
               placeholder='eg. lake'
-              value={repo}
+              value={repositoryName}
               onChange={(e) => setRepositoryName(e.target.value)}
               className='input-repository-name'
               autoComplete='off'

--- a/config-ui/src/components/pipelines/StageTaskCaption.jsx
+++ b/config-ui/src/components/pipelines/StageTaskCaption.jsx
@@ -18,7 +18,7 @@ const StageTaskCaption = (props) => {
       }}
     >
       {(task.plugin === Providers.GITLAB || task.plugin === Providers.JIRA) && (<>ID {options.projectId || options.boardId}</>)}
-      {task.plugin === Providers.GITHUB && (<>@{options.owner}/{options.repo}</>)}
+      {task.plugin === Providers.GITHUB && (<>@{options.owner}/{options.repositoryName}</>)}
       {task.plugin === Providers.JENKINS && (<>Task #{task.ID}</>)}
       {(task.plugin === Providers.GITEXTRACTOR || task.plugin === Providers.REFDIFF) && (<>{options.repoId || `ID ${task.ID}`}</>)}
     </span>

--- a/config-ui/src/components/pipelines/StageTaskName.jsx
+++ b/config-ui/src/components/pipelines/StageTaskName.jsx
@@ -70,7 +70,7 @@ const StageTaskName = (props) => {
                   {task.plugin === Providers.GITEXTRACTOR && (<>{ProviderLabels.GITEXTRACTOR}</>)}
                   {task.plugin === Providers.JENKINS && (<>{ProviderLabels.JENKINS}</>)}
                   {(task.plugin === Providers.GITLAB || task.plugin === Providers.JIRA) && (<>ID {task.options.projectId || task.options.boardId}</>)}
-                  {task.plugin === Providers.GITHUB && task.plugin !== Providers.JENKINS && (<>@{task.options.owner}/{task.options.repo}</>)}
+                  {task.plugin === Providers.GITHUB && task.plugin !== Providers.JENKINS && (<>@{task.options.owner}/{task.options.repositoryName}</>)}
                 </H3>
                 {![Providers.JENKINS, Providers.REFDIFF, Providers.GITEXTRACTOR].includes(task.plugin) && (
                   <>{ProviderLabels[task.plugin.toUpperCase()] || 'System Task'}<br /></>

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -104,10 +104,11 @@ const TaskActivity = (props) => {
               {t.plugin !== Providers.JENKINS && t.plugin !== 'refdiff' && (
                 <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   <span style={{ color: Colors.GRAY2 }}>
-                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} /> {t.options[Object.keys(t.options)[0]]}
+                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} />{' '}
+                    {t.options.projectId || t.options.boardId || t.options.owner}
                   </span>
                   {t.plugin === Providers.GITHUB && (
-                    <span style={{ fontWeight: 60 }}>/{t.options.repo}</span>
+                    <span style={{ fontWeight: 60 }}>/{t.options.repositoryName || t.options.repo || '(Repository)'}</span>
                   )}
                 </div>
               )}

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -10,7 +10,7 @@ function usePipelineValidation ({
   projectId,
   boardId,
   owner,
-  repo,
+  repositoryName,
   sourceId,
   tasks
 }) {
@@ -61,11 +61,11 @@ function usePipelineValidation ({
       errs.push('GitHub: Owner invalid format')
     }
 
-    if (enabledProviders.includes(Providers.GITHUB) && !repo) {
+    if (enabledProviders.includes(Providers.GITHUB) && !repositoryName) {
       errs.push('GitHub: Repository Name is required')
     }
 
-    if (enabledProviders.includes(Providers.GITHUB) && repo.match(/^[a-zA-Z0-9._-]+$/g) === null) {
+    if (enabledProviders.includes(Providers.GITHUB) && repositoryName.match(/^[a-zA-Z0-9._-]+$/g) === null) {
       errs.push('GitHub: Repository name invalid format')
     }
 
@@ -86,7 +86,7 @@ function usePipelineValidation ({
     projectId,
     boardId,
     owner,
-    repo,
+    repositoryName,
     sourceId,
     tasks
   ])

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -576,7 +576,7 @@ const PipelineActivity = (props) => {
                               <span>
                                 <strong>{t.options.owner}</strong>
                                 <span style={{ color: Colors.GRAY5, padding: '0 1px' }}>/</span>
-                                <strong>{t.options.repo}</strong>
+                                <strong>{t.options.repositoryName || t.options.repo || '(Repository)'}</strong>
                               </span>
                               {t.options.tasks && (
                                 <>

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -77,7 +77,7 @@ const CreatePipeline = (props) => {
   const [sourceId, setSourceId] = useState('')
   const [sources, setSources] = useState([])
   const [selectedSource, setSelectedSource] = useState()
-  const [repo, setRepo] = useState('')
+  const [repositoryName, setRepositoryName] = useState('')
   const [owner, setOwner] = useState('')
 
   const [autoRedirect, setAutoRedirect] = useState(true)
@@ -104,7 +104,7 @@ const CreatePipeline = (props) => {
     projectId,
     boardId,
     owner,
-    repo,
+    repositoryName,
     sourceId,
     runTasks
   })
@@ -161,7 +161,7 @@ const CreatePipeline = (props) => {
         break
       case Providers.GITHUB:
         options = {
-          repo,
+          repo: repositoryName,
           owner
         }
         break
@@ -174,7 +174,7 @@ const CreatePipeline = (props) => {
         break
     }
     return options
-  }, [boardId, owner, projectId, repo, sourceId])
+  }, [boardId, owner, projectId, repositoryName, sourceId])
 
   const configureProvider = useCallback((providerId) => {
     let providerConfig = {}
@@ -253,7 +253,7 @@ const CreatePipeline = (props) => {
       setSources([])
       setSelectedSource(null)
     }
-  }, [enabledProviders, projectId, boardId, sourceId, owner, repo, configureProvider, validate, fetchAllConnections])
+  }, [enabledProviders, projectId, boardId, sourceId, owner, repositoryName, configureProvider, validate, fetchAllConnections])
 
   useEffect(() => {
     console.log('>> PIPELINE LAST RUN OBJECT CHANGED!!...', pipelineRun)
@@ -302,7 +302,7 @@ const CreatePipeline = (props) => {
       }
       if (GitHubTask) {
         setEnabledProviders(eP => [...eP, Providers.GITHUB])
-        setRepositoryName(GitHubTask.options?.repo)
+        setRepositoryName(GitHubTask.options?.repositoryName || GitHubTask.options?.repo)
         setOwner(GitHubTask.options?.owner)
       }
       if (JiraTask && JiraTask.length > 0) {
@@ -541,7 +541,7 @@ const CreatePipeline = (props) => {
                           providerId={provider.id}
                           projectId={projectId}
                           owner={owner}
-                          repo={repo}
+                          repositoryName={repositoryName}
                           sourceId={sourceId}
                           sources={sources}
                           selectedSource={selectedSource}


### PR DESCRIPTION
### ⚠️ Config UI / Pipelines / **Create Pipeline RUN**
> WIP DO NOT MERGE

- [ ] Restore Functionality of **Create Pipeline** Form
- [ ] Adjust UI for change with `Api Contract` for GitHub Task Options (Refactored with #1161)
- [ ] Test Create Pipeline Functionality

### Description
This PR restores the Create Pipeline feature to original functionality after being affected by a refactor with Pull Request #1161 which changed the signature of `repositoryName` to `repo` for a pipeline with GitHub specific task options.

### Does this close any open issues?
#1161 

### Screenshots
`Pending`
