### PR TITLE
fix: refdiff rook_pkg_path typo

### DIFF
--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -195,7 +195,7 @@ func (rd RefDiff) Execute(options map[string]interface{}, progress chan<- float3
 
 // PkgPath information lost when compiled as plugin(.so)
 func (rd RefDiff) RootPkgPath() string {
-	return "github.com/merico-dev/lake/plugins/jira"
+	return "github.com/merico-dev/lake/plugins/refdiff"
 }
 
 func (rd RefDiff) ApiResources() map[string]map[string]core.ApiResourceHandler {


### PR DESCRIPTION
# Summary

Fix problem mention via PR #1189 

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
