### PR TITLE
docs: fix typo for `gitextractor` plugin

### DIFF
--- a/plugins/gitextractor/README.md
+++ b/plugins/gitextractor/README.md
@@ -23,7 +23,7 @@ curl --location --request POST 'localhost:8080/pipelines' \
                 "Plugin": "gitextractor",
                 "Options": {
                     "url": "https://github.com/merico-dev/lake.git",
-                    "repoId": "github:GithubRepos:384111310"
+                    "repoId": "github:GithubRepo:384111310"
                 }
             }
         ]


### PR DESCRIPTION
# Summary

Removed `s` from `repoId`

### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated
