### PR TITLE
fix: use hooks to handle encryption and decryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,8 @@ GRAFANA_ENDPOINT=http://localhost:3002
 AE_APP_ID=
 AE_SECRET_KEY=
 AE_ENDPOINT=
+
+##########################
+# Sensitive information encryption key
+##########################
+ENCODE_KEY=

--- a/plugins/core/plugin_utils.go
+++ b/plugins/core/plugin_utils.go
@@ -176,8 +176,13 @@ func AesDecrypt(crypted, key []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Decrypt and unalign data
+	// Get the block size and check whether the ciphertext length is legal
 	blockSize := block.BlockSize()
+	if len(crypted)%blockSize != 0 {
+		return nil, fmt.Errorf("The length of the data to be decrypted is [%d], so cannot match the required block size [%d]", len(crypted), blockSize)
+	}
+
+	// Decrypt and unalign data
 	blockMode := cipher.NewCBCDecrypter(block, key[:blockSize])
 	origData := make([]byte, len(crypted))
 	blockMode.CryptBlocks(origData, crypted)

--- a/plugins/jira/api/jira_sources.go
+++ b/plugins/jira/api/jira_sources.go
@@ -33,12 +33,6 @@ func getJiraSourceById(id uint64) (*models.JiraSource, error) {
 		return nil, err
 	}
 
-	// Decrypt the sensitive information after reading the data from the database
-	jiraSource.BasicAuthEncoded, err = core.Decode(jiraSource.BasicAuthEncoded)
-	if err != nil {
-		return nil, err
-	}
-
 	return jiraSource, nil
 }
 func mergeFieldsToJiraSource(jiraSource *models.JiraSource, sources ...map[string]interface{}) error {
@@ -64,13 +58,6 @@ func refreshAndSaveJiraSource(jiraSource *models.JiraSource, data map[string]int
 	var err error
 	// update fields from request body
 	err = mergeFieldsToJiraSource(jiraSource, data)
-	if err != nil {
-		return err
-	}
-
-	// Sensitive information is encrypted before storing in the database, and the original value needs to be cached here
-	BasicAuthEncodedOriginal := jiraSource.BasicAuthEncoded
-	jiraSource.BasicAuthEncoded, err = core.Encode(jiraSource.BasicAuthEncoded)
 	if err != nil {
 		return err
 	}
@@ -103,9 +90,6 @@ func refreshAndSaveJiraSource(jiraSource *models.JiraSource, data map[string]int
 			return err
 		}
 	}
-
-	// Since the sensitive information has been encrypted, considering that the front end needs the original data, the sensitive information is restored to the original data here.
-	jiraSource.BasicAuthEncoded = BasicAuthEncodedOriginal
 
 	return nil
 }

--- a/plugins/jira/models/jira_source.go
+++ b/plugins/jira/models/jira_source.go
@@ -1,7 +1,11 @@
 package models
 
 import (
+	"github.com/merico-dev/lake/logger"
 	"github.com/merico-dev/lake/models/common"
+	"github.com/merico-dev/lake/plugins/core"
+	"gorm.io/gorm"
+	"gorm.io/gorm/callbacks"
 )
 
 type JiraSource struct {
@@ -31,3 +35,42 @@ type JiraSourceDetail struct {
 	JiraSource
 	TypeMappings map[string]map[string]interface{} `json:"typeMappings"`
 }
+
+func (s *JiraSource) BeforeSave(tx *gorm.DB) error {
+	var err error
+	// Sensitive information is encrypted before storing in the database
+	s.BasicAuthEncoded, err = core.Encode(s.BasicAuthEncoded)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *JiraSource) AfterSave(tx *gorm.DB) error {
+	var err error
+	// Decrypt the sensitive information after saving to recover the original data
+	s.BasicAuthEncoded, err = core.Decode(s.BasicAuthEncoded)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *JiraSource) AfterFind(tx *gorm.DB) error {
+	var err error
+	// Decrypt the sensitive information after reading the data from the database
+	s.BasicAuthEncoded, err = core.Decode(s.BasicAuthEncoded)
+	if err != nil {
+		logger.Warn("Decrypt BasicAuthEncoded failed:", err)
+		s.BasicAuthEncoded = ""
+		return nil
+	}
+
+	return nil
+}
+
+var _ callbacks.BeforeSaveInterface = (*JiraSource)(nil)
+var _ callbacks.AfterSaveInterface = (*JiraSource)(nil)
+var _ callbacks.AfterFindInterface = (*JiraSource)(nil)

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -45,12 +45,6 @@ func NewJiraApiClientBySourceId(sourceId uint64) (*JiraApiClient, error) {
 		return nil, err
 	}
 
-	// Decrypt the sensitive information after reading the data from the database
-	jiraSource.BasicAuthEncoded, err = core.Decode(jiraSource.BasicAuthEncoded)
-	if err != nil {
-		return nil, err
-	}
-
 	return NewJiraApiClient(jiraSource.Endpoint, jiraSource.BasicAuthEncoded), nil
 }
 


### PR DESCRIPTION
# Summary
use hooks to handle encryption and decryption

### Key Points
- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Add BeforeSave and AfterSave hooks to handle the process of Jira sensitive information being stored in the database
Add AfterFind to handle the process of Jira sensitive information read from the database
When the decryption of sensitive information in Jira fails, it no longer returns an error, but prints the log and blanks the sensitive information

### Does this close any open issues?
Please mention the issues here.

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
