### PR TITLE
docs: update developer setup procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,16 @@
 # https://stackoverflow.com/questions/920413/make-error-missing-separator
 # https://tutorialedge.net/golang/makefiles-for-go-developers/
 
-hello:
-	echo "Hello"
-
 build-plugin:
 	@sh scripts/compile-plugins.sh
 
 build: build-plugin
 	go build -o bin/lake
 
-dev: build
-	bin/lake
-
 run:
 	go run main.go
+
+dev: build-plugin run
 
 configure:
 	docker-compose up config-ui
@@ -23,18 +19,8 @@ configure:
 configure-dev:
 	cd config-ui; npm install; npm start;
 
-compose:
-	docker-compose up -d grafana
-
-compose-down:
-	docker-compose down
-
 commit:
 	git cz
-
-install:
-	go clean --modcache
-	go get
 
 test: unit-test e2e-test models-test
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -273,10 +273,14 @@ GitHub | 概述，数据和指标，配置，API | [Link](plugins/github/README-
    cd lake
    ```
 
+2. 安装插件依赖
+
+   - [RefDiff](plugins/refdiff#development)
+
 2. 安装 go packages
 
     ```sh
-    make install
+	go get
     ```
 
 3. 将样本配置文件复制到新的本地文件
@@ -292,14 +296,11 @@ GitHub | 概述，数据和指标，配置，API | [Link](plugins/github/README-
     > 确保在此步骤之前 Docker 正在运行。
 
     ```sh
-    docker-compose up mysql grafana
+    docker-compose up -d mysql grafana
     ```
 
-6. 安装依赖
-   
-   - <a href="plugins/refdiff#install-libgit2" target="_blank">Libgit2</a>
 
-7. 在 2 个终端种分别以开发者模式运行 lake 和 config UI:
+6. 在 2 个终端种分别以开发者模式运行 lake 和 config UI:
 
     ```sh
     # run lake
@@ -308,17 +309,17 @@ GitHub | 概述，数据和指标，配置，API | [Link](plugins/github/README-
     make configure-dev
     ```
 
-8. 访问 config-ui `localhost:4000` 来配置 Dev Lake 数据源
+7. 访问 config-ui `localhost:4000` 来配置 Dev Lake 数据源
    >- 在 "Integration"页面上找到到所需的插件页面
    >- 你需要为你打算使用的插件输入必要的信息
    >- 请参考以下内容，以了解如何配置每个插件的更多细节
    >-> <a href="plugins/jira/README-zh-CN.md" target="_blank">Jira</a>
    >-> <a href="plugins/gitlab/README-zh-CN.md" target="_blank">GitLab</a>
-   >-> <a href="plugins/jenkins/README-zh-CN.md" target="_blank">Jenkins</a> 
+   >-> <a href="plugins/jenkins/README-zh-CN.md" target="_blank">Jenkins</a>
    >-> <a href="plugins/github/README-zh-CN.md" target="_blank">GitHub</a>
 
 
-9. 访问 `localhost:4000/create-pipeline`，创建 1个Pipeline run，并触发数据收集
+8. 访问 `localhost:4000/create-pipeline`，创建 1个Pipeline run，并触发数据收集
 
    Pipeline Runs 可以通过新的 "Create Run"界面启动。只需启用你希望运行的数据源，并指定数据收集的范围，比如Gitlab的项目ID和GitHub的仓库名称。
 
@@ -346,11 +347,11 @@ GitHub | 概述，数据和指标，配置，API | [Link](plugins/github/README-
    >     ]
    >   ]
    >   ```
-   
+
    请参考这篇 wiki [How to trigger data collection](https://github.com/merico-dev/lake/wiki/How-to-use-the-triggers-page).
 
 
-10. 在Grafana仪表板中实现数据的可视化
+9. 在Grafana仪表板中实现数据的可视化
 
     _从这里你可以看到丰富的图表，这些图表来自于收集和处理后的数据_
 

--- a/README.md
+++ b/README.md
@@ -262,9 +262,8 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
 
 #### Requirements
 
-- <a href="https://github.com/libgit2/libgit2#quick-start" target="_blank">Libgit2</a>
 - <a href="https://docs.docker.com/get-docker" target="_blank">Docker</a>
-- <a href="https://golang.org/doc/install" target="_blank">Golang</a>
+- <a href="https://golang.org/doc/install" target="_blank">Golang v1.17+</a>
 - Make
   - Mac (Already installed)
   - Windows: [Download](http://gnuwin32.sourceforge.net/packages/make.htm)
@@ -278,19 +277,24 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
    cd lake
    ```
 
-2. Install Go packages:
+2. Install dependencies for plugins:
+
+   - [RefDiff](plugins/refdiff#development)
+
+3. Install Go packages
 
     ```sh
-    make install
+	go get
     ```
 
-3. Copy the sample config file to new local file:
+4. Copy the sample config file to new local file:
 
     ```sh
     cp .env.example .env
     ```
 
-4. Update the following variables in the file `.env`:
+5. Update the following variables in the file `.env`:
+
     * `DB_URL`: Replace `mysql:3306` with `127.0.0.1:3306`
 
 5. Start the MySQL and Grafana containers:
@@ -298,13 +302,10 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
     > Make sure the Docker daemon is running before this step.
 
     ```sh
-    docker-compose up
+    docker-compose up -d mysql grafana
     ```
-6. Install required libraries
 
-   - <a href="plugins/refdiff#install-libgit2" target="_blank">Libgit2</a>
-
-7. Run lake and config UI in dev mode in two seperate terminals:
+6. Run lake and config UI in dev mode in two seperate terminals:
 
     ```sh
     # run lake
@@ -313,7 +314,7 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
     make configure-dev
     ```
 
-8. Visit config UI at `localhost:4000` to configure data sources.
+7. Visit config UI at `localhost:4000` to configure data sources.
    >- Navigate to desired plugins pages on the Integrations page
    >- You will need to enter the required information for the plugins you intend to use.
    >- Please reference the following for more details on how to configure each one:
@@ -324,7 +325,7 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
 
    >- Submit the form to update the values by clicking on the **Save Connection** button on each form page
 
-9. Visit `localhost:4000/create-pipeline` to RUN a Pipeline and trigger data collection.
+8. Visit `localhost:4000/create-pipeline` to RUN a Pipeline and trigger data collection.
 
 
    Pipelines Runs can be initiated by the new "Create Run" Interface. Simply enable the **Data Source Providers** you wish to run collection for, and specify the data you want to collect, for instance, **Project ID** for Gitlab and **Repository Name** for GitHub.
@@ -357,7 +358,7 @@ To synchronize data periodically, we provide [`lake-cli`](./cmd/lake-cli/README.
    Please refer to this wiki [How to trigger data collection](https://github.com/merico-dev/lake/wiki/How-to-use-the-triggers-page).
 
 
-10. Click *View Dashboards* button when done (username: `admin`, password: `admin`). The button is shown in the top left.
+9. Click *View Dashboards* button when done (username: `admin`, password: `admin`). The button is shown in the top left.
 <br>
 
 ****

--- a/plugins/gitextractor/README.md
+++ b/plugins/gitextractor/README.md
@@ -7,7 +7,7 @@ This plugin extract commits and references from a remote or local git repository
 
 1. Use the Git repo extractor to retrieve commit-and-branch-related data from your repo
 2. Use the GitHub plugin to retrieve Github-issue-and-pr-related data from your repo. NOTE: you can run only one the issue collection stage as described in the Github Plugin README.
-3. Use the RefDiff plugin to calculate version diff, which will be stored in refs_commits_diffs.
+3. Use the [RefDiff](../refdiff) plugin to calculate version diff, which will be stored in `refs_commits_diffs` table.
 
 ## Sample Request
 
@@ -38,3 +38,9 @@ curl --location --request POST 'localhost:8080/pipelines' \
 - `password`: optional, for cloning private repository using HTTP/HTTPS
 - `privateKey`: optional, for SSH cloning, base64 encoded `PEM` file
 - `passphrase`: optional, passphrase for the private key
+
+
+## Development
+
+This plugin depends on `libgit2`, you need to install version 1.3.0 in order to run and debug this plugin on your local
+machine. [Click here](../refdiff#Development) for a brief guide.

--- a/plugins/refdiff/README.md
+++ b/plugins/refdiff/README.md
@@ -57,7 +57,10 @@ curl -v -XPOST http://localhost:8080/pipelines --data @- <<'JSON'
 JSON
 ```
 
-## Install `libgit2`
+## Development
+
+This plugin depends on `libgit2`, you need to install version 1.3.0 in order to run and debug this plugin on your local
+machine.
 
 ### Ubuntu
 
@@ -86,13 +89,13 @@ make
 make install
 ```
 
-## Troubleshooting (MacOS)
+Troubleshooting (MacOS)
 
 Q: I got an error saying: `pkg-config: exec: "pkg-config": executable file not found in $PATH`
 
-A: 
+A:
 
-1. Make sure you have pkg-config installed: 
+1. Make sure you have pkg-config installed:
 
   `brew install pkg-config`
 


### PR DESCRIPTION
# Summary

  1. libgit2 installation should be placed before go pkg installation
  2. fix command that to bring up mysql/grafana
  3. remove useless/confusing make Target
  4. add link for `libgit2` installation to gitextractor


### Key Points

- [ ] This is a breaking change
- [x] New or existing documentation is updated
