### PR TITLE
fix: github reporting 'invalid token' for invalid endpoint url

### DIFF
--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -3,8 +3,8 @@ package api
 import (
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/merico-dev/lake/logger"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/tasks"
 )
@@ -24,6 +24,7 @@ type PublicEmail struct {
 POST /plugins/github/test
 */
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
+	// process input
 	ValidationResult := core.ValidateParams(input, []string{"endpoint", "auth"})
 	if !ValidationResult.Success {
 		return &core.ApiResourceOutput{Body: ValidationResult}, nil
@@ -32,6 +33,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 	auth := input.Body["auth"].(string)
 	tokens := strings.Split(auth, ",")
 
+	// verify multiple token in parallel
 	// PLEASE NOTE: This works because GitHub API Client rotates tokens on each request
 	results := make(chan error)
 	for i := 0; i < len(tokens); i++ {
@@ -39,24 +41,23 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		i := i
 		go func() {
 			githubApiClient := tasks.CreateApiClient(endpoint, []string{token}, nil)
+			githubApiClient.SetTimeout(3 * time.Second)
 			res, err := githubApiClient.Get("user/public_emails", nil, nil)
-			if err != nil || res.StatusCode != 200 {
-				logger.Error("Error: ", err)
-				results <- fmt.Errorf("invalid token #%v %s", i, token)
+			if err != nil {
+				results <- fmt.Errorf("verify token failed for #%v %s %w", i, token, err)
 				return
 			}
 			githubApiResponse := &ApiUserPublicEmailResponse{}
 			err = core.UnmarshalResponse(res, githubApiResponse)
 			if err != nil {
-				logger.Error("Error: ", err)
-				results <- fmt.Errorf("invalid token #%v %s", i, token)
+				results <- fmt.Errorf("invalid token #%v %s %w", i, token, err)
 			} else {
 				results <- nil
 			}
 		}()
 	}
 
-	println("length of tokens", len(tokens))
+	// collect verification results
 	msgs := make([]string, 0)
 	i := 0
 	for err := range results {
@@ -68,5 +69,12 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 			close(results)
 		}
 	}
-	return &core.ApiResourceOutput{Body: core.TestResult{Success: len(msgs) == 0, Message: strings.Join(msgs, "\n")}}, nil
+
+	// output
+	return &core.ApiResourceOutput{
+		Body: core.TestResult{
+			Success: len(msgs) == 0,
+			Message: strings.Join(msgs, "\n"),
+		},
+	}, nil
 }

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -50,7 +50,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 			githubApiResponse := &ApiUserPublicEmailResponse{}
 			err = core.UnmarshalResponse(res, githubApiResponse)
 			if err != nil {
-				results <- fmt.Errorf("invalid token #%v %s %w", i, token, err)
+				results <- fmt.Errorf("verify token failed for #%v %s %w", i, token, err)
 			} else {
 				results <- nil
 			}


### PR DESCRIPTION
# Summary

To fix #1216


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
report invalid token for invalid token
![image](https://user-images.githubusercontent.com/61080/154448963-b3b73938-0218-4077-bb93-f9cfb9ca0789.png)

report timeout for invalid endpoint
![image](https://user-images.githubusercontent.com/61080/154448860-84d2dfea-a4ee-4f37-a83c-c9821eaa1c68.png)

### Does this close any open issues?
Closes #1216

### Current Behavior
reporting 'invalid token' for both invalid endpoint/token


### New Behavior
added more specific message to help user understand the situation in depth
