### PR TITLE
fix(jenkins): fix table definition

### DIFF
--- a/plugins/jenkins/models/jenkins_build.go
+++ b/plugins/jenkins/models/jenkins_build.go
@@ -10,7 +10,7 @@ type JenkinsBuildProps struct {
 	Duration          float64 // build time
 	DisplayName       string  // "#7"
 	EstimatedDuration float64
-	Number            int64 `gorm:"primaryKey"`
+	Number            int64
 	Result            string
 	Timestamp         int64     // start time
 	StartTime         time.Time // convered by timestamp
@@ -20,6 +20,13 @@ type JenkinsBuildProps struct {
 // JenkinsBuild db entity for jenkins build
 type JenkinsBuild struct {
 	common.NoPKModel
-	JobName string `gorm:"primaryKey;type:varchar(255)"`
-	JenkinsBuildProps
+	JobName           string  `gorm:"primaryKey;type:varchar(255)"`
+	Duration          float64 // build time
+	DisplayName       string  // "#7"
+	EstimatedDuration float64
+	Number            int64 `gorm:"primaryKey;type:INT(10) UNSIGNED NOT NULL"`
+	Result            string
+	Timestamp         int64     // start time
+	StartTime         time.Time // convered by timestamp
+	CommitSha         string
 }

--- a/plugins/jenkins/tasks/jenkins_build_collector.go
+++ b/plugins/jenkins/tasks/jenkins_build_collector.go
@@ -68,17 +68,15 @@ func CollectBuilds(apiClient *JenkinsApiClient, scheduler *utils.WorkerScheduler
 			var jenkinsBuilds = make([]models.JenkinsBuild, len(filteredData))
 			for i, v := range filteredData {
 				var jenkinsBuild = models.JenkinsBuild{
-					JobName: jobCtx.Name,
-					JenkinsBuildProps: models.JenkinsBuildProps{
-						Duration:          v.Duration,
-						DisplayName:       v.DisplayName,
-						EstimatedDuration: v.EstimatedDuration,
-						Number:            v.Number,
-						Result:            v.Result,
-						Timestamp:         v.Timestamp,
-						StartTime:         time.Unix(v.Timestamp/1000, 0),
-						CommitSha:         v.CommitSha,
-					},
+					JobName:           jobCtx.Name,
+					Duration:          v.Duration,
+					DisplayName:       v.DisplayName,
+					EstimatedDuration: v.EstimatedDuration,
+					Number:            v.Number,
+					Result:            v.Result,
+					Timestamp:         v.Timestamp,
+					StartTime:         time.Unix(v.Timestamp/1000, 0),
+					CommitSha:         v.CommitSha,
 				}
 				jenkinsBuilds[i] = jenkinsBuild
 			}


### PR DESCRIPTION
# Summary

Changed jenkins_builds definition
closes #1217 

Gorm set primaryKey to autoincrement by default, we have to set it to sql type manually