### PR TITLE
fix(refdiff): correct progress

### DIFF
--- a/plugins/refdiff/refdiff.go
+++ b/plugins/refdiff/refdiff.go
@@ -112,7 +112,7 @@ func (rd RefDiff) Execute(options map[string]interface{}, progress chan<- float3
 	// calculate diffs for commits pairs and store them into database
 	commitsDiff := &code.RefsCommitsDiff{}
 	ancestors := cayley.StartMorphism().Out(quad.String("childOf"))
-	lenCommitPairs := len(commitPairs)
+	lenCommitPairs := float32(len(commitPairs))
 	for i, pair := range commitPairs {
 		// ref might advance, keep commit sha for debugging
 		commitsDiff.NewRefCommitSha = pair[0]
@@ -186,7 +186,7 @@ func (rd RefDiff) Execute(options map[string]interface{}, progress chan<- float3
 			commitsDiff.OldRefCommitSha,
 		))
 		// calculate progress after conversion
-		progress <- float32((i + 1) / lenCommitPairs)
+		progress <- float32(i+1) / lenCommitPairs
 	}
 
 	return nil


### PR DESCRIPTION
# Summary

Closes #1234

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Fix refdiff progress

### Does this close any open issues?
#1234 

### Current Behavior
Right now the progress always shows zero until 

### New Behavior
The progress shows correctly now

### Screenshots
<img width="117" alt="image" src="https://user-images.githubusercontent.com/39366025/154630038-1e3176a4-1916-47fa-9c22-f0fd91656aa5.png">


