### PR TITLE
refactor(github): improve github collection performance

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,9 @@
 package errors
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type Error struct {
 	Status  int
@@ -23,3 +26,4 @@ func NewError(status int, message string) *Error {
 }
 
 var InternalError = NewError(http.StatusInternalServerError, "Server Internal Error")
+var TaskCanceled = fmt.Errorf("task got canceled")

--- a/models/domainlayer/code/pull_request_issue.go
+++ b/models/domainlayer/code/pull_request_issue.go
@@ -1,6 +1,0 @@
-package code
-
-type PullRequestIssue struct {
-	PullRequestId string `json:"id" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
-	IssueId       string `gorm:"primaryKey"`
-}

--- a/models/domainlayer/code/pull_request_issue.go
+++ b/models/domainlayer/code/pull_request_issue.go
@@ -1,0 +1,6 @@
+package code
+
+type PullRequestIssue struct {
+	PullRequestId string `json:"id" gorm:"primaryKey;type:varchar(255);comment:This key is generated based on details from the original plugin"` // format: <Plugin>:<Entity>:<PK0>:<PK1>
+	IssueId       string `gorm:"primaryKey"`
+}

--- a/plugins/ae/tasks/ae_api_client.go
+++ b/plugins/ae/tasks/ae_api_client.go
@@ -87,6 +87,7 @@ func CreateApiClient(ctx context.Context) *AEApiClient {
 		nil,
 		30*time.Second,
 		3,
+		nil,
 	)
 	aeApiClient.SetBeforeFunction(aeApiClient.beforeRequest)
 	aeApiClient.SetContext(ctx)

--- a/plugins/ae/tasks/ae_commits_converter.go
+++ b/plugins/ae/tasks/ae_commits_converter.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	aeModels "github.com/merico-dev/lake/plugins/ae/models"
-	"github.com/merico-dev/lake/plugins/core"
 )
 
 // NOTE: This only works on Commits in the Domain layer. You need to run Github or Gitlab collection and Domain layer enrichemnt first.
@@ -26,7 +26,7 @@ func ConvertCommits(ctx context.Context) error {
 		// we do a non-blocking checking, this should be applied to all converters from all plugins
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		// uncomment following line if you want to test out canceling feature for this task

--- a/plugins/core/errors.go
+++ b/plugins/core/errors.go
@@ -1,5 +1,0 @@
-package core
-
-import "fmt"
-
-var TaskCanceled = fmt.Errorf("task got canceled")

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -41,7 +41,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		token := tokens[i]
 		i := i
 		go func() {
-			githubApiClient := tasks.CreateApiClient(endpoint, []string{token}, nil)
+			githubApiClient := tasks.NewGithubApiClient(endpoint, []string{token}, nil)
 			githubApiClient.SetTimeout(3 * time.Second)
 			if proxy != "" {
 				err := githubApiClient.SetProxy(proxy)

--- a/plugins/github/api/github_connection.go
+++ b/plugins/github/api/github_connection.go
@@ -41,7 +41,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		token := tokens[i]
 		i := i
 		go func() {
-			githubApiClient := tasks.NewGithubApiClient(endpoint, []string{token}, nil)
+			githubApiClient := tasks.NewGithubApiClient(endpoint, []string{token}, nil, nil)
 			githubApiClient.SetTimeout(3 * time.Second)
 			if proxy != "" {
 				err := githubApiClient.SetProxy(proxy)

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -105,7 +105,7 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	endpoint := config.V.GetString("GITHUB_ENDPOINT")
 	tokens := strings.Split(config.V.GetString("GITHUB_AUTH"), ",")
 	// TODO: add endpoind, auth validation
-	apiClient := tasks.CreateApiClient(endpoint, tokens, ctx)
+	apiClient := tasks.NewGithubApiClient(endpoint, tokens, ctx)
 	err = apiClient.SetProxy(config.V.GetString("GITHUB_PROXY"))
 	if err != nil {
 		return err
@@ -398,7 +398,7 @@ func main() {
 	endpoint := config.V.GetString("GITHUB_ENDPOINT")
 	configTokensString := config.V.GetString("GITHUB_AUTH")
 	tokens := strings.Split(configTokensString, ",")
-	githubApiClient := tasks.CreateApiClient(endpoint, tokens, nil)
+	githubApiClient := tasks.NewGithubApiClient(endpoint, tokens, nil)
 	_ = githubApiClient.SetProxy(config.V.GetString("GITHUB_PROXY"))
 	_, collectRepoErr := tasks.CollectRepository(owner, repo, githubApiClient)
 	if collectRepoErr != nil {
@@ -416,7 +416,7 @@ func main() {
 					"collectIssues",
 					"collectPullRequests",
 					//"collectIssueEvents",
-					//"collectIssueComments",
+					"collectIssueComments",
 					//"collectPullRequestReviews",
 					//"collectPullRequestCommits",
 					//"collectPullRequestComments",

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -21,7 +21,7 @@ type GithubApiClient struct {
 	core.ApiClient
 }
 
-func CreateApiClient(endpoint string, tokens []string, ctx context.Context) *GithubApiClient {
+func NewGithubApiClient(endpoint string, tokens []string, ctx context.Context) *GithubApiClient {
 	githubApiClient := &GithubApiClient{}
 	githubApiClient.tokenIndex = 0
 	githubApiClient.tokens = tokens
@@ -45,64 +45,54 @@ func CreateApiClient(endpoint string, tokens []string, ctx context.Context) *Git
 }
 
 type GithubPaginationHandler func(res *http.Response) error
+type GithubSearchPaginationHandler func(res *http.Response) (int, error)
 
 // run all requests in an Ants worker pool
 // conc - number of concurent requests you want to run
-func (githubApiClient *GithubApiClient) FetchWithPaginationAnts(path string, queryParams *url.Values, pageSize int, conc int, scheduler *utils.WorkerScheduler, handler GithubPaginationHandler) error {
+func (githubApiClient *GithubApiClient) FetchPages(path string, queryParams *url.Values, pageSize int,
+	scheduler *utils.WorkerScheduler, handler GithubPaginationHandler) error {
 	if queryParams == nil {
 		queryParams = &url.Values{}
 	}
-	return githubApiClient.RunConcurrently(path, queryParams, pageSize, conc, scheduler, handler)
-}
 
-// This method exists in the case where we do not know how many pages of data we have to fetch
-// This loops through the data in chunks of `conc` and if there is any request in there with no data returned, we assume we are at the end of the data required to fetch
-// This is needed since we do not want to make a request to get the paging details first since the rate limit for github is so low
-func (githubApiClient *GithubApiClient) RunConcurrently(path string, queryParams *url.Values, pageSize int, conc int, scheduler *utils.WorkerScheduler, handler GithubPaginationHandler) error {
-
-	if conc == 0 {
-		logger.Error("you must send a conc count to RunConcurrently()", true)
+	queryParams.Set("page", strconv.Itoa(1))
+	queryParams.Set("per_page", strconv.Itoa(pageSize))
+	res, err := githubApiClient.Get(path, queryParams, nil)
+	if err != nil {
+		return err
 	}
+	handlerErr := handler(res)
+	if handlerErr != nil {
+		return handlerErr
+	}
+	linkHeader := res.Header.Get("Link")
+	if linkHeader == "" {
+		return nil
+	}
+	paginationInfo2, getPagingErr := githubUtils.GetPagingFromLinkHeader(linkHeader)
+	if getPagingErr != nil {
+		logger.Info("GetPagingFromLinkHeader err: ", getPagingErr)
+	}
+	pages := paginationInfo2.Last
 
-	// How many requests would you like to send at once in chunks
-	step := 0
-	isContinue := true
-	for isContinue {
-		for i := conc; i > 0; i-- {
-			page := step*conc + i
-			err := scheduler.Submit(func() error {
-				queryParams.Set("page", strconv.Itoa(page))
-				queryParams.Set("per_page", strconv.Itoa(pageSize))
-				res, err := githubApiClient.Get(path, queryParams, nil)
-				if err != nil {
-					isContinue = false
-					return err
-				}
-				linkHeader := res.Header.Get("Link")
-				paginationInfo2, getPagingErr := githubUtils.GetPagingFromLinkHeader(linkHeader)
-				if getPagingErr != nil {
-					logger.Info("GetPagingFromLinkHeader err: ", getPagingErr)
-				}
-				handlerErr := handler(res)
-				if handlerErr != nil {
-					isContinue = false
-					return handlerErr
-				}
-
-				// only send message to channel if I'm the last page
-				if page%conc == 0 {
-					if paginationInfo2.Next == 1 {
-						fmt.Println(page, "has no next page")
-						isContinue = false
-					}
-				}
-				return nil
-			})
+	for i := 2; i <= pages; i++ {
+		page := i
+		err = scheduler.Submit(func() error {
+			queryParams.Set("page", strconv.Itoa(page))
+			queryParams.Set("per_page", strconv.Itoa(pageSize))
+			res, err := githubApiClient.Get(path, queryParams, nil)
 			if err != nil {
 				return err
 			}
+			handlerErr = handler(res)
+			if handlerErr != nil {
+				return handlerErr
+			}
+			return nil
+		})
+		if err != nil {
+			return err
 		}
-		step += 1
 	}
 
 	scheduler.WaitUntilFinish()

--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -77,24 +77,14 @@ func (githubApiClient *GithubApiClient) FetchPages(path string, queryParams *url
 
 	for i := 2; i <= pages; i++ {
 		page := i
-		err = githubApiClient.Scheduler.Submit(func() error {
-			queryParams.Set("page", strconv.Itoa(page))
-			queryParams.Set("per_page", strconv.Itoa(pageSize))
-			res, err := githubApiClient.Get(path, queryParams, nil)
-			if err != nil {
-				return err
-			}
-			handlerErr = handler(res)
-			if handlerErr != nil {
-				return handlerErr
-			}
-			return nil
-		})
+		queryParams.Set("page", strconv.Itoa(page))
+		queryParams.Set("per_page", strconv.Itoa(pageSize))
+		err = githubApiClient.GetAsync(path, queryParams, handler)
 		if err != nil {
 			return err
 		}
 	}
 
-	githubApiClient.Scheduler.WaitUntilFinish()
+	githubApiClient.WaitOtherGoroutines()
 	return nil
 }

--- a/plugins/github/tasks/github_commit_collector.go
+++ b/plugins/github/tasks/github_commit_collector.go
@@ -45,7 +45,7 @@ type ApiSingleCommitResponse struct {
 
 func CollectCommits(owner string, repo string, repoId int, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repo)
-	return apiClient.FetchWithPaginationAnts(getUrl, nil, 100, 20, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_commit_collector.go
+++ b/plugins/github/tasks/github_commit_collector.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -115,9 +116,14 @@ func CollectCommitsStat(
 	owner string,
 	repo string,
 	repoId int,
-	scheduler *utils.WorkerScheduler,
 	apiClient *GithubApiClient,
+	rateLimitPerSecondInt int,
+	ctx context.Context,
 ) error {
+	scheduler, err := utils.NewWorkerScheduler(rateLimitPerSecondInt*2, rateLimitPerSecondInt, ctx)
+	if err != nil {
+		return err
+	}
 	cursor, err := lakeModels.Db.Table("github_commits gc").
 		Joins(`left join github_repo_commits grc on (
 			grc.commit_sha = gc.sha
@@ -139,7 +145,7 @@ func CollectCommitsStat(
 		}
 		err = scheduler.Submit(func() error {
 			// This call is to update the details of the individual pull request with additions / deletions / etc.
-			err := CollectCommit(owner, repo, repoId, commit, apiClient)
+			err := CollectCommit(owner, repo, repoId, commit, apiClient, ctx)
 			if err != nil {
 				return err
 			}
@@ -161,6 +167,7 @@ func CollectCommit(
 	repoId int,
 	commit *models.GithubCommit,
 	apiClient *GithubApiClient,
+	ctx context.Context,
 ) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits/%v", owner, repo, commit.Sha)
 	res, getErr := apiClient.Get(getUrl, nil, nil)

--- a/plugins/github/tasks/github_commit_collector.go
+++ b/plugins/github/tasks/github_commit_collector.go
@@ -43,9 +43,9 @@ type ApiSingleCommitResponse struct {
 	}
 }
 
-func CollectCommits(owner string, repo string, repoId int, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func CollectCommits(owner string, repo string, repoId int, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/commits", owner, repo)
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiCommitsResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_commit_converter.go
+++ b/plugins/github/tasks/github_commit_converter.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
-	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
@@ -35,7 +35,7 @@ func ConvertCommits(githubRepoId int, ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubCommit)

--- a/plugins/github/tasks/github_issue_collector.go
+++ b/plugins/github/tasks/github_issue_collector.go
@@ -9,7 +9,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -40,11 +39,11 @@ type IssuesResponse struct {
 	GithubUpdatedAt core.Iso8601Time  `json:"updated_at"`
 }
 
-func CollectIssues(owner string, repo string, repoId int, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func CollectIssues(owner string, repo string, repoId int, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	queryParams := &url.Values{}
 	queryParams.Set("state", "all")
-	return apiClient.FetchPages(getUrl, queryParams, 100, scheduler,
+	return apiClient.FetchPages(getUrl, queryParams, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssuesResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_issue_collector.go
+++ b/plugins/github/tasks/github_issue_collector.go
@@ -44,7 +44,7 @@ func CollectIssues(owner string, repo string, repoId int, scheduler *utils.Worke
 	getUrl := fmt.Sprintf("repos/%v/%v/issues", owner, repo)
 	queryParams := &url.Values{}
 	queryParams.Set("state", "all")
-	return apiClient.FetchWithPaginationAnts(getUrl, queryParams, 100, 20, scheduler,
+	return apiClient.FetchPages(getUrl, queryParams, 100, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssuesResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_issue_comments_collector.go
+++ b/plugins/github/tasks/github_issue_comments_collector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
 	githubUtils "github.com/merico-dev/lake/plugins/github/utils"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 	"net/http"
 )
@@ -24,8 +23,8 @@ type IssueComment struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectIssueComments(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
-	commentsErr := processCommentsCollection(owner, repo, scheduler, apiClient)
+func CollectIssueComments(owner string, repo string, apiClient *GithubApiClient) error {
+	commentsErr := processCommentsCollection(owner, repo, apiClient)
 	if commentsErr != nil {
 		logger.Error("Could not collect issue Comments", commentsErr)
 		return commentsErr
@@ -35,11 +34,10 @@ func CollectIssueComments(owner string, repo string, scheduler *utils.WorkerSche
 func processCommentsCollection(
 	owner string,
 	repo string,
-	scheduler *utils.WorkerScheduler,
 	apiClient *GithubApiClient,
 ) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueCommentResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_issue_comments_collector.go
+++ b/plugins/github/tasks/github_issue_comments_collector.go
@@ -2,14 +2,14 @@ package tasks
 
 import (
 	"fmt"
-	"net/http"
-
 	"github.com/merico-dev/lake/logger"
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
+	githubUtils "github.com/merico-dev/lake/plugins/github/utils"
 	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
+	"net/http"
 )
 
 type ApiIssueCommentResponse []IssueComment
@@ -20,38 +20,26 @@ type IssueComment struct {
 	User     struct {
 		Login string
 	}
+	IssueUrl        string           `json:"issue_url"`
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
 func CollectIssueComments(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
-	githubIssue := &models.GithubIssue{}
-	cursor, err := lakeModels.Db.Model(githubIssue).Rows()
-	if err != nil {
-		return err
-	}
-	defer cursor.Close()
-	for cursor.Next() {
-		err = lakeModels.Db.ScanRows(cursor, githubIssue)
-		if err != nil {
-			return err
-		}
-		commentsErr := processCommentsCollection(owner, repo, githubIssue, scheduler, apiClient)
-		if commentsErr != nil {
-			logger.Error("Could not collect issue Comments", commentsErr)
-			return commentsErr
-		}
+	commentsErr := processCommentsCollection(owner, repo, scheduler, apiClient)
+	if commentsErr != nil {
+		logger.Error("Could not collect issue Comments", commentsErr)
+		return commentsErr
 	}
 	return nil
 }
 func processCommentsCollection(
 	owner string,
 	repo string,
-	issue *models.GithubIssue,
 	scheduler *utils.WorkerScheduler,
 	apiClient *GithubApiClient,
 ) error {
-	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repo, issue.Number)
-	return apiClient.FetchWithPaginationAnts(getUrl, nil, 100, 1, scheduler,
+	getUrl := fmt.Sprintf("repos/%v/%v/issues/comments", owner, repo)
+	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueCommentResponse{}
 			if res.StatusCode == 200 {
@@ -61,7 +49,7 @@ func processCommentsCollection(
 					return err
 				}
 				for _, comment := range *githubApiResponse {
-					githubComment, err := convertGithubComment(&comment, issue.GithubId)
+					githubComment, err := convertGithubComment(&comment)
 					if err != nil {
 						return err
 					}
@@ -79,7 +67,11 @@ func processCommentsCollection(
 		})
 }
 
-func convertGithubComment(comment *IssueComment, issueId int) (*models.GithubIssueComment, error) {
+func convertGithubComment(comment *IssueComment) (*models.GithubIssueComment, error) {
+	issueId, err := githubUtils.GetIssueIdByIssueUrl(comment.IssueUrl)
+	if err != nil {
+		return nil, err
+	}
 	githubComment := &models.GithubIssueComment{
 		GithubId:        comment.GithubId,
 		IssueId:         issueId,

--- a/plugins/github/tasks/github_issue_converter.go
+++ b/plugins/github/tasks/github_issue_converter.go
@@ -2,13 +2,13 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 	"strconv"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -30,7 +30,7 @@ func ConvertIssues(repoId int, ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubIssue)

--- a/plugins/github/tasks/github_issue_enricher.go
+++ b/plugins/github/tasks/github_issue_enricher.go
@@ -2,12 +2,12 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 	"regexp"
 
 	"github.com/merico-dev/lake/config"
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 )
 
@@ -56,7 +56,7 @@ func EnrichGithubIssues(ctx context.Context) (err error) {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubIssue)

--- a/plugins/github/tasks/github_issue_events_collector.go
+++ b/plugins/github/tasks/github_issue_events_collector.go
@@ -8,7 +8,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -26,9 +25,9 @@ type IssueEvent struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectIssueEvents(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func CollectIssueEvents(owner string, repo string, apiClient *GithubApiClient) error {
 
-	eventsErr := processEventsCollection(owner, repo, scheduler, apiClient)
+	eventsErr := processEventsCollection(owner, repo, apiClient)
 	if eventsErr != nil {
 		logger.Error("Could not collect issue events", eventsErr)
 		return eventsErr
@@ -36,9 +35,9 @@ func CollectIssueEvents(owner string, repo string, scheduler *utils.WorkerSchedu
 	return nil
 }
 
-func processEventsCollection(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func processEventsCollection(owner string, repo string, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/events", owner, repo)
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiIssueEventResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_issue_labels_convertor.go
+++ b/plugins/github/tasks/github_issue_labels_convertor.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func ConvertIssueLabels(ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubIssueLabel)

--- a/plugins/github/tasks/github_note_converter.go
+++ b/plugins/github/tasks/github_note_converter.go
@@ -2,12 +2,12 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -23,7 +23,7 @@ func ConvertNotes(ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubPrComment)

--- a/plugins/github/tasks/github_pull_request_collector.go
+++ b/plugins/github/tasks/github_pull_request_collector.go
@@ -45,7 +45,7 @@ func CollectPullRequests(
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	queryParams := &url.Values{}
 	queryParams.Set("state", "all")
-	return apiClient.FetchPages(getUrl, queryParams, 100, scheduler,
+	return apiClient.FetchPages(getUrl, queryParams, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)

--- a/plugins/github/tasks/github_pull_request_collector.go
+++ b/plugins/github/tasks/github_pull_request_collector.go
@@ -9,7 +9,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -39,7 +38,6 @@ func CollectPullRequests(
 	owner string,
 	repo string,
 	repoId int,
-	scheduler *utils.WorkerScheduler,
 	apiClient *GithubApiClient,
 ) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)

--- a/plugins/github/tasks/github_pull_request_collector.go
+++ b/plugins/github/tasks/github_pull_request_collector.go
@@ -45,7 +45,7 @@ func CollectPullRequests(
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls", owner, repo)
 	queryParams := &url.Values{}
 	queryParams.Set("state", "all")
-	return apiClient.FetchWithPaginationAnts(getUrl, queryParams, 100, 20, scheduler,
+	return apiClient.FetchPages(getUrl, queryParams, 100, scheduler,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestResponse{}
 			err := core.UnmarshalResponse(res, githubApiResponse)
@@ -88,6 +88,7 @@ func CollectPullRequests(
 				}).Create(&githubPull).Error
 				if err != nil {
 					logger.Error("Could not upsert: ", err)
+					return err
 				}
 			}
 			return nil

--- a/plugins/github/tasks/github_pull_request_comments_collector.go
+++ b/plugins/github/tasks/github_pull_request_comments_collector.go
@@ -35,10 +35,8 @@ func CollectPullRequestComments(owner string, repo string, scheduler *utils.Work
 		if err != nil {
 			return err
 		}
-		schedulerNew := scheduler
-
 		err = scheduler.Submit(func() error {
-			commentsErr := processPullRequestCommentsCollection(owner, repo, githubPr, schedulerNew, apiClient)
+			commentsErr := processPullRequestCommentsCollection(owner, repo, githubPr, apiClient)
 			if commentsErr != nil {
 				logger.Error("Could not collect PR Comments", commentsErr)
 				return commentsErr
@@ -54,9 +52,9 @@ func CollectPullRequestComments(owner string, repo string, scheduler *utils.Work
 	return nil
 }
 
-func processPullRequestCommentsCollection(owner string, repo string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func processPullRequestCommentsCollection(owner string, repo string, pull *models.GithubPullRequest, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/issues/%v/comments", owner, repo, pull.Number)
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommentResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_comments_collector.go
+++ b/plugins/github/tasks/github_pull_request_comments_collector.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -23,7 +24,11 @@ type PullRequestComment struct {
 	GithubCreatedAt core.Iso8601Time `json:"created_at"`
 }
 
-func CollectPullRequestComments(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func CollectPullRequestComments(owner string, repo string, apiClient *GithubApiClient, rateLimitPerSecondInt int, ctx context.Context) error {
+	scheduler, err := utils.NewWorkerScheduler(rateLimitPerSecondInt*2, rateLimitPerSecondInt, ctx)
+	if err != nil {
+		return err
+	}
 	cursor, err := lakeModels.Db.Model(&models.GithubPullRequest{}).Rows()
 	if err != nil {
 		return err

--- a/plugins/github/tasks/github_pull_request_commit_convertor.go
+++ b/plugins/github/tasks/github_pull_request_commit_convertor.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
-	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -27,7 +27,7 @@ func PrCommitConvertor(ctx context.Context) (err error) {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubPullRequestCommit)

--- a/plugins/github/tasks/github_pull_request_commits_collector.go
+++ b/plugins/github/tasks/github_pull_request_commits_collector.go
@@ -46,7 +46,7 @@ func CollectPullRequestCommits(owner string, repo string, scheduler *utils.Worke
 			return err
 		}
 		err = scheduler.Submit(func() error {
-			processErr := ProcessCollection(owner, repo, githubPr, scheduler, apiClient)
+			processErr := ProcessCollection(owner, repo, githubPr, apiClient)
 			if processErr != nil {
 				logger.Error("Could not collect PR Commits", err)
 				return processErr
@@ -74,7 +74,7 @@ func convertPullRequestCommit(prCommit *PrCommitsResponse) (*models.GithubCommit
 	return githubCommit, nil
 }
 
-func ProcessCollection(owner string, repo string, pr *models.GithubPullRequest, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func ProcessCollection(owner string, repo string, pr *models.GithubPullRequest, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/commits", owner, repo, pr.Number)
 	err := lakeModels.Db.Where("pull_request_id = ?",
 		pr.GithubId).Delete(&models.GithubPullRequestCommit{}).Error
@@ -82,7 +82,7 @@ func ProcessCollection(owner string, repo string, pr *models.GithubPullRequest, 
 		logger.Error("Could not delete: ", err)
 		return err
 	}
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestCommitResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_pull_request_converter.go
+++ b/plugins/github/tasks/github_pull_request_converter.go
@@ -2,12 +2,12 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -25,7 +25,7 @@ func ConvertPullRequests(ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, pr)

--- a/plugins/github/tasks/github_pull_request_enricher.go
+++ b/plugins/github/tasks/github_pull_request_enricher.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 	"regexp"
 
 	"github.com/merico-dev/lake/config"
 	lakeModels "github.com/merico-dev/lake/models"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 )
 
@@ -37,7 +37,7 @@ func EnrichGithubPullRequests(repoId int, ctx context.Context) (err error) {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubPullRequst)

--- a/plugins/github/tasks/github_pull_request_reviewer_collector.go
+++ b/plugins/github/tasks/github_pull_request_reviewer_collector.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -25,7 +26,11 @@ type PullRequestReview struct {
 	SubmittedAt core.Iso8601Time `json:"submitted_at"`
 }
 
-func CollectPullRequestReviews(owner string, repo string, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func CollectPullRequestReviews(owner string, repo string, apiClient *GithubApiClient, rateLimitPerSecondInt int, ctx context.Context) error {
+	scheduler, err := utils.NewWorkerScheduler(rateLimitPerSecondInt*2, rateLimitPerSecondInt, ctx)
+	if err != nil {
+		return err
+	}
 	cursor, err := lakeModels.Db.Model(&models.GithubPullRequest{}).Rows()
 	if err != nil {
 		return nil

--- a/plugins/github/tasks/github_pull_request_reviewer_collector.go
+++ b/plugins/github/tasks/github_pull_request_reviewer_collector.go
@@ -38,10 +38,8 @@ func CollectPullRequestReviews(owner string, repo string, scheduler *utils.Worke
 		if err != nil {
 			return nil
 		}
-		schedulerNew := scheduler
-
 		err = scheduler.Submit(func() error {
-			reviewErr := processPullRequestReviewsCollection(owner, repo, githubPr, schedulerNew, apiClient)
+			reviewErr := processPullRequestReviewsCollection(owner, repo, githubPr, apiClient)
 			if reviewErr != nil {
 				logger.Error("Could not collect PR Reviews", reviewErr)
 				return reviewErr
@@ -56,9 +54,9 @@ func CollectPullRequestReviews(owner string, repo string, scheduler *utils.Worke
 
 	return nil
 }
-func processPullRequestReviewsCollection(owner string, repo string, pull *models.GithubPullRequest, scheduler *utils.WorkerScheduler, apiClient *GithubApiClient) error {
+func processPullRequestReviewsCollection(owner string, repo string, pull *models.GithubPullRequest, apiClient *GithubApiClient) error {
 	getUrl := fmt.Sprintf("repos/%v/%v/pulls/%v/reviews", owner, repo, pull.Number)
-	return apiClient.FetchPages(getUrl, nil, 100, scheduler,
+	return apiClient.FetchPages(getUrl, nil, 100,
 		func(res *http.Response) error {
 			githubApiResponse := &ApiPullRequestReviewResponse{}
 			if res.StatusCode == 200 {

--- a/plugins/github/tasks/github_repo_converter.go
+++ b/plugins/github/tasks/github_repo_converter.go
@@ -3,13 +3,13 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer"
 	"github.com/merico-dev/lake/models/domainlayer/code"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/ticket"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -28,7 +28,7 @@ func ConvertRepos(ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubRepository)

--- a/plugins/github/tasks/github_user_converter.go
+++ b/plugins/github/tasks/github_user_converter.go
@@ -2,11 +2,11 @@ package tasks
 
 import (
 	"context"
+	"github.com/merico-dev/lake/errors"
 
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/models/domainlayer/user"
-	"github.com/merico-dev/lake/plugins/core"
 	githubModels "github.com/merico-dev/lake/plugins/github/models"
 	"gorm.io/gorm/clause"
 )
@@ -26,7 +26,7 @@ func ConvertUsers(ctx context.Context) error {
 	for cursor.Next() {
 		select {
 		case <-ctx.Done():
-			return core.TaskCanceled
+			return errors.TaskCanceled
 		default:
 		}
 		err = lakeModels.Db.ScanRows(cursor, githubUser)

--- a/plugins/github/utils/utils.go
+++ b/plugins/github/utils/utils.go
@@ -113,3 +113,13 @@ func GetPagingFromLinkHeader(link string) (PagingInfo, error) {
 		return result, errors.New("the link string provided is invalid. There is likely no next page of data to fetch")
 	}
 }
+
+func GetIssueIdByIssueUrl(s string) (int, error) {
+	regex := regexp.MustCompile(`.*/issues/(\d+)`)
+	groups := regex.FindStringSubmatch(s)
+	if len(groups) > 0 {
+		return strconv.Atoi(groups[1])
+	} else {
+		return 0, errors.New("invalid issue url")
+	}
+}

--- a/plugins/github/utils/utils_test.go
+++ b/plugins/github/utils/utils_test.go
@@ -57,3 +57,12 @@ func TestGetRateLimitPerSecond(t *testing.T) {
 	rateLimitPerSecond := GetRateLimitPerSecond(rateLimitInfo)
 	assert.Equal(t, rateLimitPerSecond, 31)
 }
+
+func TestGetIssueIdByIssueUrl(t *testing.T) {
+	s := "https://api.github.com/repos/octocat/Hello-World/issues/1347"
+	s1, err := GetIssueIdByIssueUrl(s)
+	if err != nil {
+		fmt.Println("ERROR: ", err)
+	}
+	assert.Equal(t, s1, 1347)
+}

--- a/plugins/gitlab/api/gitlab_connections.go
+++ b/plugins/gitlab/api/gitlab_connections.go
@@ -19,7 +19,7 @@ type ApiUserResponse struct {
 POST /plugins/gitlab/test
 */
 func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
-	gitlabApiClient := tasks.CreateApiClient()
+	gitlabApiClient := tasks.CreateApiClient(nil)
 
 	ValidationResult := core.ValidateParams(input, []string{"endpoint", "auth"})
 	if !ValidationResult.Success {

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -99,13 +99,15 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 			"convertNotes":     true,
 		}
 	}
+
+	gitlabApiClient := tasks.CreateApiClient(scheduler)
 	progress <- 0.1
-	if err := tasks.CollectProject(projectIdInt); err != nil {
+	if err := tasks.CollectProject(projectIdInt, gitlabApiClient); err != nil {
 		return fmt.Errorf("could not collect projects: %v", err)
 	}
 	if tasksToRun["collectCommits"] {
 		progress <- 0.25
-		if err := tasks.CollectCommits(projectIdInt, scheduler); err != nil {
+		if err := tasks.CollectCommits(projectIdInt, gitlabApiClient); err != nil {
 			return &errors.SubTaskError{
 				SubTaskName: "collectCommits",
 				Message:     fmt.Errorf("could not collect commits: %v", err).Error(),
@@ -114,7 +116,7 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	if tasksToRun["collectTags"] {
 		progress <- 0.3
-		if err := tasks.CollectTags(projectIdInt, scheduler); err != nil {
+		if err := tasks.CollectTags(projectIdInt, gitlabApiClient); err != nil {
 			return &errors.SubTaskError{
 				SubTaskName: "collectTags",
 				Message:     fmt.Errorf("could not collect tags: %v", err).Error(),
@@ -123,7 +125,7 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	if tasksToRun["collectMrs"] {
 		progress <- 0.35
-		mergeRequestErr := tasks.CollectMergeRequests(projectIdInt, scheduler)
+		mergeRequestErr := tasks.CollectMergeRequests(projectIdInt, gitlabApiClient)
 		if mergeRequestErr != nil {
 			return &errors.SubTaskError{
 				SubTaskName: "collectMrs",
@@ -131,7 +133,7 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 			}
 		}
 		progress <- 0.4
-		collectChildrenOnMergeRequests(projectIdInt, scheduler)
+		collectChildrenOnMergeRequests(projectIdInt, gitlabApiClient)
 	}
 	if tasksToRun["enrichMrs"] {
 		progress <- 0.5
@@ -145,13 +147,13 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	}
 	if tasksToRun["collectPipelines"] {
 		progress <- 0.6
-		if err := tasks.CollectAllPipelines(projectIdInt, scheduler); err != nil {
+		if err := tasks.CollectAllPipelines(projectIdInt, gitlabApiClient); err != nil {
 			return &errors.SubTaskError{
 				SubTaskName: "collectPipelines",
 				Message:     fmt.Errorf("could not collect pipelines: %v", err).Error(),
 			}
 		}
-		if err := tasks.CollectChildrenOnPipelines(projectIdInt, scheduler); err != nil {
+		if err := tasks.CollectChildrenOnPipelines(projectIdInt, gitlabApiClient); err != nil {
 			return &errors.SubTaskError{
 				SubTaskName: "collectChildrenOnPipelines",
 				Message:     fmt.Errorf("could not collect children pipelines: %v", err).Error(),
@@ -202,11 +204,11 @@ func (plugin Gitlab) Execute(options map[string]interface{}, progress chan<- flo
 	return nil
 }
 
-func collectNotesWithScheduler(projectIdInt int, scheduler *utils.WorkerScheduler, mrs []gitlabModels.GitlabMergeRequest) {
+func collectNotes(projectIdInt int, gitlabApiClient *tasks.GitlabApiClient, mrs []gitlabModels.GitlabMergeRequest) {
 	for i := 0; i < len(mrs); i++ {
 		mr := (mrs)[i]
-		err := scheduler.Submit(func() error {
-			notesErr := tasks.CollectMergeRequestNotes(projectIdInt, &mr)
+		err := gitlabApiClient.Scheduler.Submit(func() error {
+			notesErr := tasks.CollectMergeRequestNotes(projectIdInt, &mr, gitlabApiClient)
 			if notesErr != nil {
 				logger.Error("Could not collect MR Notes", notesErr)
 				return notesErr
@@ -219,13 +221,13 @@ func collectNotesWithScheduler(projectIdInt int, scheduler *utils.WorkerSchedule
 		}
 	}
 
-	scheduler.WaitUntilFinish()
+	gitlabApiClient.Scheduler.WaitUntilFinish()
 }
-func collectCommitsWithScheduler(projectIdInt int, scheduler *utils.WorkerScheduler, mrs []gitlabModels.GitlabMergeRequest) {
+func collectCommits(projectIdInt int, gitlabApiClient *tasks.GitlabApiClient, mrs []gitlabModels.GitlabMergeRequest) {
 	for i := 0; i < len(mrs); i++ {
 		mr := (mrs)[i]
-		err := scheduler.Submit(func() error {
-			commitsErr := tasks.CollectMergeRequestCommits(projectIdInt, &mr)
+		err := gitlabApiClient.Scheduler.Submit(func() error {
+			commitsErr := tasks.CollectMergeRequestCommits(projectIdInt, &mr, gitlabApiClient)
 			if commitsErr != nil {
 				logger.Error("Could not collect MR Commits", commitsErr)
 				return commitsErr
@@ -238,16 +240,16 @@ func collectCommitsWithScheduler(projectIdInt int, scheduler *utils.WorkerSchedu
 		}
 	}
 
-	scheduler.WaitUntilFinish()
+	gitlabApiClient.Scheduler.WaitUntilFinish()
 }
 
-func collectChildrenOnMergeRequests(projectIdInt int, scheduler *utils.WorkerScheduler) {
+func collectChildrenOnMergeRequests(projectIdInt int, gitlabApiClient *tasks.GitlabApiClient) {
 	// find all mrs from db
 	var mrs []gitlabModels.GitlabMergeRequest
 	lakeModels.Db.Find(&mrs)
 
-	collectNotesWithScheduler(projectIdInt, scheduler, mrs)
-	collectCommitsWithScheduler(projectIdInt, scheduler, mrs)
+	collectNotes(projectIdInt, gitlabApiClient, mrs)
+	collectCommits(projectIdInt, gitlabApiClient, mrs)
 }
 
 func (plugin Gitlab) RootPkgPath() string {

--- a/plugins/gitlab/tasks/gitlab_commit_collector.go
+++ b/plugins/gitlab/tasks/gitlab_commit_collector.go
@@ -9,7 +9,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitlab/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -35,13 +34,12 @@ type GitlabApiCommit struct {
 	}
 }
 
-func CollectCommits(projectId int, scheduler *utils.WorkerScheduler) error {
-	gitlabApiClient := CreateApiClient()
+func CollectCommits(projectId int, gitlabApiClient *GitlabApiClient) error {
 	relativePath := fmt.Sprintf("projects/%v/repository/commits", projectId)
 	queryParams := &url.Values{}
 	queryParams.Set("with_stats", "true")
 	gitlabUser := &models.GitlabUser{}
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, relativePath, queryParams, 100,
+	return gitlabApiClient.FetchWithPaginationAnts(relativePath, queryParams, 100,
 		func(res *http.Response) error {
 
 			gitlabApiResponse := &ApiCommitResponse{}

--- a/plugins/gitlab/tasks/gitlab_merge_request_collector.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_collector.go
@@ -7,7 +7,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitlab/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -37,10 +36,8 @@ type MergeRequestRes struct {
 
 type ApiMergeRequestResponse []MergeRequestRes
 
-func CollectMergeRequests(projectId int, scheduler *utils.WorkerScheduler) error {
-	gitlabApiClient := CreateApiClient()
-
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, fmt.Sprintf("projects/%v/merge_requests", projectId), nil, 100,
+func CollectMergeRequests(projectId int, gitlabApiClient *GitlabApiClient) error {
+	return gitlabApiClient.FetchWithPaginationAnts(fmt.Sprintf("projects/%v/merge_requests", projectId), nil, 100,
 		func(res *http.Response) error {
 			gitlabApiResponse := &ApiMergeRequestResponse{}
 			err := core.UnmarshalResponse(res, gitlabApiResponse)

--- a/plugins/gitlab/tasks/gitlab_merge_request_commits.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_commits.go
@@ -28,8 +28,7 @@ type GitlabMergeRequestCommit struct {
 	WebUrl         string           `json:"web_url"`
 }
 
-func CollectMergeRequestCommits(projectId int, mr *models.GitlabMergeRequest) error {
-	gitlabApiClient := CreateApiClient()
+func CollectMergeRequestCommits(projectId int, mr *models.GitlabMergeRequest, gitlabApiClient *GitlabApiClient) error {
 
 	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/commits", projectId, mr.Iid)
 	return gitlabApiClient.FetchWithPagination(getUrl, nil, 100,

--- a/plugins/gitlab/tasks/gitlab_merge_request_note.go
+++ b/plugins/gitlab/tasks/gitlab_merge_request_note.go
@@ -67,8 +67,7 @@ func updateMergeRequestWithFirstCommentTime(notes *ApiMergeRequestNoteResponse, 
 	return nil
 }
 
-func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest) error {
-	gitlabApiClient := CreateApiClient()
+func CollectMergeRequestNotes(projectId int, mr *models.GitlabMergeRequest, gitlabApiClient *GitlabApiClient) error {
 
 	getUrl := fmt.Sprintf("projects/%v/merge_requests/%v/notes?system=false", projectId, mr.Iid)
 	return gitlabApiClient.FetchWithPagination(getUrl, nil, 100,

--- a/plugins/gitlab/tasks/gitlab_pipeline_collector.go
+++ b/plugins/gitlab/tasks/gitlab_pipeline_collector.go
@@ -9,7 +9,6 @@ import (
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitlab/models"
 	gitlabModels "github.com/merico-dev/lake/plugins/gitlab/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -39,12 +38,12 @@ type ApiSinglePipelineResponse struct {
 	Status          string
 }
 
-func CollectAllPipelines(projectId int, scheduler *utils.WorkerScheduler) error {
-	gitlabApiClient := CreateApiClient()
+func CollectAllPipelines(projectId int, gitlabApiClient *GitlabApiClient) error {
+
 	queryParams := &url.Values{}
 	queryParams.Set("order_by", "updated_at")
 	queryParams.Set("sort", "desc")
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler,
+	return gitlabApiClient.FetchWithPaginationAnts(
 		fmt.Sprintf("projects/%v/pipelines", projectId),
 		queryParams,
 		100,
@@ -77,8 +76,7 @@ func CollectAllPipelines(projectId int, scheduler *utils.WorkerScheduler) error 
 		})
 }
 
-func CollectChildrenOnPipelines(projectIdInt int, scheduler *utils.WorkerScheduler) error {
-	gitlabApiClient := CreateApiClient()
+func CollectChildrenOnPipelines(projectIdInt int, gitlabApiClient *GitlabApiClient) error {
 
 	var pipelines []gitlabModels.GitlabPipeline
 
@@ -87,7 +85,7 @@ func CollectChildrenOnPipelines(projectIdInt int, scheduler *utils.WorkerSchedul
 
 	for i := 0; i < len(pipelines); i++ {
 		pipeline := (pipelines)[i]
-		schedulerErr := scheduler.Submit(func() error {
+		schedulerErr := gitlabApiClient.Scheduler.Submit(func() error {
 
 			getUrl := fmt.Sprintf("projects/%v/pipelines/%v", projectIdInt, pipeline.GitlabId)
 			res, err := gitlabApiClient.Get(getUrl, nil, nil)
@@ -131,7 +129,7 @@ func CollectChildrenOnPipelines(projectIdInt int, scheduler *utils.WorkerSchedul
 		}
 
 	}
-	scheduler.WaitUntilFinish()
+	gitlabApiClient.Scheduler.WaitUntilFinish()
 	return nil
 }
 

--- a/plugins/gitlab/tasks/gitlab_project_collector.go
+++ b/plugins/gitlab/tasks/gitlab_project_collector.go
@@ -29,8 +29,8 @@ type GitlabApiProject struct {
 
 type GitlabApiProjectResponse GitlabApiProject
 
-func CollectProject(projectId int) error {
-	gitlabApiClient := CreateApiClient()
+func CollectProject(projectId int, gitlabApiClient *GitlabApiClient) error {
+
 	res, err := gitlabApiClient.Get(fmt.Sprintf("projects/%v", projectId), nil, nil)
 	if err != nil {
 		logger.Error("Error: ", err)

--- a/plugins/gitlab/tasks/gitlab_tag_collector.go
+++ b/plugins/gitlab/tasks/gitlab_tag_collector.go
@@ -9,7 +9,6 @@ import (
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitlab/models"
-	"github.com/merico-dev/lake/utils"
 	"gorm.io/gorm/clause"
 )
 
@@ -26,12 +25,11 @@ type GitlabApiTag struct {
 	}
 }
 
-func CollectTags(projectId int, scheduler *utils.WorkerScheduler) error {
-	gitlabApiClient := CreateApiClient()
+func CollectTags(projectId int, gitlabApiClient *GitlabApiClient) error {
 	relativePath := fmt.Sprintf("projects/%v/repository/tags", projectId)
 	queryParams := &url.Values{}
 	queryParams.Set("with_stats", "true")
-	return gitlabApiClient.FetchWithPaginationAnts(scheduler, relativePath, queryParams, 100,
+	return gitlabApiClient.FetchWithPaginationAnts(relativePath, queryParams, 100,
 		func(res *http.Response) error {
 
 			gitlabApiResponse := &ApiTagsResponse{}

--- a/plugins/jenkins/api/jenkins_connections.go
+++ b/plugins/jenkins/api/jenkins_connections.go
@@ -24,6 +24,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		},
 		10*time.Second,
 		3,
+		nil,
 	)
 	res, err := apiClient.Get("", nil, nil)
 	if err != nil || res.StatusCode != 200 {

--- a/plugins/jira/api/jira_connections.go
+++ b/plugins/jira/api/jira_connections.go
@@ -60,7 +60,7 @@ func TestConnection(input *core.ApiResourceInput) (*core.ApiResourceOutput, erro
 		return &core.ApiResourceOutput{Body: core.TestResult{Success: false, Message: core.NetworkConnectError}}, nil
 	}
 
-	jiraApiClient := tasks.NewJiraApiClient(params.Endpoint, params.Auth, params.Proxy)
+	jiraApiClient := tasks.NewJiraApiClient(params.Endpoint, params.Auth, params.Proxy, nil)
 	jiraApiClient.SetTimeout(2 * time.Second)
 
 	serverInfo, statusCode, err := jiraApiClient.GetJiraServerInfo()

--- a/plugins/jira/api/jira_proxy.go
+++ b/plugins/jira/api/jira_proxy.go
@@ -24,7 +24,7 @@ func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := tasks.NewJiraApiClientBySourceId(jiraSourceId)
+	client, err := tasks.NewJiraApiClientBySourceId(jiraSourceId, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/jira/tasks/jira_changelog_collector.go
+++ b/plugins/jira/tasks/jira_changelog_collector.go
@@ -129,7 +129,7 @@ func collectChangelogsByIssueId(
 	jiraApiClient *JiraApiClient,
 	issueId uint64,
 ) error {
-	return jiraApiClient.FetchPages(scheduler, fmt.Sprintf("api/3/issue/%v/changelog", issueId), nil,
+	return jiraApiClient.FetchPages(fmt.Sprintf("api/3/issue/%v/changelog", issueId), nil,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiChangelogResponse := &JiraApiChangelogsResponse{}

--- a/plugins/jira/tasks/jira_issue_collector.go
+++ b/plugins/jira/tasks/jira_issue_collector.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/merico-dev/lake/logger"
-	"github.com/merico-dev/lake/utils"
-
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/jira/models"
@@ -119,14 +117,7 @@ func CollectIssues(
 	query := &url.Values{}
 	query.Set("jql", jql)
 
-	scheduler, err := utils.NewWorkerScheduler(10, rateLimitPerSecondInt, ctx)
-	if err != nil {
-		logger.Error("jira collect issues: scheduler failed", err)
-		return err
-	}
-	defer scheduler.Release()
-
-	err = jiraApiClient.FetchPages(scheduler, fmt.Sprintf("agile/1.0/board/%v/issue", boardId), query,
+	err := jiraApiClient.FetchPages(fmt.Sprintf("agile/1.0/board/%v/issue", boardId), query,
 		func(res *http.Response) error {
 			// parse response
 			jiraApiIssuesResponse := &JiraApiIssuesResponse{}
@@ -186,7 +177,6 @@ func CollectIssues(
 		logger.Error("jira collect issues: fetch page failed", err)
 		return err
 	}
-	scheduler.WaitUntilFinish()
 	return nil
 }
 

--- a/utils/worker_scheduler.go
+++ b/utils/worker_scheduler.go
@@ -3,11 +3,11 @@ package utils
 import (
 	"context"
 	"fmt"
+	"github.com/merico-dev/lake/errors"
 	"sync"
 	"time"
 
 	"github.com/merico-dev/lake/logger"
-	"github.com/merico-dev/lake/plugins/core"
 	"github.com/panjf2000/ants/v2"
 )
 
@@ -54,7 +54,7 @@ func NewWorkerScheduler(workerNum int, maxWorkEverySeconds int, ctx context.Cont
 func (s *WorkerScheduler) Submit(task func() error) error {
 	select {
 	case <-s.ctx.Done():
-		return core.TaskCanceled
+		return errors.TaskCanceled
 	default:
 	}
 	s.waitGroup.Add(1)
@@ -68,7 +68,7 @@ func (s *WorkerScheduler) Submit(task func() error) error {
 		}()
 		select {
 		case <-s.ctx.Done():
-			logger.Error("task got canceled", core.TaskCanceled)
+			logger.Error("task got canceled", errors.TaskCanceled)
 		default:
 		}
 		if s.ticker != nil {


### PR DESCRIPTION
# Summary

Improve github collection performance

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
We can get page information from github api headers


### Does this close any open issues?
Closes #1230 #1220 #1221

### Current Behavior
Keep trying to get pages, sometimes even request for over 50 pages but only first page has data
Iterated issues one by one to get events/comments

### New Behavior
Only request for the pages with data
Get events/comments by repo

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
