### PR TITLE
fix: gitlab provider - disable project id mappings field

### DIFF
--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -302,7 +302,7 @@ export default function ConfigureConnection () {
                         intent={Intent.PRIMARY}
                         text='Save Settings'
                         loading={isSaving}
-                        disabled={isSaving || providerId === Providers.JENKINS}
+                        disabled={isSaving || providerId === Providers.JENKINS || providerId === Providers.GITLAB}
                         onClick={saveSettings}
                         style={{ marginLeft: '10px' }}
                       />

--- a/config-ui/src/pages/configure/settings/gitlab.jsx
+++ b/config-ui/src/pages/configure/settings/gitlab.jsx
@@ -117,6 +117,10 @@ export default function GitlabSettings (props) {
     console.log('>> LINKING JIRA BOARD', selectedBoard, ' TO GITLAB PROJECT ', selectedProject)
   }
 
+  const cancel = () => {
+    history.push(`/integrations/${provider.id}`)
+  }
+
   useEffect(() => {
     // @todo FETCH BOARDS FROM BE API
     // setBoards([])
@@ -133,7 +137,17 @@ export default function GitlabSettings (props) {
 
   return (
     <>
-      <h3 className='headline'>Enter Map IDs Manually</h3>
+      <div className='headlineContainer'>
+        <h3 className='headline'>No Additional Settings</h3>
+        <p className='description'>
+          This integration doesn’t require any configuration.
+          You can continue to&nbsp;
+          <a href='#' style={{ textDecoration: 'underline' }} onClick={cancel}>add other data sources</a>&nbsp;
+          or trigger collection at the <a href='#' style={{ textDecoration: 'underline' }} onClick={cancel}>previous page</a>.
+        </p>
+      </div>
+      {/* #1245 - DISABLE Gitlab Project ID Mappings <DEPRECATED> */}
+      {/* <h3 className='headline'>Enter Map IDs Manually</h3>
       <p className=''>Type comma separated mappings using the format <code>[JIRA_BOARD_ID]:[GITLAB_PROJECT_ID]</code></p>
       <div className='formContainer'>
         <FormGroup
@@ -155,7 +169,7 @@ export default function GitlabSettings (props) {
             className='input'
           />
         </FormGroup>
-      </div>
+      </div> */}
       {/* ========== BOARD LINKING UX ======================== */}
       {/* @todo continue/restore  board-linking ux after ITER3 */}
       {/* <h3 className='headline'>JIRA Board Mappings <span className='bp3-form-helper-text'>JIRA_BOARD_GITLAB_PROJECTS</span></h3>

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -50,15 +50,8 @@ For an overview of the **GitLab REST API**, please see official [GitLab Docs on 
 Click **Save Connection** to update connection settings.
     
 ### Provider (Datasource) Settings
-Manage additional settings and options for the GitLab Datasource Provider. Currently there is only one **optional** setting that allows you to Map multiple JIRA Boards to GitLab Projects.
-
-- **JIRA Board Mappings [ `Optional`]**
-**Map JIRA Boards to GitLab**. Type comma separated mappings using the format `[JIRA_BOARD_ID]:[GITLAB_PROJECT_ID]`
-```
-# Map JIRA Board ID 8 ==> Gitlab Projects 8967944,8967945
-<JIRA_BOARD>:<GITLAB_PROJECT_ID>,...; eg. 8:8967944,8967945;9:8967946,8967947
-```
-Click **Save Settings** to update additional settings.
+There are no additional settings for the GitLab Datasource Provider at this time.
+NOTE: `GitLab Project ID` Mappings feature has been deprecated.
 
 ## Gathering Data with Gitlab
 


### PR DESCRIPTION
### Config-UI / Integrations / **Gitlab** / Configure Connection

- [x] Update Connection Settings for **GitLab Instances** 
    - **Disable** GitLab ID Project Mappings Field (`DEPRECATED` feature)
- [x] Update **EN** `README.md`

### Description
This PR deprecates a field for `GitLab` Connection Instances. Gitlab Project ID Mappings is no longer a supported feature. A "No Additional Settings" message will be displayed, and the Save Settings action will be **disabled** (as we do with `Jenkins` Provider)

### Does this close any open issues?
#1245

### Screenshots
<img width="1263" alt="Screen Shot 2022-02-21 at 11 16 06 AM" src="https://user-images.githubusercontent.com/1742233/154992454-bf3b1e8d-6964-4dc1-84cb-768a2e3def8e.png">

