### PR TITLE
fix: multithread read empty config

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,8 @@ import (
 )
 
 func CreateApiService() {
-	gin.SetMode(config.V.GetString("MODE"))
+	v := config.GetConfig()
+	gin.SetMode(v.GetString("MODE"))
 	router := gin.Default()
 
 	// CORS CONFIG
@@ -23,7 +24,7 @@ func CreateApiService() {
 	}))
 
 	RegisterRouter(router)
-	err := router.Run(config.V.GetString("PORT"))
+	err := router.Run(v.GetString("PORT"))
 	if err != nil {
 		panic(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -36,15 +36,15 @@ type Config struct {
 var V *viper.Viper
 
 func LoadConfigFile() *viper.Viper {
-	V = viper.New()
-	V.SetConfigFile(".env")
-	_ = V.ReadInConfig()
-	V.AutomaticEnv()
-	return V
+	VV := viper.New()
+	VV.SetConfigFile(".env")
+	_ = VV.ReadInConfig()
+	VV.AutomaticEnv()
+	return VV
 }
 
 func init() {
-	V := LoadConfigFile()
+	V = LoadConfigFile()
 	V.SetDefault("PORT", ":8080")
 	V.SetDefault("PLUGIN_DIR", "bin/plugins")
 	// This line is essential for reading and writing

--- a/config/config.go
+++ b/config/config.go
@@ -1,61 +1,34 @@
 package config
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
-type Config struct {
-	PORT                               string `mapstructure:"PORT"`
-	DB_URL                             string `mapstructure:"DB_URL"`
-	MODE                               string `mapstructure:"MODE"`
-	JIRA_ENDPOINT                      string `mapstructure:"JIRA_ENDPOINT"`
-	JIRA_BASIC_AUTH_ENCODED            string `mapstructure:"JIRA_BASIC_AUTH_ENCODED"`
-	JIRA_ISSUE_EPIC_KEY_FIELD          string `mapstructure:"JIRA_ISSUE_EPIC_KEY_FIELD"`
-	JIRA_ISSUE_WORKLOAD_FIELD          string `mapstructure:"JIRA_ISSUE_WORKLOAD_FIELD"`
-	JIRA_BOARD_GITLAB_PROJECTS         string `mapstructure:"JIRA_BOARD_GITLAB_PROJECTS"`
-	JIRA_ISSUE_BUG_STATUS_MAPPING      string `mapstructure:"JIRA_ISSUE_BUG_STATUS_MAPPING"`
-	JIRA_ISSUE_INCIDENT_STATUS_MAPPING string `mapstructure:"JIRA_ISSUE_INCIDENT_STATUS_MAPPING"`
-	JIRA_ISSUE_STORY_STATUS_MAPPING    string `mapstructure:"JIRA_ISSUE_STORY_STATUS_MAPPING"`
-	JIRA_ISSUE_TYPE_MAPPING            string `mapstructure:"JIRA_ISSUE_TYPE_MAPPING"`
-	GITLAB_ENDPOINT                    string `mapstructure:"GITLAB_ENDPOINT"`
-	GITLAB_AUTH                        string `mapstructure:"GITLAB_AUTH"`
-	GITHUB_ENDPOINT                    string `mapstructure:"GITHUB_ENDPOINT"`
-	GITHUB_AUTH                        string `mapstructure:"GITHUB_AUTH"`
-	GITHUB_PROXY                       string `mapstructure:"GITHUB_PROXY"`
-	JENKINS_ENDPOINT                   string `mapstructure:"JENKINS_ENDPOINT"`
-	JENKINS_USERNAME                   string `mapstructure:"JENKINS_USERNAME"`
-	JENKINS_PASSWORD                   string `mapstructure:"JENKINS_PASSWORD"`
-	FEISHU_APPID                       string `mapstructure:"FEISHU_APPID"`
-	FEISHU_APPSCRECT                   string `mapstructure:"FEISHU_APPSCRECT"`
-	AE_APP_ID                          string `mapstructure:"AE_APP_ID"`
-	AE_NONCE_STR                       string `mapstructure:"AE_NONCE_STR"`
-	AE_SIGN                            string `mapstructure:"AE_SIGN"`
-	AE_ENDPOINT                        string `mapstructure:"AE_ENDPOINT"`
+// Lowcase V for private this. You can use it by call GetConfig.
+var v *viper.Viper = nil
+
+func GetConfig() *viper.Viper {
+	return v
 }
 
-var V *viper.Viper
-
-func LoadConfigFile() *viper.Viper {
-	VV := viper.New()
-	VV.SetConfigFile(".env")
-	_ = VV.ReadInConfig()
-	VV.AutomaticEnv()
-	return VV
+// Set default value for no .env or .env not set it
+func setDefaultValue() {
+	v.SetDefault("PORT", ":8080")
+	v.SetDefault("PLUGIN_DIR", "bin/plugins")
 }
 
 func init() {
-	V = LoadConfigFile()
-	V.SetDefault("PORT", ":8080")
-	V.SetDefault("PLUGIN_DIR", "bin/plugins")
-	// This line is essential for reading and writing
-	V.WatchConfig()
-}
-
-func GetConfigJson() (*Config, error) {
-	var configJson Config
-	err := V.Unmarshal(&configJson)
+	// create the object and load the .env file
+	v = viper.New()
+	v.SetConfigFile(".env")
+	err := v.ReadInConfig()
 	if err != nil {
-		return nil, err
+		logrus.Warn("Failed to read [.env] file:", err)
 	}
-	return &configJson, nil
+	v.AutomaticEnv()
+
+	setDefaultValue()
+	// This line is essential for reading and writing
+	v.WatchConfig()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,27 +6,18 @@ import (
 	"github.com/magiconair/properties/assert"
 )
 
-func TestGetConfigJson(t *testing.T) {
-	_, err := GetConfigJson()
-	assert.Equal(t, err == nil, true)
-}
-
 func TestReadAndWriteToConfig(t *testing.T) {
-	// Verify new value is not equal to current value
-	configJson, err := GetConfigJson()
-	assert.Equal(t, err == nil, true)
-	currentDbUrl := configJson.DB_URL
+	v := GetConfig()
+	currentDbUrl := v.GetString("DB_URL")
 	newDbUrl := "ThisIsATest"
 	assert.Equal(t, currentDbUrl != newDbUrl, true)
-	V := LoadConfigFile()
-	V.Set("DB_URL", newDbUrl)
-	err = V.WriteConfig()
+	v.Set("DB_URL", newDbUrl)
+	err := v.WriteConfig()
 	assert.Equal(t, err == nil, true)
-	newConfigJson, err := GetConfigJson()
-	assert.Equal(t, err == nil, true)
-	assert.Equal(t, newConfigJson.DB_URL, newDbUrl)
+	nowDbUrl := v.GetString("DB_URL")
+	assert.Equal(t, nowDbUrl == newDbUrl, true)
 	// Reset back to current
-	V.Set("DB_URL", currentDbUrl)
-	err = V.WriteConfig()
+	v.Set("DB_URL", currentDbUrl)
+	err = v.WriteConfig()
 	assert.Equal(t, err == nil, true)
 }

--- a/e2e/database.go
+++ b/e2e/database.go
@@ -10,8 +10,8 @@ import (
 )
 
 func InitializeDb() (*sql.DB, error) {
-	V := LoadConfigFile()
-	dbUrl := V.GetString("DB_URL")
+	v := LoadConfigFile()
+	dbUrl := v.GetString("DB_URL")
 	db, err := sql.Open("mysql", dbUrl)
 	if err != nil {
 		return nil, err

--- a/logger/log.go
+++ b/logger/log.go
@@ -29,7 +29,7 @@ var (
 )
 
 func Color(colorString string) func(...interface{}) string {
-	if config.V.GetBool("NO_COLOR") {
+	if config.GetConfig().GetBool("NO_COLOR") {
 		return fmt.Sprint
 	}
 	sprint := func(args ...interface{}) string {

--- a/models/init.go
+++ b/models/init.go
@@ -20,8 +20,9 @@ import (
 var Db *gorm.DB
 
 func init() {
-	connectionString := config.V.GetString("DB_URL")
-	if config.V.Get("TEST") == "true" {
+	V := config.GetConfig()
+	connectionString := V.GetString("DB_URL")
+	if V.Get("TEST") == "true" {
 		connectionString = "merico:merico@tcp(localhost:3306)/lake_test"
 	}
 	var err error

--- a/plugins/ae/api/ae_sources.go
+++ b/plugins/ae/api/ae_sources.go
@@ -32,22 +32,22 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	V := config.LoadConfigFile()
+	v := config.GetConfig()
 
 	if aeSource.AE_APP_ID != "" {
-		V.Set("AE_SIGN", aeSource.AE_SIGN)
+		v.Set("AE_SIGN", aeSource.AE_SIGN)
 	}
 	if aeSource.AE_SIGN != "" {
-		V.Set("AE_SIGN", aeSource.AE_SIGN)
+		v.Set("AE_SIGN", aeSource.AE_SIGN)
 	}
 	if aeSource.AE_NONCE_STR != "" {
-		V.Set("AE_NONCE_STR", aeSource.AE_NONCE_STR)
+		v.Set("AE_NONCE_STR", aeSource.AE_NONCE_STR)
 	}
 	if aeSource.AE_ENDPOINT != "" {
-		V.Set("AE_ENDPOINT", aeSource.AE_ENDPOINT)
+		v.Set("AE_ENDPOINT", aeSource.AE_ENDPOINT)
 	}
 
-	err = V.WriteConfig()
+	err = v.WriteConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -81,9 +81,9 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*AEResponse, error) {
-	V := config.LoadConfigFile()
+	v := config.GetConfig()
 	var configJson AEConfig
-	err := V.Unmarshal(&configJson)
+	err := v.Unmarshal(&configJson)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/ae/tasks/ae_api_client.go
+++ b/plugins/ae/tasks/ae_api_client.go
@@ -62,11 +62,12 @@ func getSign(query url.Values, appId, secretKey, nonceStr, timestamp string) str
 }
 
 func (client *AEApiClient) beforeRequest(req *http.Request) error {
-	appId := config.V.GetString("AE_APP_ID")
+	V := config.GetConfig()
+	appId := V.GetString("AE_APP_ID")
 	if appId == "" {
 		return fmt.Errorf("invalid AE_APP_ID")
 	}
-	secretKey := config.V.GetString("AE_SECRET_KEY")
+	secretKey := V.GetString("AE_SECRET_KEY")
 	if appId == "" {
 		return fmt.Errorf("invalid AE_SECRET_KEY")
 	}
@@ -83,7 +84,7 @@ func (client *AEApiClient) beforeRequest(req *http.Request) error {
 func CreateApiClient(ctx context.Context) *AEApiClient {
 	aeApiClient := &AEApiClient{}
 	aeApiClient.Setup(
-		config.V.GetString("AE_ENDPOINT"),
+		config.GetConfig().GetString("AE_ENDPOINT"),
 		nil,
 		30*time.Second,
 		3,

--- a/plugins/compound/compound.go
+++ b/plugins/compound/compound.go
@@ -24,7 +24,7 @@ func (plugin Compound) Init() {
 	if err != nil {
 		panic(err)
 	}
-	text := config.V.GetString("JIRA_BOARD_GITLAB_PROJECTS")
+	text := config.GetConfig().GetString("JIRA_BOARD_GITLAB_PROJECTS")
 	if text == "" {
 		return
 	}

--- a/plugins/core/plugin_utils.go
+++ b/plugins/core/plugin_utils.go
@@ -76,14 +76,14 @@ func GetRateLimitPerSecond(options map[string]interface{}, defaultValue int) (in
 // AES + Base64 encryption using ENCODE_KEY in .env as key
 func Encode(Input string) (string, error) {
 	// Read encryption key from configuration
-	V := config.LoadConfigFile()
-	encodingKey := V.GetString(EncodeKeyEnvStr)
+	v := config.GetConfig()
+	encodingKey := v.GetString(EncodeKeyEnvStr)
 	// when encryption key is not set
 	if encodingKey == "" {
 		// Randomly generate a bunch of encryption keys and set them to config
 		encodingKey = RandomCapsStr(128)
-		V.Set(EncodeKeyEnvStr, encodingKey)
-		err := V.WriteConfig()
+		v.Set(EncodeKeyEnvStr, encodingKey)
+		err := v.WriteConfig()
 		if err != nil {
 			return "", err
 		}
@@ -102,8 +102,8 @@ func Encode(Input string) (string, error) {
 //  Base64 + AES decryption using ENCODE_KEY in .env as key
 func Decode(Input string) (string, error) {
 	// Read encryption key from configuration
-	V := config.LoadConfigFile()
-	encodingKey := V.GetString(EncodeKeyEnvStr)
+	v := config.GetConfig()
+	encodingKey := v.GetString(EncodeKeyEnvStr)
 	// when encryption key is not set
 	if encodingKey == "" {
 		// return error message

--- a/plugins/github/api/github_sources.go
+++ b/plugins/github/api/github_sources.go
@@ -37,15 +37,15 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	V := config.LoadConfigFile()
+	v := config.GetConfig()
 	if githubSource.GITHUB_ENDPOINT != "" {
-		V.Set("GITHUB_ENDPOINT", githubSource.GITHUB_ENDPOINT)
+		v.Set("GITHUB_ENDPOINT", githubSource.GITHUB_ENDPOINT)
 	}
 	if githubSource.GITHUB_AUTH != "" {
-		V.Set("GITHUB_AUTH", githubSource.GITHUB_AUTH)
+		v.Set("GITHUB_AUTH", githubSource.GITHUB_AUTH)
 	}
-	V.Set("GITHUB_PROXY", githubSource.GITHUB_PROXY)
-	err = V.WriteConfig()
+	v.Set("GITHUB_PROXY", githubSource.GITHUB_PROXY)
+	err = v.WriteConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -79,9 +79,9 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*GithubResponse, error) {
-	V := config.LoadConfigFile()
+	v := config.GetConfig()
 	var configJson GithubConfig
-	err := V.Unmarshal(&configJson)
+	err := v.Unmarshal(&configJson)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/github/github.go
+++ b/plugins/github/github.go
@@ -101,9 +101,10 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 		}
 	}
 
+	v := config.GetConfig()
 	// process configuration
-	endpoint := config.V.GetString("GITHUB_ENDPOINT")
-	tokens := strings.Split(config.V.GetString("GITHUB_AUTH"), ",")
+	endpoint := v.GetString("GITHUB_ENDPOINT")
+	tokens := strings.Split(v.GetString("GITHUB_AUTH"), ",")
 	// setup rate limit
 	tokenCount := len(tokens)
 	if tokenCount == 0 {
@@ -120,7 +121,7 @@ func (plugin Github) Execute(options map[string]interface{}, progress chan<- flo
 	defer scheduler.Release()
 	// TODO: add endpoind, auth validation
 	apiClient := tasks.NewGithubApiClient(endpoint, tokens, ctx, scheduler)
-	err = apiClient.SetProxy(config.V.GetString("GITHUB_PROXY"))
+	err = apiClient.SetProxy(v.GetString("GITHUB_PROXY"))
 	if err != nil {
 		return err
 	}
@@ -392,11 +393,12 @@ func main() {
 	}
 	PluginEntry.Init()
 	progress := make(chan float32)
-	endpoint := config.V.GetString("GITHUB_ENDPOINT")
-	configTokensString := config.V.GetString("GITHUB_AUTH")
+	v := config.GetConfig()
+	endpoint := v.GetString("GITHUB_ENDPOINT")
+	configTokensString := v.GetString("GITHUB_AUTH")
 	tokens := strings.Split(configTokensString, ",")
 	githubApiClient := tasks.NewGithubApiClient(endpoint, tokens, nil, nil)
-	_ = githubApiClient.SetProxy(config.V.GetString("GITHUB_PROXY"))
+	_ = githubApiClient.SetProxy(v.GetString("GITHUB_PROXY"))
 	_, collectRepoErr := tasks.CollectRepository(owner, repo, githubApiClient)
 	if collectRepoErr != nil {
 		fmt.Println(fmt.Errorf("Could not collect repositories: %v", collectRepoErr))

--- a/plugins/github/tasks/github_issue_enricher.go
+++ b/plugins/github/tasks/github_issue_enricher.go
@@ -19,12 +19,13 @@ var issueTypeRequirementRegex *regexp.Regexp
 var issueTypeIncidentRegex *regexp.Regexp
 
 func init() {
-	var issueSeverity = config.V.GetString("GITHUB_ISSUE_SEVERITY")
-	var issueComponent = config.V.GetString("GITHUB_ISSUE_COMPONENT")
-	var issuePriority = config.V.GetString("GITHUB_ISSUE_PRIORITY")
-	var issueTypeBug = config.V.GetString("GITHUB_ISSUE_TYPE_BUG")
-	var issueTypeRequirement = config.V.GetString("GITHUB_ISSUE_TYPE_REQUIREMENT")
-	var issueTypeIncident = config.V.GetString("GITHUB_ISSUE_TYPE_INCIDENT")
+	v := config.GetConfig()
+	var issueSeverity = v.GetString("GITHUB_ISSUE_SEVERITY")
+	var issueComponent = v.GetString("GITHUB_ISSUE_COMPONENT")
+	var issuePriority = v.GetString("GITHUB_ISSUE_PRIORITY")
+	var issueTypeBug = v.GetString("GITHUB_ISSUE_TYPE_BUG")
+	var issueTypeRequirement = v.GetString("GITHUB_ISSUE_TYPE_REQUIREMENT")
+	var issueTypeIncident = v.GetString("GITHUB_ISSUE_TYPE_INCIDENT")
 	if len(issueSeverity) > 0 {
 		issueSeverityRegex = regexp.MustCompile(issueSeverity)
 	}

--- a/plugins/github/tasks/github_pull_request_enricher.go
+++ b/plugins/github/tasks/github_pull_request_enricher.go
@@ -14,8 +14,9 @@ var labelTypeRegex *regexp.Regexp
 var labelComponentRegex *regexp.Regexp
 
 func init() {
-	var prType = config.V.GetString("GITHUB_PR_TYPE")
-	var prComponent = config.V.GetString("GITHUB_PR_COMPONENT")
+	V := config.GetConfig()
+	var prType = V.GetString("GITHUB_PR_TYPE")
+	var prComponent = V.GetString("GITHUB_PR_COMPONENT")
 	if len(prType) > 0 {
 		labelTypeRegex = regexp.MustCompile(prType)
 	}

--- a/plugins/gitlab/api/gitlab_sources.go
+++ b/plugins/gitlab/api/gitlab_sources.go
@@ -37,7 +37,7 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	V := config.LoadConfigFile()
+	V := config.GetConfig()
 	if gitlabSource.GITLAB_ENDPOINT != "" {
 		V.Set("GITLAB_ENDPOINT", gitlabSource.GITLAB_ENDPOINT)
 	}
@@ -81,7 +81,7 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*GitlabResponse, error) {
-	V := config.LoadConfigFile()
+	V := config.GetConfig()
 	var configJson GitlabConfig
 	err := V.Unmarshal(&configJson)
 	if err != nil {

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -20,10 +20,11 @@ type GitlabApiClient struct {
 
 func CreateApiClient(scheduler *utils.WorkerScheduler) *GitlabApiClient {
 	gitlabApiClient := &GitlabApiClient{}
+	V := config.GetConfig()
 	gitlabApiClient.Setup(
-		config.V.GetString("GITLAB_ENDPOINT"),
+		V.GetString("GITLAB_ENDPOINT"),
 		map[string]string{
-			"Authorization": fmt.Sprintf("Bearer %v", config.V.GetString("GITLAB_AUTH")),
+			"Authorization": fmt.Sprintf("Bearer %v", V.GetString("GITLAB_AUTH")),
 		},
 		10*time.Second,
 		3,

--- a/plugins/jenkins/api/jenkins_sources.go
+++ b/plugins/jenkins/api/jenkins_sources.go
@@ -51,11 +51,11 @@ func PutSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	V := config.LoadConfigFile()
-	V.Set("JENKINS_ENDPOINT", jenkinsSource.JENKINS_ENDPOINT)
-	V.Set("JENKINS_USERNAME", jenkinsSource.JENKINS_USERNAME)
-	V.Set("JENKINS_PASSWORD", jenkinsSource.JENKINS_PASSWORD)
-	err = V.WriteConfig()
+	v := config.GetConfig()
+	v.Set("JENKINS_ENDPOINT", jenkinsSource.JENKINS_ENDPOINT)
+	v.Set("JENKINS_USERNAME", jenkinsSource.JENKINS_USERNAME)
+	v.Set("JENKINS_PASSWORD", jenkinsSource.JENKINS_PASSWORD)
+	err = v.WriteConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -89,14 +89,11 @@ func GetSource(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 }
 
 func GetSourceFromEnv() (*JenkinsSource, error) {
-	configJson, err := config.GetConfigJson()
-	if err != nil {
-		return nil, err
-	}
+	v := config.GetConfig()
 	return &JenkinsSource{
-		Endpoint: configJson.JENKINS_ENDPOINT,
-		Username: configJson.JENKINS_USERNAME,
-		Password: configJson.JENKINS_PASSWORD,
+		Endpoint: v.GetString("JENKINS_ENDPOINT"),
+		Username: v.GetString("JENKINS_USERNAME"),
+		Password: v.GetString("JENKINS_PASSWORD"),
 		// The UI relies on a source ID here but we will hardcode it until the sources work is done for Jenkins
 		ID:   1,
 		Name: "Jenkins",

--- a/plugins/jenkins/jenkins.go
+++ b/plugins/jenkins/jenkins.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/merico-dev/lake/config"
 	errors "github.com/merico-dev/lake/errors"
 	"github.com/merico-dev/lake/logger"
@@ -44,10 +45,11 @@ func (j Jenkins) CleanData() {
 }
 
 func (j Jenkins) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
+	v := config.GetConfig()
 	var op = JenkinsOptions{
-		Host:     config.V.GetString("JENKINS_ENDPOINT"),
-		Username: config.V.GetString("JENKINS_USERNAME"),
-		Password: config.V.GetString("JENKINS_PASSWORD"),
+		Host:     v.GetString("JENKINS_ENDPOINT"),
+		Username: v.GetString("JENKINS_USERNAME"),
+		Password: v.GetString("JENKINS_PASSWORD"),
 	}
 
 	var err = mapstructure.Decode(options, &op)

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -58,6 +58,6 @@ func RunPlugin(name string, options map[string]interface{}, progress chan<- floa
 }
 
 func PluginDir() string {
-	pluginDir := config.V.GetString("PLUGIN_DIR")
+	pluginDir := config.GetConfig().GetString("PLUGIN_DIR")
 	return pluginDir
 }

--- a/services/pipeline.go
+++ b/services/pipeline.go
@@ -22,8 +22,9 @@ type PipelineQuery struct {
 }
 
 func init() {
-	var notificationEndpoint = config.V.GetString("NOTIFICATION_ENDPOINT")
-	var notificationSecret = config.V.GetString("NOTIFICATION_SECRET")
+	v := config.GetConfig()
+	var notificationEndpoint = v.GetString("NOTIFICATION_ENDPOINT")
+	var notificationSecret = v.GetString("NOTIFICATION_SECRET")
 	if strings.TrimSpace(notificationEndpoint) != "" {
 		notificationService = NewNotificationService(notificationEndpoint, notificationSecret)
 	}


### PR DESCRIPTION
# Summary
fix: multithread read empty config
refactored configuration file processing
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Fix multithreading unsafe issue of flushing global variables in LoadConfigFile().
Fix the problem that the use of local variables in init() of config.go may cause invalid operation.

Delete the ConfigJson data structure
Remove LoadConfigFile() function
Add the GetConfig() function to privatize the Config global variable
Some Chinese annotations were killed because of klesh
All the unified calling functions for Config requirements in the adjustment code are GetConfig()

### Does this close any open issues?
close https://github.com/merico-dev/lake/issues/1243

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
