### PR TITLE
fix(plugins): fix concurrent problems

### DIFF
--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -77,9 +77,14 @@ func (githubApiClient *GithubApiClient) FetchPages(path string, queryParams *url
 
 	for i := 2; i <= pages; i++ {
 		page := i
-		queryParams.Set("page", strconv.Itoa(page))
-		queryParams.Set("per_page", strconv.Itoa(pageSize))
-		err = githubApiClient.GetAsync(path, queryParams, handler)
+		queryCopy := url.Values{}
+		for k, v := range *queryParams {
+			queryCopy[k] = v
+		}
+		queryCopy.Set("page", strconv.Itoa(page))
+		queryCopy.Set("per_page", strconv.Itoa(pageSize))
+
+		err = githubApiClient.GetAsync(path, &queryCopy, handler)
 		if err != nil {
 			return err
 		}

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -104,9 +104,14 @@ func (gitlabApiClient *GitlabApiClient) FetchWithPaginationAnts(path string, que
 		for {
 			for i := conc; i > 0; i-- {
 				page := step*conc + i
-				queryParams.Set("per_page", strconv.Itoa(pageSize))
-				queryParams.Set("page", strconv.Itoa(page))
-				err = gitlabApiClient.GetAsync(path, queryParams, handler)
+				queryCopy := url.Values{}
+				for k, v := range *queryParams {
+					queryCopy[k] = v
+				}
+				queryCopy.Set("page", strconv.Itoa(page))
+				queryCopy.Set("per_page", strconv.Itoa(pageSize))
+
+				err = gitlabApiClient.GetAsync(path, &queryCopy, handler)
 				if err != nil {
 					return err
 				}
@@ -124,9 +129,15 @@ func (gitlabApiClient *GitlabApiClient) FetchWithPaginationAnts(path string, que
 		for i := 1; (i * pageSize) <= (total + pageSize); i++ {
 			// we need to save the value for the request so it is not overwritten
 			currentPage := i
-			queryParams.Set("per_page", strconv.Itoa(pageSize))
-			queryParams.Set("page", strconv.Itoa(currentPage))
-			err = gitlabApiClient.GetAsync(path, queryParams, handler)
+			queryCopy := url.Values{}
+			for k, v := range *queryParams {
+				queryCopy[k] = v
+
+			}
+			queryCopy.Set("page", strconv.Itoa(currentPage))
+			queryCopy.Set("per_page", strconv.Itoa(pageSize))
+
+			err = gitlabApiClient.GetAsync(path, &queryCopy, handler)
 
 			if err != nil {
 				return err

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -92,13 +92,13 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 
 	for nextStart < total {
 		nextStartTmp := nextStart
-		detailQuery := &url.Values{}
+		queryCopy := url.Values{}
 		for key, value := range *query {
-			(*detailQuery)[key] = value
+			queryCopy[key] = value
 		}
-		detailQuery.Set("maxResults", strconv.Itoa(pageSize))
-		detailQuery.Set("startAt", strconv.Itoa(nextStartTmp))
-		err = jiraApiClient.GetAsync(path, detailQuery, handler)
+		queryCopy.Set("maxResults", strconv.Itoa(pageSize))
+		queryCopy.Set("startAt", strconv.Itoa(nextStartTmp))
+		err = jiraApiClient.GetAsync(path, &queryCopy, handler)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Summary

when pass the pointer to apiclient.GetAsync, met some concurrent problems

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
We should new an object and pass this object's pointer to the goroutine func in every iteration

### Does this close any open issues?


### Current Behavior
Concurrent problems

### New Behavior
generated an new object and pass the pointer to go func for every iteration

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
