### PR TITLE
feat: reconfigure proxy and extend github settings

### DIFF
--- a/config-ui/src/components/Sidebar.jsx
+++ b/config-ui/src/components/Sidebar.jsx
@@ -22,7 +22,7 @@ const Sidebar = () => {
   return (
     <Card interactive={false} elevation={Elevation.ZERO} className='card sidebar-card'>
       <img src='/logo.svg' className='logo' />
-      <a href={ GRAFANA_URL } rel='noreferrer' target='_blank' className='dashboardBtnLink'>
+      <a href={GRAFANA_URL} rel='noreferrer' target='_blank' className='dashboardBtnLink'>
         <Button icon='grouped-bar-chart' outlined={true} className='dashboardBtn'>View Dashboards</Button>
       </a>
 

--- a/config-ui/src/data/NullConnection.js
+++ b/config-ui/src/data/NullConnection.js
@@ -3,6 +3,7 @@ const NullConnection = {
   ID: null,
   name: null,
   endpoint: null,
+  proxy: null,
   token: null,
   username: null,
   password: null,

--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -43,7 +43,7 @@ const ProviderFormLabels = {
   null: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
-    proxy: 'Proxy',
+    proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -51,7 +51,7 @@ const ProviderFormLabels = {
   gitlab: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
-    proxy: 'Proxy',
+    proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -59,7 +59,7 @@ const ProviderFormLabels = {
   jenkins: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
-    proxy: 'Proxy',
+    proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -67,7 +67,7 @@ const ProviderFormLabels = {
   jira: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
-    proxy: 'Proxy',
+    proxy: 'Proxy URL',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -75,7 +75,7 @@ const ProviderFormLabels = {
   github: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
-    proxy: 'Proxy',
+    proxy: 'Proxy URL',
     // token: 'Auth Token(s)',
     token: (
       <Tooltip

--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -43,6 +43,7 @@ const ProviderFormLabels = {
   null: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
+    proxy: 'Proxy',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -50,6 +51,7 @@ const ProviderFormLabels = {
   gitlab: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
+    proxy: 'Proxy',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -57,6 +59,7 @@ const ProviderFormLabels = {
   jenkins: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
+    proxy: 'Proxy',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -64,6 +67,7 @@ const ProviderFormLabels = {
   jira: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
+    proxy: 'Proxy',
     token: 'Basic Auth Token',
     username: 'Username',
     password: 'Password'
@@ -71,6 +75,7 @@ const ProviderFormLabels = {
   github: {
     name: 'Connection Name',
     endpoint: 'Endpoint URL',
+    proxy: 'Proxy',
     // token: 'Auth Token(s)',
     token: (
       <Tooltip
@@ -88,6 +93,7 @@ const ProviderFormPlaceholders = {
   null: {
     name: 'Enter Instance Name',
     endpoint: 'Enter Endpoint URL eg. https://null-api.localhost',
+    proxy: 'Enter Proxy URL eg. http://proxy.localhost:8080',
     token: 'Enter Auth Token eg. 3f5cda2a23ff410792e0',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'
@@ -95,6 +101,7 @@ const ProviderFormPlaceholders = {
   gitlab: {
     name: 'Enter Instance Name',
     endpoint: 'Enter Endpoint URL eg. https://gitlab.com/api/v4',
+    proxy: 'Enter Proxy URL eg. http://proxy.localhost:8080',
     token: 'Enter Auth Token eg. ff9d1ad0e5c04f1f98fa',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'
@@ -102,6 +109,7 @@ const ProviderFormPlaceholders = {
   jenkins: {
     name: 'Enter Instance Name',
     endpoint: 'Enter Endpoint URL eg. https://api.jenkins.io',
+    proxy: 'Enter Proxy URL eg. http://proxy.localhost:8080',
     token: 'Enter Auth Token eg. 6b057ffe68464c93a057',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'
@@ -109,6 +117,7 @@ const ProviderFormPlaceholders = {
   jira: {
     name: 'Enter Instance Name',
     endpoint: 'Enter Endpoint URL eg. https://your-domain.atlassian.net/rest/',
+    proxy: 'Enter Proxy URL eg. http://proxy.localhost:8080',
     token: 'Enter Auth Token eg. 8c06a7cc50b746bfab30',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'
@@ -116,6 +125,7 @@ const ProviderFormPlaceholders = {
   github: {
     name: 'Enter Instance Name',
     endpoint: 'Enter Endpoint URL eg. https://api.github.com',
+    proxy: 'Enter Proxy URL eg. http://proxy.localhost:8080',
     token: 'Enter Auth Token(s) eg. 4c5cbdb62c165e2b3d18, 40008ebccff9837bb8d2',
     username: 'Enter Username / E-mail',
     password: 'Enter Password'

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -101,7 +101,6 @@ function useConnectionManager ({
       case Providers.JIRA:
         connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, JIRA_PROXY: proxy }
         break
-        // @todo fix/set github payload
       case Providers.GITHUB:
         connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token, GITHUB_PROXY: proxy }
         break

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -301,15 +301,15 @@ function useConnectionManager ({
           break
         case Providers.GITLAB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.proxy)
+          setProxy(activeConnection.Proxy)
           break
         case Providers.GITHUB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.proxy)
+          setProxy(activeConnection.Proxy)
           break
         case Providers.JIRA:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.proxy)
+          setProxy(activeConnection.Proxy)
           break
       }
       ToastNotification.clear()

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -31,6 +31,7 @@ function useConnectionManager ({
 
   const [name, setName] = useState()
   const [endpointUrl, setEndpointUrl] = useState()
+  const [proxy, setProxy] = useState()
   const [token, setToken] = useState()
   const [username, setUsername] = useState()
   const [password, setPassword] = useState()
@@ -62,16 +63,16 @@ function useConnectionManager ({
       let connectionPayload
       switch (activeProvider.id) {
         case Providers.JIRA:
-          connectionPayload = { endpoint: endpointUrl, auth: token }
+          connectionPayload = { endpoint: endpointUrl, auth: token, proxy: proxy }
           break
         case Providers.GITHUB:
-          connectionPayload = { endpoint: endpointUrl, auth: token }
+          connectionPayload = { endpoint: endpointUrl, auth: token, proxy: proxy }
           break
         case Providers.JENKINS:
           connectionPayload = { endpoint: endpointUrl, username: username, password: password }
           break
         case Providers.GITLAB:
-          connectionPayload = { endpoint: endpointUrl, auth: token }
+          connectionPayload = { endpoint: endpointUrl, auth: token, proxy: proxy }
           break
       }
 
@@ -98,17 +99,17 @@ function useConnectionManager ({
     let connectionPayload
     switch (activeProvider.id) {
       case Providers.JIRA:
-        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token }
+        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, JIRA_PROXY: proxy }
         break
         // @todo fix/set github payload
       case Providers.GITHUB:
-        connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token }
+        connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token, GITHUB_PROXY: proxy }
         break
       case Providers.JENKINS:
         connectionPayload = { name: name, JENKINS_ENDPOINT: endpointUrl, JENKINS_USERNAME: username, JENKINS_PASSWORD: password }
         break
       case Providers.GITLAB:
-        connectionPayload = { name: name, GITLAB_ENDPOINT: endpointUrl, GITLAB_AUTH: token }
+        connectionPayload = { name: name, GITLAB_ENDPOINT: endpointUrl, GITLAB_AUTH: token, GITLAB_PROXY: proxy }
         break
     }
 
@@ -300,12 +301,15 @@ function useConnectionManager ({
           break
         case Providers.GITLAB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
+          setProxy(activeConnection.proxy)
           break
         case Providers.GITHUB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
+          setProxy(activeConnection.proxy)
           break
         case Providers.JIRA:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
+          setProxy(activeConnection.proxy)
           break
       }
       ToastNotification.clear()
@@ -356,11 +360,13 @@ function useConnectionManager ({
     testStatus,
     name,
     endpointUrl,
+    proxy,
     username,
     password,
     token,
     setName,
     setEndpointUrl,
+    setProxy,
     setToken,
     setUsername,
     setPassword,

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -99,7 +99,7 @@ function useConnectionManager ({
     let connectionPayload
     switch (activeProvider.id) {
       case Providers.JIRA:
-        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, JIRA_PROXY: proxy }
+        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, Proxy: proxy }
         break
       case Providers.GITHUB:
         connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token, GITHUB_PROXY: proxy }
@@ -300,15 +300,15 @@ function useConnectionManager ({
           break
         case Providers.GITLAB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.Proxy)
+          setProxy(activeConnection.Proxy || activeConnection.proxy)
           break
         case Providers.GITHUB:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.Proxy)
+          setProxy(activeConnection.Proxy || activeConnection.proxy)
           break
         case Providers.JIRA:
           setToken(activeConnection.basicAuthEncoded || activeConnection.Auth)
-          setProxy(activeConnection.Proxy)
+          setProxy(activeConnection.Proxy || activeConnection.proxy)
           break
       }
       ToastNotification.clear()

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -206,8 +206,8 @@ function useConnectionManager ({
         setActiveConnection({
           ...connectionData,
           name: connectionData.name || connectionData.Name,
-          // TODO: This needs to be Capital case for all json responses from the golang APIs
           endpoint: connectionData.endpoint || connectionData.Endpoint,
+          proxy: connectionData.proxy || connectionData.Proxy,
           username: connectionData.username || connectionData.Username,
           password: connectionData.password || connectionData.Password
         })

--- a/config-ui/src/hooks/useConnectionValidation.jsx
+++ b/config-ui/src/hooks/useConnectionValidation.jsx
@@ -52,7 +52,7 @@ function useConnectionValidation ({
       errs.push('Endpoint URL must end in trailing slash (/)')
     }
 
-    if (proxy !== '' && !validURIs.some(uri => proxy?.startsWith(uri))) {
+    if (proxy && proxy !== '' && !validURIs.some(uri => proxy?.startsWith(uri))) {
       errs.push('Proxy URL must be valid HTTP/S protocol')
     }
 

--- a/config-ui/src/hooks/useConnectionValidation.jsx
+++ b/config-ui/src/hooks/useConnectionValidation.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { ToastNotification } from '@/components/Toast'
+import { useState, useEffect, useCallback } from 'react'
 import {
   Providers,
 } from '@/data/Providers'
@@ -8,12 +7,17 @@ function useConnectionValidation ({
   activeProvider,
   name,
   endpointUrl,
+  proxy,
   token,
   username,
   password
 }) {
   const [errors, setErrors] = useState([])
   const [isValid, setIsValid] = useState(false)
+  const [validURIs, setValidURIs] = useState([
+    'http://',
+    'https://'
+  ])
 
   const clear = () => {
     setErrors([])
@@ -26,6 +30,7 @@ function useConnectionValidation ({
     console.log(
       'NAME', name,
       'ENDPOINT URL', endpointUrl,
+      'PROXY URL', proxy,
       'TOKEN', token,
       'USERNAME', username,
       'PASSWORD', password
@@ -47,6 +52,10 @@ function useConnectionValidation ({
       errs.push('Endpoint URL must end in trailing slash (/)')
     }
 
+    if (proxy !== '' && !validURIs.some(uri => proxy?.startsWith(uri))) {
+      errs.push('Proxy URL must be valid HTTP/S protocol')
+    }
+
     switch (activeProvider.id) {
       case Providers.GITHUB:
       case Providers.JIRA:
@@ -66,7 +75,16 @@ function useConnectionValidation ({
     }
 
     setErrors(errs)
-  }, [name, endpointUrl, token, username, password, activeProvider])
+  }, [
+    name,
+    endpointUrl,
+    proxy,
+    token,
+    username,
+    password,
+    activeProvider,
+    validURIs
+  ])
 
   useEffect(() => {
     console.log('>>> CONNECTION FORM ERRORS...', errors)
@@ -81,7 +99,8 @@ function useConnectionValidation ({
     errors,
     isValid,
     validate,
-    clear
+    clear,
+    setValidURIs
   }
 }
 

--- a/config-ui/src/hooks/useConnectionValidation.jsx
+++ b/config-ui/src/hooks/useConnectionValidation.jsx
@@ -36,8 +36,12 @@ function useConnectionValidation ({
       'PASSWORD', password
     )
 
-    if (!name || name.length <= 2) {
+    if (!name) {
       errs.push('Connection Source name is required')
+    }
+
+    if (name && name.length <= 2) {
+      errs.push('Connection Source name too short/incomplete')
     }
 
     if (!endpointUrl || endpointUrl.length <= 2) {

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -5,6 +5,7 @@ import {
 import { ToastNotification } from '@/components/Toast'
 import { DEVLAKE_ENDPOINT } from '@/utils/config'
 import request from '@/utils/request'
+import { Providers } from '@/data/Providers'
 
 function useSettingsManager ({
   activeProvider,
@@ -20,8 +21,8 @@ function useSettingsManager ({
 
   const saveSettings = () => {
     setIsSaving(true)
-
     const settingsPayload = {
+      ...buildConnectionPayload(activeConnection),
       ...settings,
       // DEV: true
     }
@@ -68,6 +69,49 @@ function useSettingsManager ({
     }, 2000)
   }
 
+  const buildConnectionPayload = (connection) => {
+    let connectionPayload = {}
+    switch (activeProvider.id) {
+      case Providers.JIRA:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          Endpoint: connection.endpoint,
+          BasicAuthEncoded: connection.basicAuthEncoded,
+          Proxy: connection.proxy || connection.Proxy
+        }
+        break
+      case Providers.GITHUB:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          GITHUB_ENDPOINT: connection.endpoint,
+          GITHUB_AUTH: connection.Auth,
+          GITHUB_PROXY: connection.proxy || connection.Proxy
+        }
+        break
+      case Providers.JENKINS:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          JENKINS_ENDPOINT: connection.endpoint,
+          JENKINS_USERNAME: connection.username,
+          JENKINS_PASSWORD: connection.password
+        }
+        break
+      case Providers.GITLAB:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          GITLAB_ENDPOINT: connection.endpoint,
+          GITLAB_AUTH: connection.Auth,
+          GITLAB_PROXY: connection.proxy || connection.Proxy
+        }
+        break
+    }
+    return connectionPayload
+  }
+
   const clear = () => {
 
   }
@@ -88,6 +132,7 @@ function useSettingsManager ({
     setIsTesting,
     setErrors,
     setShowError,
+    buildConnectionPayload
   }
 }
 

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -69,6 +69,7 @@ export default function AddConnection () {
     activeProvider,
     name,
     endpointUrl,
+    proxy,
     token,
     username,
     password

--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -44,11 +44,13 @@ export default function AddConnection () {
     testStatus,
     name,
     endpointUrl,
+    proxy,
     token,
     username,
     password,
     setName,
     setEndpointUrl,
+    setProxy,
     setUsername,
     setPassword,
     setToken,
@@ -148,6 +150,7 @@ export default function AddConnection () {
                   activeProvider={activeProvider}
                   name={name}
                   endpointUrl={endpointUrl}
+                  proxy={proxy}
                   token={token}
                   username={username}
                   password={password}
@@ -157,6 +160,7 @@ export default function AddConnection () {
                   onValidate={validate}
                   onNameChange={setName}
                   onEndpointChange={setEndpointUrl}
+                  onProxyChange={setProxy}
                   onTokenChange={setToken}
                   onUsernameChange={setUsername}
                   onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -58,6 +58,7 @@ export default function ConfigureConnection () {
     activeConnection,
     name,
     endpointUrl,
+    proxy,
     username,
     password,
     token,
@@ -68,6 +69,7 @@ export default function ConfigureConnection () {
     isFetching: isLoadingConnection,
     setName,
     setEndpointUrl,
+    setProxy,
     setUsername,
     setPassword,
     setToken,
@@ -245,6 +247,7 @@ export default function ConfigureConnection () {
                             activeProvider={activeProvider}
                             name={name}
                             endpointUrl={endpointUrl}
+                            proxy={proxy}
                             token={token}
                             username={username}
                             password={password}
@@ -254,6 +257,7 @@ export default function ConfigureConnection () {
                             onValidate={validate}
                             onNameChange={setName}
                             onEndpointChange={setEndpointUrl}
+                            onProxyChange={setProxy}
                             onTokenChange={setToken}
                             onUsernameChange={setUsername}
                             onPasswordChange={setPassword}

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -103,6 +103,7 @@ export default function ConfigureConnection () {
     activeProvider,
     name,
     endpointUrl,
+    proxy,
     token,
     username,
     password

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -341,30 +341,32 @@ export default function ConnectionForm (props) {
             </div>
           </>
         )}
-        <div className='formContainer'>
-          <FormGroup
-            disabled={isTesting || isSaving || isLocked}
-            labelFor='connection-proxy'
-            className='formGroup'
-            contentClassName='formGroupContent'
-          >
-            <Label>
-              {labels
-                ? labels.proxy
-                : (
-                  <>Proxy&nbsp;URL</>
-                  )}
-            </Label>
-            <InputGroup
-              id='github-proxy'
-              placeholder={placeholders.proxy ? placeholders.proxy : 'http://proxy.localhost:8080'}
-              defaultValue={proxy}
-              onChange={(e) => onProxyChange(e.target.value)}
+        {[Providers.GITHUB, Providers.GITLAB, Providers.JIRA].includes(activeProvider.id) && (
+          <div className='formContainer'>
+            <FormGroup
               disabled={isTesting || isSaving || isLocked}
-              className='input'
-            />
-          </FormGroup>
-        </div>
+              labelFor='connection-proxy'
+              className='formGroup'
+              contentClassName='formGroupContent'
+            >
+              <Label>
+                {labels
+                  ? labels.proxy
+                  : (
+                    <>Proxy&nbsp;URL</>
+                    )}
+              </Label>
+              <InputGroup
+                id='github-proxy'
+                placeholder={placeholders.proxy ? placeholders.proxy : 'http://proxy.localhost:8080'}
+                defaultValue={proxy}
+                onChange={(e) => onProxyChange(e.target.value)}
+                disabled={isTesting || isSaving || isLocked}
+                className='input'
+              />
+            </FormGroup>
+          </div>
+        )}
         <div
           className='form-actions-block'
           style={{ display: 'flex', marginTop: '30px', justifyContent: 'space-between' }}

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -345,6 +345,7 @@ export default function ConnectionForm (props) {
           <div className='formContainer'>
             <FormGroup
               disabled={isTesting || isSaving || isLocked}
+              inline={true}
               labelFor='connection-proxy'
               className='formGroup'
               contentClassName='formGroupContent'

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -26,6 +26,7 @@ export default function ConnectionForm (props) {
     token,
     username,
     password,
+    proxy = '',
     isSaving,
     isTesting,
     showError,
@@ -39,6 +40,7 @@ export default function ConnectionForm (props) {
     onTokenChange = () => {},
     onUsernameChange = () => {},
     onPasswordChange = () => {},
+    onProxyChange = () => {},
     onValidate = () => {},
     authType = 'token',
     sourceLimits = {},
@@ -339,6 +341,27 @@ export default function ConnectionForm (props) {
             </div>
           </>
         )}
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isTesting || isSaving || isLocked}
+            labelFor='connection-proxy'
+            helperText='PROXY'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Proxy URL
+            </Label>
+            <InputGroup
+              id='github-proxy'
+              placeholder='http://your-proxy-server.com:1080'
+              defaultValue={proxy}
+              onChange={(e) => onProxyChange(e.target.value)}
+              disabled={isTesting || isSaving || isLocked}
+              className='input'
+            />
+          </FormGroup>
+        </div>
         <div
           className='form-actions-block'
           style={{ display: 'flex', marginTop: '30px', justifyContent: 'space-between' }}

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -345,16 +345,19 @@ export default function ConnectionForm (props) {
           <FormGroup
             disabled={isTesting || isSaving || isLocked}
             labelFor='connection-proxy'
-            helperText='PROXY'
             className='formGroup'
             contentClassName='formGroupContent'
           >
             <Label>
-              Proxy URL
+              {labels
+                ? labels.proxy
+                : (
+                  <>Proxy&nbsp;URL</>
+                  )}
             </Label>
             <InputGroup
               id='github-proxy'
-              placeholder='http://your-proxy-server.com:1080'
+              placeholder={placeholders.proxy ? placeholders.proxy : 'http://proxy.localhost:8080'}
               defaultValue={proxy}
               onChange={(e) => onProxyChange(e.target.value)}
               disabled={isTesting || isSaving || isLocked}

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -45,9 +45,9 @@ export default function GithubSettings (props) {
     setPrComponent(connection.PrComponent)
     setIssueSeverity(connection.IssueSeverity)
     setIssuePriority(connection.IssuePriority)
-    setIssueComponent(connection.issueComponent)
+    setIssueComponent(connection.IssueComponent)
     setIssueTypeBug(connection.IssueTypeBug)
-    setIssueTypeRequirement(connection.IssueRequirement)
+    setIssueTypeRequirement(connection.IssueTypeRequirement)
     setIssueTypeIncident(connection.IssueTypeIncident)
   }, [connection])
 
@@ -58,7 +58,7 @@ export default function GithubSettings (props) {
       GITHUB_ISSUE_SEVERITY: issueSeverity,
       GITHUB_ISSUE_COMPONENT: issueComponent,
       GITHUB_ISSUE_PRIORITY: issuePriority,
-      GITHUB_ISSUE_REQUIREMENT: issueTypeRequirement,
+      GITHUB_ISSUE_TYPE_REQUIREMENT: issueTypeRequirement,
       GITHUB_ISSUE_TYPE_BUG: issueTypeBug,
       GITHUB_ISSUE_TYPE_INCIDENT: issueTypeIncident,
     }

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -45,6 +45,7 @@ export default function GithubSettings (props) {
     setPrComponent(connection.PrComponent)
     setIssueSeverity(connection.IssueSeverity)
     setIssuePriority(connection.IssuePriority)
+    setIssueComponent(connection.issueComponent)
     setIssueTypeBug(connection.IssueTypeBug)
     setIssueTypeRequirement(connection.IssueRequirement)
     setIssueTypeIncident(connection.IssueTypeIncident)

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -17,7 +17,6 @@ export default function GithubSettings (props) {
   const { connection, provider, isSaving, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
-  // const [githubProxy, setGithubProxy] = useState(null)
   const [prType, setPrType] = useState('')
   const [prComponent, setPrComponent] = useState('')
   const [issueSeverity, setIssueSeverity] = useState('')
@@ -28,10 +27,6 @@ export default function GithubSettings (props) {
   const [issueTypeIncident, setIssueTypeIncident] = useState('')
 
   const [errors, setErrors] = useState([])
-
-  // const cancel = () => {
-  //   history.push(`/integrations/${provider.id}`)
-  // }
 
   useEffect(() => {
     setErrors(['This integration doesn’t require any configuration.'])
@@ -47,12 +42,10 @@ export default function GithubSettings (props) {
 
   useEffect(() => {
     // setGithubProxy(connection.proxy)
-
   }, [connection])
 
   useEffect(() => {
     const settings = {
-      // GITHUB_PROXY: githubProxy
       GITHUB_PR_TYPE: prType,
       GITHUB_PR_COMPONENT: prComponent,
       GITHUB_ISSUE_SEVERITY: issueSeverity,
@@ -65,7 +58,6 @@ export default function GithubSettings (props) {
     console.log('>> GITHUB INSTANCE SETTINGS FIELDS CHANGED!', settings)
     onSettingsChange(settings)
   }, [
-    // githubProxy,
     prType,
     prComponent,
     issueSeverity,

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -42,6 +42,14 @@ export default function GithubSettings (props) {
 
   useEffect(() => {
     // setGithubProxy(connection.proxy)
+    // @todo: TEST/Validate Backend API Changes! (Depends on PR #1282)
+    // setPrType(connection.prType)
+    // setPrComponent(connection.prComponent)
+    // setIssueSeverity(connection.issueSeverity)
+    // setIssuePriority(connection.issuePrority)
+    // setIssueTypeBug(connection.issueTypeBug)
+    // setIssueTypeRequirement(connection.issueTypeRequirement)
+    // setIssueTypeIncident(connection.issueTypeIncident)
   }, [connection])
 
   useEffect(() => {

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -41,15 +41,13 @@ export default function GithubSettings (props) {
   }, [errors, onSettingsChange, connectionId, providerId])
 
   useEffect(() => {
-    // setGithubProxy(connection.proxy)
-    // @todo: TEST/Validate Backend API Changes! (Depends on PR #1282)
-    // setPrType(connection.prType)
-    // setPrComponent(connection.prComponent)
-    // setIssueSeverity(connection.issueSeverity)
-    // setIssuePriority(connection.issuePrority)
-    // setIssueTypeBug(connection.issueTypeBug)
-    // setIssueTypeRequirement(connection.issueTypeRequirement)
-    // setIssueTypeIncident(connection.issueTypeIncident)
+    setPrType(connection.PrType)
+    setPrComponent(connection.PrComponent)
+    setIssueSeverity(connection.IssueSeverity)
+    setIssuePriority(connection.IssuePriority)
+    setIssueTypeBug(connection.IssueTypeBug)
+    setIssueTypeRequirement(connection.IssueRequirement)
+    setIssueTypeIncident(connection.IssueTypeIncident)
   }, [connection])
 
   useEffect(() => {

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -7,6 +7,7 @@ import {
   FormGroup,
   InputGroup,
   Label,
+  Tag
 } from '@blueprintjs/core'
 
 import '@/styles/integration.scss'
@@ -16,13 +17,21 @@ export default function GithubSettings (props) {
   const { connection, provider, isSaving, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
-  const [githubProxy, setGithubProxy] = useState(null)
+  // const [githubProxy, setGithubProxy] = useState(null)
+  const [prType, setPrType] = useState('')
+  const [prComponent, setPrComponent] = useState('')
+  const [issueSeverity, setIssueSeverity] = useState('')
+  const [issueComponent, setIssueComponent] = useState('')
+  const [issuePriority, setIssuePriority] = useState('')
+  const [issueTypeBug, setIssueTypeBug] = useState('')
+  const [issueTypeRequirement, setIssueTypeRequirement] = useState('')
+  const [issueTypeIncident, setIssueTypeIncident] = useState('')
 
   const [errors, setErrors] = useState([])
 
-  const cancel = () => {
-    history.push(`/integrations/${provider.id}`)
-  }
+  // const cancel = () => {
+  //   history.push(`/integrations/${provider.id}`)
+  // }
 
   useEffect(() => {
     setErrors(['This integration doesn’t require any configuration.'])
@@ -37,29 +46,224 @@ export default function GithubSettings (props) {
   }, [errors, onSettingsChange, connectionId, providerId])
 
   useEffect(() => {
-    setGithubProxy(connection.proxy)
+    // setGithubProxy(connection.proxy)
+
   }, [connection])
 
   useEffect(() => {
     const settings = {
-      GITHUB_PROXY: githubProxy
+      // GITHUB_PROXY: githubProxy
+      GITHUB_PR_TYPE: prType,
+      GITHUB_PR_COMPONENT: prComponent,
+      GITHUB_ISSUE_SEVERITY: issueSeverity,
+      GITHUB_ISSUE_COMPONENT: issueComponent,
+      GITHUB_ISSUE_PRIORITY: issuePriority,
+      GITHUB_ISSUE_REQUIREMENT: issueTypeRequirement,
+      GITHUB_ISSUE_TYPE_BUG: issueTypeBug,
+      GITHUB_ISSUE_TYPE_INCIDENT: issueTypeIncident,
     }
     console.log('>> GITHUB INSTANCE SETTINGS FIELDS CHANGED!', settings)
     onSettingsChange(settings)
   }, [
-    githubProxy,
+    // githubProxy,
+    prType,
+    prComponent,
+    issueSeverity,
+    issueComponent,
+    issuePriority,
+    issueTypeRequirement,
+    issueTypeBug,
+    issueTypeIncident,
     onSettingsChange
   ])
 
   return (
     <>
-      <h3 className='headline'>Github Proxy</h3>
+      <h3 className='headline'>Pull Request Enrichment Options <Tag className='bp3-form-helper-text'>RegExp</Tag></h3>
+      <p className=''>Enrich GitHub PRs using Label data.</p>
+
+      <div style={{ maxWidth: '60%' }}>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-pr-type'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Type
+            </Label>
+            <InputGroup
+              id='github-pr-type'
+              placeholder='type/(.*)$'
+              defaultValue={prType}
+              onChange={(e) => setPrType(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-pr-component'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Component
+            </Label>
+            <InputGroup
+              id='github-pr-type'
+              placeholder='component/(.*)$'
+              defaultValue={prComponent}
+              onChange={(e) => setPrComponent(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+      </div>
+
+      <h3 className='headline'>Issue Type Enrichment Options <Tag className='bp3-form-helper-text'>RegExp</Tag></h3>
+      <p className=''>Enrich GitHub Issues using Label data.</p>
+      <div style={{ maxWidth: '60%' }}>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-severity'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Severity
+            </Label>
+            <InputGroup
+              id='github-issue-severity'
+              placeholder='type/(.*)$'
+              defaultValue={issueSeverity}
+              onChange={(e) => setIssueSeverity(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-component'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Component
+            </Label>
+            <InputGroup
+              id='github-issue-component'
+              placeholder='component/(.*)$'
+              defaultValue={issueComponent}
+              onChange={(e) => setIssueComponent(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-priority'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              Priority
+            </Label>
+            <InputGroup
+              id='github-issue-priority'
+              placeholder='(highest|high|medium|low)$'
+              defaultValue={issuePriority}
+              onChange={(e) => setIssuePriority(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-requirement'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              <span className='bp3-tag tag-requirement'>Requirement</span>
+            </Label>
+            <InputGroup
+              id='github-issue-requirement'
+              placeholder='(feat|feature|proposal|requirement)$'
+              defaultValue={issueTypeRequirement}
+              onChange={(e) => setIssueTypeRequirement(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-bug'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              <span className='bp3-tag tag-bug'>Bug</span>
+            </Label>
+            <InputGroup
+              id='github-issue-bug'
+              placeholder='(bug|broken)$'
+              defaultValue={issueTypeBug}
+              onChange={(e) => setIssueTypeBug(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+        <div className='formContainer'>
+          <FormGroup
+            disabled={isSaving}
+            labelFor='github-issue-bug'
+            className='formGroup'
+            contentClassName='formGroupContent'
+          >
+            <Label>
+              <span className='bp3-tag tag-incident'>Incident</span>
+            </Label>
+            <InputGroup
+              id='github-issue-incident'
+              placeholder='(incident|p0|p1|p2)$'
+              defaultValue={issueTypeIncident}
+              onChange={(e) => setIssueTypeIncident(e.target.value)}
+              disabled={isSaving}
+              className='input'
+              maxLength={255}
+            />
+          </FormGroup>
+        </div>
+      </div>
+      {/* <h3 className='headline'>Github Proxy</h3>
       <p className=''>Optional</p>
       <div className='formContainer'>
         <FormGroup
           disabled={isSaving}
           labelFor='github-proxy'
-          helperText='GITHUB_PROXY'
+          helperText='PROXY'
           className='formGroup'
           contentClassName='formGroupContent'
         >
@@ -75,7 +279,7 @@ export default function GithubSettings (props) {
             className='input'
           />
         </FormGroup>
-      </div>
+      </div> */}
     </>
   )
 }

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -108,6 +108,7 @@ export default function JiraSettings (props) {
       jiraIssueEpicKeyField,
       jiraIssueStoryPointField,
       jiraIssueStoryCoefficient,
+      remoteLinkCommitSha,
       onSettingsChange)
   }, [
     typeMappingBug,

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState, useCallback, Fragment } from 'react'
 import {
   ButtonGroup,
+  FormGroup,
+  InputGroup,
   MenuItem,
   Position,
   Button,
   Intent,
+  Label,
   Icon,
   Colors,
   Tag,
@@ -45,6 +48,7 @@ export default function JiraSettings (props) {
   const [jiraIssueEpicKeyField, setJiraIssueEpicKeyField] = useState('')
   const [jiraIssueStoryCoefficient, setJiraIssueStoryCoefficient] = useState(1)
   const [jiraIssueStoryPointField, setJiraIssueStoryPointField] = useState('')
+  const [remoteLinkCommitSha, setRemoteLinkCommitSha] = useState('')
 
   const [requirementTags, setRequirementTags] = useState([])
   const [bugTags, setBugTags] = useState([])
@@ -91,6 +95,7 @@ export default function JiraSettings (props) {
       epicKeyField: jiraIssueEpicKeyField?.value || '',
       typeMappings: typeMappingAll,
       storyPointField: jiraIssueStoryPointField?.value || '',
+      remotelinkCommitShaPattern: remoteLinkCommitSha || ''
     }
     onSettingsChange(settings)
     console.log('>> JIRA INSTANCE SETTINGS FIELDS CHANGED!', settings)
@@ -113,6 +118,7 @@ export default function JiraSettings (props) {
     jiraIssueEpicKeyField,
     jiraIssueStoryPointField,
     jiraIssueStoryCoefficient,
+    remoteLinkCommitSha,
     onSettingsChange
   ])
 
@@ -142,6 +148,7 @@ export default function JiraSettings (props) {
       // Parse Type Mappings (V2)
       parseTypeMappings(connection.typeMappings)
       setStatusMappings([])
+      setRemoteLinkCommitSha(connection.remotelinkCommitShaPattern)
       // setJiraIssueEpicKeyField(fieldsList.find(f => f.value === connection.epicKeyField))
       // setJiraIssueStoryPointField(fieldsList.find(f => f.value === connection.storyPointField))
     }
@@ -465,7 +472,7 @@ export default function JiraSettings (props) {
         </div>
       </div>
       <div className='headlineContainer'>
-        <h3 className='headline'>Story Point Field (Optional)</h3>
+        <h3 className='headline'>Story Point Field</h3>
         <p className=''>Choose the JIRA field you’re using to represent the granularity of a requirement-type issue.</p>
         <div style={{ display: 'flex', minWidth: '260px' }}>
           <ButtonGroup disabled={isSaving}>
@@ -534,6 +541,32 @@ export default function JiraSettings (props) {
             )}
           </div>
         </div>
+      </div>
+      <div className='headlineContainer'>
+        <h3 className='headline'>Remotelink Commit SHA <Tag className='bp3-form-helper-text'>RegExp</Tag></h3>
+        <p>Issue Weblink <strong>Commit SHA Pattern</strong> (Add weblink to jira for gitlab.)</p>
+      </div>
+      <div className='formContainer' style={{ maxWidth: '550px' }}>
+        <FormGroup
+          fill={false}
+          disabled={isSaving}
+          labelFor='jira-remotelink-sha'
+          className='formGroup'
+          contentClassName='formGroupContent'
+        >
+          <Label>
+            Commit Pattern
+          </Label>
+          <InputGroup
+            id='jira-remotelink-sha'
+            fill={false}
+            placeholder='/commit/([0-9a-f]{40})$'
+            defaultValue={remoteLinkCommitSha}
+            onChange={(e) => setRemoteLinkCommitSha(e.target.value)}
+            disabled={isSaving}
+            className='input'
+          />
+        </FormGroup>
       </div>
     </>
   )

--- a/config-ui/src/styles/sidebar.scss
+++ b/config-ui/src/styles/sidebar.scss
@@ -2,7 +2,7 @@
   width: 250px;
   border-radius: 0;
   background: #ffffff;
-  z-index: 1;
+  z-index: 10000;
   box-shadow: none;
   position: fixed;
   height: 100vh;

--- a/config-ui/src/styles/sidebar.scss
+++ b/config-ui/src/styles/sidebar.scss
@@ -2,7 +2,7 @@
   width: 250px;
   border-radius: 0;
   background: #ffffff;
-  z-index: 10000;
+  z-index: 10;
   box-shadow: none;
   position: fixed;
   height: 100vh;


### PR DESCRIPTION
###  Config-UI / Data Integrations / **GitHub**

- [x] Re-configure **Proxy** (Optional Field) as a `Connection` level field
- [x] Extend/Support new **GitHub** Provider Settings
  - GITHUB_PR_TYPE
  - GITHUB_PR_COMPONENT
  - GITHUB_ISSUE_SEVERITY
  - GITHUB_ISSUE_COMPONENT
  - GITHUB_ISSUE_PRIORITY
  - GITHUB_ISSUE_REQUIREMENT
  - GITHUB_ISSUE_TYPE_BUG
  - GITHUB_ISSUE_TYPE_INCIDENT
- [x] Extend/Support new **JIRA** Provider Settings
  - `RemoteLinkCommitSha`
- [x] Update Connection Validation Hook
- [x] Test/Verify GitHub Provider Integration
- [x] Test All Data Integrations
- [x] Test Production Build

### Description
This PR re-configures the **Proxy** field as a _Connection_ level parameter for all applicable providers (**GitHub**, **JIRA**, **GitLab**). It also enhances the **GitHub** Provider Settings with 8 new fields related to PR and Issue Enrichment using `Labels`. It also adds the `RemoteLinkCommitSha` field for **JIRA** Provider.

NOTE: This PR will impact and resolve multiple issue tickets related to Data Provider settings & Proxy (outlined below)

### Does this close any open issues?
#1223, #1247, #1248, #1249, #1252, #1264

### Screenshots
<img width="1209" alt="Screen Shot 2022-03-03 at 11 38 05 PM" src="https://user-images.githubusercontent.com/1742233/156700478-ed018246-5bed-4d4b-859c-219f1a3ea604.png">
<img width="1210" alt="Screen Shot 2022-03-03 at 11 38 24 PM" src="https://user-images.githubusercontent.com/1742233/156700472-382f7602-73f9-494f-b8fd-ede01950202b.png">
<img width="1106" alt="Screen Shot 2022-03-03 at 11 39 41 PM" src="https://user-images.githubusercontent.com/1742233/156700584-a1d7c14d-2b9a-46fb-80c3-0f518a643562.png">


### Older Screenshots
<img width="1143" alt="Screen Shot 2022-02-24 at 9 04 57 AM" src="https://user-images.githubusercontent.com/1742233/155539027-b9956480-865d-4768-9ed3-489df79a1a12.png">
<img width="967" alt="Screen Shot 2022-02-25 at 11 15 52 PM" src="https://user-images.githubusercontent.com/1742233/155829154-2497ae0c-8b60-4b0e-a6a8-f099c175c0e8.png">
<img width="951" alt="Screen Shot 2022-02-25 at 11 38 16 PM" src="https://user-images.githubusercontent.com/1742233/155829196-57716ba8-f26b-4914-b417-84d39b32e25a.png">
<img width="949" alt="Screen Shot 2022-02-25 at 11 37 39 PM" src="https://user-images.githubusercontent.com/1742233/155829197-f3ad9d47-1c17-4a66-9280-ad81cf30c866.png">
<img width="862" alt="Screen Shot 2022-02-25 at 11 39 15 PM" src="https://user-images.githubusercontent.com/1742233/155829215-0097355f-a9ad-4695-9b4d-52a1d8056963.png">
<img width="1064" alt="Screen Shot 2022-02-25 at 11 41 42 PM" src="https://user-images.githubusercontent.com/1742233/155829283-c917dc4b-4581-46d7-8099-49a251fb9306.png">
<img width="1124" alt="Screen Shot 2022-02-25 at 11 45 45 PM" src="https://user-images.githubusercontent.com/1742233/155829385-6535c0f1-d9f6-4d1b-aea1-4bd705bb02ad.png">

