### PR TITLE
fix(jenkins): change delete scope

### DIFF
--- a/plugins/jenkins/tasks/jenkins_build_convertor.go
+++ b/plugins/jenkins/tasks/jenkins_build_convertor.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ConvertBuilds(ctx context.Context) error {
-	err := lakeModels.Db.Delete(&devops.Build{}, "`job_id` not in (select `id` from jobs)").Error
+	err := lakeModels.Db.Where("id like 'jenkins:JenkinsBuild:%'").Delete(&devops.Build{}).Error
 	if err != nil {
 		return err
 	}

--- a/plugins/jenkins/tasks/jenkins_job_convertor.go
+++ b/plugins/jenkins/tasks/jenkins_job_convertor.go
@@ -14,8 +14,7 @@ func ConvertJobs(ctx context.Context) error {
 	jenkinsJob := &jenkinsModels.JenkinsJob{}
 
 	jobIdGen := didgen.NewDomainIdGenerator(jenkinsJob)
-	err := lakeModels.Db.
-		Delete(&devops.Job{}, "`name` not in (select `name` from jenkins_jobs)").Error
+	err := lakeModels.Db.Where("id like 'jenkins:JenkinsJob:%'").Delete(&devops.Job{}).Error
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Summary

Changed jenkins job delete scope

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
only delete builds and jobs which belong to jenkins

### Does this close any open issues?
closes #1229

### Current Behavior
Delete all builds and jobs whether is belong to jenkins


### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
