### PR TITLE
fix: jira proxy should be lowercase

### DIFF
--- a/plugins/jira/models/jira_source.go
+++ b/plugins/jira/models/jira_source.go
@@ -16,7 +16,7 @@ type JiraSource struct {
 	EpicKeyField               string `gorm:"type:varchar(50);" json:"epicKeyField"`
 	StoryPointField            string `gorm:"type:varchar(50);" json:"storyPointField"`
 	RemotelinkCommitShaPattern string `gorm:"type:varchar(255);comment='golang regexp, the first group will be recognized as commit sha, ref https://github.com/google/re2/wiki/Syntax'" json:"remotelinkCommitShaPattern"`
-	Proxy                      string
+	Proxy                      string `json:"proxy"`
 }
 
 type JiraIssueTypeMapping struct {


### PR DESCRIPTION
# Summary

Change proxy field into lowercase, related to #1288

![156133192-fc6a02f0-d742-4d08-88c2-3532a016c4ee](https://user-images.githubusercontent.com/61080/156134224-6232754f-6ca6-4325-b0c5-c977b7f08de0.png)



### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
