### PR TITLE
fix: create pipeline > restore basic textarea editor in advanced mode

### DIFF
--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -10,7 +10,7 @@ import {
   Button, Icon, Intent, Switch,
   FormGroup, ButtonGroup, InputGroup,
   Elevation,
-  // TextArea,
+  TextArea,
   Card,
   Popover,
   Tooltip,
@@ -35,7 +35,7 @@ import Nav from '@/components/Nav'
 import Sidebar from '@/components/Sidebar'
 import AppCrumbs from '@/components/Breadcrumbs'
 import Content from '@/components/Content'
-import CodeEditor from '@uiw/react-textarea-code-editor'
+// import CodeEditor from '@uiw/react-textarea-code-editor'
 import { ReactComponent as HelpIcon } from '@/images/help.svg'
 import { ReactComponent as BackArrowIcon } from '@/images/undo.svg'
 import RunPipelineIcon from '@/images/duplicate.png'
@@ -637,15 +637,16 @@ const CreatePipeline = (props) => {
                             </>
                           )}
                         </h3>
-                        {/* <TextArea
-                          growVertically={true}
+                        <TextArea
+                          growVertically={false}
                           fill={true}
                           className='codeArea'
                           style={{ height: '440px !important', maxWidth: '640px' }}
                           value={rawConfiguration}
                           onChange={(e) => setRawConfiguration(e.target.value)}
-                        /> */}
-                        <div
+                        />
+                        {/* @todo: fix bug with @uiw/react-textarea-code-editor in a future release */}
+                        {/* <div
                           className='code-editor-wrapper' style={{
                             minHeight: '384px',
                             height: '440px !important',
@@ -669,7 +670,7 @@ const CreatePipeline = (props) => {
                               fontFamily: 'JetBrains Mono,Source Code Pro,ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace',
                             }}
                           />
-                        </div>
+                        </div> */}
                         <div
                           className='code-editor-card-footer'
                           style={{


### PR DESCRIPTION
### Config UI / Pipelines / Create Pipeline (**Advanced Mode**)

- [x] Restore Basic TextareaEditor
- [x] Test Pipeline Configuration loading
- [x] Test Production Build

### Description
This PR downgrades the **Enhanced** `CodeEditor` to a **Basic** `TextArea` Editor in order to restore functionality for Advanced Pipeline Editing for Config-UI in both development-mode and with **Docker** production-mode. After much troubleshooting there appears to be a problem with the package `@uiw/react-textarea-code-editor` and the application in Built/Minified mode. This will require more troubleshooting in `v0.10.0` and the CodeEditor will be upgraded in a future release with a replacement package or fix.

### Does this close any open issues?
#1251

### Current Behavior
The Pipeline Advanced Editor is malfunctioning in Production UI mode.

### New Behavior
The Pipeline Advanced Editor is working in both development and production mode.

### Screenshots
<img width="1194" alt="Screen Shot 2022-03-01 at 11 44 11 AM" src="https://user-images.githubusercontent.com/1742233/156211342-47bd8f03-ecfe-4817-84b4-c695bf1f98d0.png">

