### PR TITLE
fix: jira settings > enable reset query on multiselect fields

### DIFF
--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -205,6 +205,7 @@ export default function JiraSettings (props) {
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
             disabled={isSaving}
+            resetOnSelect={true}
             placeholder='< Select one or more Requirement Tags >'
             popoverProps={{ usePortal: false, minimal: true, fill: true, style: { width: '100%' } }}
             className='multiselector-requirement-type'
@@ -271,6 +272,7 @@ export default function JiraSettings (props) {
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
             disabled={isSaving}
+            resetOnSelect={true}
             placeholder='< Select one or more Bug Tags >'
             popoverProps={{ usePortal: false, minimal: true }}
             className='multiselector-bug-type'
@@ -337,6 +339,7 @@ export default function JiraSettings (props) {
         <div className='issue-type-multiselect-selector' style={{ minWidth: '200px', width: '50%' }}>
           <MultiSelect
             disabled={isSaving}
+            resetOnSelect={true}
             placeholder='< Select one or more Incident Tags >'
             popoverProps={{ usePortal: false, minimal: true }}
             className='multiselector-incident-type'


### PR DESCRIPTION
### Config UI / Data Integrations / JIRA

- [x] Enable `resetOnSelect` feature for **MultiSelect** Fields

### Description
This PR enables the  `resetOnSelect` for the BlueprintJS **MultiSelect** widgets for the **JIRA** Issue Type Mapping fields. Which will clear the user's typed entry keywords after an option is selected from the Dropdown Menu.

### Does this close any open issues?
#1250 

### Current Behavior
When searching for a tag the entered keywords (query) is not cleared after Selecting an option.

### New Behavior
The component will be Reset after a Selection is made so the search keywords (query) is cleared.

### Screenshots
<img width="1101" alt="Screen Shot 2022-03-01 at 12 39 56 PM" src="https://user-images.githubusercontent.com/1742233/156220247-3b9fe970-8321-4b2e-8a04-35173ed88355.png">

