### PR TITLE
fix(frontend): modify jira url for issuetyp and field

### DIFF
--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -31,8 +31,8 @@ export default function JiraSettings (props) {
   // const history = useHistory()
 
   const API_PROXY_ENDPOINT = `/api/plugins/jira/sources/${connection?.ID}/proxy/rest`
-  const ISSUE_TYPES_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/issuetype`
-  const ISSUE_FIELDS_ENDPOINT = `${API_PROXY_ENDPOINT}/api/3/field`
+  const ISSUE_TYPES_ENDPOINT = `${API_PROXY_ENDPOINT}/api/2/issuetype`
+  const ISSUE_FIELDS_ENDPOINT = `${API_PROXY_ENDPOINT}/api/2/field`
 
   const { fetchIssueTypes, fetchFields, issueTypes, fields, isFetching: isFetchingJIRA, error: jiraProxyError } = useJIRA({
     apiProxyPath: API_PROXY_ENDPOINT,


### PR DESCRIPTION
# Summary
Change url for issuetype and field from api/3 to api/2


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
closes #1308

### Current Behavior
Use api/3, but jira server cannot support 

### New Behavior
Use api/2/issuetype 

### Screenshots
<img width="374" alt="image" src="https://user-images.githubusercontent.com/39366025/157008967-3fdd6747-a112-4905-afe3-e34b28e79692.png">


### Other Information
Any other information that is important to this PR.
