### PR TITLE
fix(jenkins): change DurationSec unit to second

### DIFF
--- a/plugins/jenkins/tasks/jenkins_build_convertor.go
+++ b/plugins/jenkins/tasks/jenkins_build_convertor.go
@@ -39,7 +39,7 @@ func ConvertBuilds(ctx context.Context) error {
 			},
 			JobId:       jobIdGen.Generate(jenkinsBuild.JobName),
 			Name:        jenkinsBuild.DisplayName,
-			DurationSec: uint64(jenkinsBuild.Duration),
+			DurationSec: uint64(jenkinsBuild.Duration / 1000),
 			Status:      jenkinsBuild.Result,
 			StartedDate: jenkinsBuild.StartTime,
 			CommitSha:   jenkinsBuild.CommitSha,


### PR DESCRIPTION
# Summary

Change jenkins durationSec unit from microsecond to second

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Please mention the issues here.

### Current Behavior
DurationSec: uint64(jenkinsBuild.Duration),

### New Behavior
DurationSec: uint64(jenkinsBuild.Duration / 1000),

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/157034013-ba8a79dc-3930-4346-ba5e-1189b9525459.png)


### Other Information
Any other information that is important to this PR.
