### PR TITLE
`feat`: create pipeline ui - add gitextractor plugin support

### DIFF
--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -283,6 +283,7 @@ const ProviderSettings = (props) => {
             className=''
             contentClassName=''
             fill
+            style={{ minWidth: '372px' }}
           >
             <InputGroup
               id='gitextractor-url'
@@ -302,7 +303,7 @@ const ProviderSettings = (props) => {
             labelFor='gitextractor-repo-id'
             className=''
             contentClassName=''
-            style={{ marginLeft: '12px' }}
+            style={{ marginLeft: '12px', minWidth: '215px' }}
             fill
           >
             <InputGroup

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -24,12 +24,16 @@ const ProviderSettings = (props) => {
     boardId = [],
     owner,
     repositoryName,
+    gitExtractorUrl,
+    gitExtractorRepoId,
     setProjectId = () => {},
     setSourceId = () => {},
     setSelectedSource = () => {},
     setBoardId = () => {},
     setOwner = () => {},
     setRepositoryName = () => {},
+    setGitExtractorUrl = () => {},
+    setGitExtractorRepoId = () => {},
     isEnabled = () => {},
     isRunning = false,
   } = props
@@ -263,6 +267,54 @@ const ProviderSettings = (props) => {
                 className='input-project-id tagInput'
               />
             </div>
+          </FormGroup>
+        </>
+      )
+      break
+    case Providers.GITEXTRACTOR:
+      providerSettings = (
+        <>
+          <FormGroup
+            disabled={isRunning || !isEnabled(providerId)}
+            label={<strong>Git URL<span className='requiredStar'>*</span></strong>}
+            labelInfo={<span style={{ display: 'block' }}>Enter Repository URL</span>}
+            inline={false}
+            labelFor='git-url'
+            className=''
+            contentClassName=''
+            fill
+          >
+            <InputGroup
+              id='gitextractor-url'
+              disabled={isRunning || !isEnabled(providerId)}
+              placeholder='eg. https://github.com/merico-dev/lake.git'
+              value={gitExtractorUrl}
+              onChange={(e) => setGitExtractorUrl(e.target.value)}
+              className='input-gitextractor-url'
+              autoComplete='off'
+            />
+          </FormGroup>
+          <FormGroup
+            disabled={isRunning || !isEnabled(providerId)}
+            label={<strong>Repository ID<span className='requiredStar'>*</span></strong>}
+            labelInfo={<span style={{ display: 'block' }}>Enter Repo Column ID</span>}
+            inline={false}
+            labelFor='gitextractor-repo-id'
+            className=''
+            contentClassName=''
+            style={{ marginLeft: '12px' }}
+            fill
+          >
+            <InputGroup
+              id='gitextractor-repo-id'
+              disabled={isRunning || !isEnabled(providerId)}
+              placeholder='eg. github:GithubRepo:384111310'
+              value={gitExtractorRepoId}
+              onChange={(e) => setGitExtractorRepoId(e.target.value)}
+              className='input-gitextractor-repo-id'
+              autoComplete='off'
+              fill={false}
+            />
           </FormGroup>
         </>
       )

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -303,7 +303,7 @@ const ProviderSettings = (props) => {
             labelFor='gitextractor-repo-id'
             className=''
             contentClassName=''
-            style={{ marginLeft: '12px', minWidth: '215px' }}
+            style={{ marginLeft: '12px', minWidth: '280px' }}
             fill
           >
             <InputGroup

--- a/config-ui/src/components/pipelines/TaskActivity.jsx
+++ b/config-ui/src/components/pipelines/TaskActivity.jsx
@@ -103,13 +103,19 @@ const TaskActivity = (props) => {
               }}
             >
               {t.plugin !== Providers.JENKINS && t.plugin !== 'refdiff' && (
-                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', justifyContent: 'flex-start' }}>
                   <span style={{ color: Colors.GRAY2 }}>
-                    <Icon icon='link' size={8} style={{ marginBottom: '3px' }} />{' '}
+                    <Icon icon='link' size={8} style={{ marginBottom: '3px', alignSelf: 'flex-start' }} />{' '}
                     {t.options.projectId || t.options.boardId || t.options.owner}
                   </span>
                   {t.plugin === Providers.GITHUB && (
-                    <span style={{ fontWeight: 60 }}>/{t.options.repositoryName || t.options.repo || '(Repository)'}</span>
+                    <span style={{ fontWeight: 600 }}>/{t.options.repositoryName || t.options.repo || '(Repository)'}</span>
+                  )}
+                  {t.plugin === Providers.GITEXTRACTOR && (
+                    <div style={{ paddingLeft: '12px', display: 'inline-block' }}>
+                      <span>{t.options.url}</span><br />
+                      <strong>{t.options.repoId}</strong>
+                    </div>
                   )}
                 </div>
               )}

--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -19,6 +19,12 @@ const Providers = {
   FEISHU: 'feishu'
 }
 
+const ProviderTypes = {
+  PLUGIN: 'plugin',
+  INTEGRATION: 'integration',
+  PIPELINE: 'pipeline'
+}
+
 const ProviderLabels = {
   NULL: 'NullProvider',
   GITLAB: 'GitLab',
@@ -145,6 +151,7 @@ const ProviderIcons = {
 
 export {
   Providers,
+  ProviderTypes,
   ProviderIcons,
   ProviderLabels,
   ProviderSourceLimits,

--- a/config-ui/src/data/integrations.jsx
+++ b/config-ui/src/data/integrations.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Providers, ProviderLabels } from '@/data/Providers'
+import { Providers, ProviderLabels, ProviderTypes } from '@/data/Providers'
 
 import JiraSettings from '@/pages/configure/settings/jira'
 import GitlabSettings from '@/pages/configure/settings/gitlab'
@@ -11,11 +11,14 @@ import { ReactComponent as GitlabProvider } from '@/images/integrations/gitlab.s
 import { ReactComponent as JenkinsProvider } from '@/images/integrations/jenkins.svg'
 import { ReactComponent as JiraProvider } from '@/images/integrations/jira.svg'
 import { ReactComponent as GitHubProvider } from '@/images/integrations/github.svg'
+import GitExtractorProvider from '@/images/git.png'
+import RefDiffProvider from '@/images/git-diff.png'
 // import { ReactComponent as NullProvider } from '@/images/integrations/null.svg'
 
 const integrationsData = [
   {
     id: Providers.GITLAB,
+    type: ProviderTypes.INTEGRATION,
     enabled: true,
     multiSource: false,
     name: ProviderLabels.GITLAB,
@@ -32,6 +35,7 @@ const integrationsData = [
   },
   {
     id: Providers.JENKINS,
+    type: ProviderTypes.INTEGRATION,
     enabled: true,
     multiSource: false,
     name: ProviderLabels.JENKINS,
@@ -48,6 +52,7 @@ const integrationsData = [
   },
   {
     id: Providers.JIRA,
+    type: ProviderTypes.INTEGRATION,
     enabled: true,
     multiSource: true,
     name: ProviderLabels.JIRA,
@@ -64,6 +69,7 @@ const integrationsData = [
   },
   {
     id: Providers.GITHUB,
+    type: ProviderTypes.INTEGRATION,
     enabled: true,
     multiSource: false,
     name: ProviderLabels.GITHUB,
@@ -80,6 +86,23 @@ const integrationsData = [
   },
 ]
 
+const pluginsData = [
+  {
+    id: Providers.GITEXTRACTOR,
+    type: ProviderTypes.PIPELINE,
+    enabled: true,
+    multiSource: false,
+    name: ProviderLabels.GITEXTRACTOR,
+    icon: <img src={GitExtractorProvider} className='providerIconPng' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
+    iconDashboard: <img src={GitExtractorProvider} className='providerIconPng' width='48' height='48' />,
+    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+      null
+    )
+  },
+
+]
+
 export {
-  integrationsData
+  integrationsData,
+  pluginsData
 }

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -11,6 +11,8 @@ function usePipelineValidation ({
   boardId,
   owner,
   repositoryName,
+  gitExtractorUrl,
+  gitExtractorRepoId,
   sourceId,
   tasks,
   tasksAdvanced,
@@ -81,6 +83,23 @@ function usePipelineValidation ({
       errs.push('GitHub: Repository name invalid format')
     }
 
+    if (enabledProviders.includes(Providers.GITEXTRACTOR) && !gitExtractorUrl) {
+      errs.push('GitExtractor: Repository Git URL is required')
+    }
+
+    if (enabledProviders.includes(Providers.GITEXTRACTOR) &&
+        gitExtractorUrl.toLowerCase().match(/^(http:\/\/|https:\/\/|ssh:\/\/|git@)+/g) === null) {
+      errs.push('GitExtractor: Repository Git URL must be valid HTTP/S, SSH or Git@ protocol')
+    }
+
+    if (enabledProviders.includes(Providers.GITEXTRACTOR) && !gitExtractorUrl.toLowerCase().endsWith('.git')) {
+      errs.push('GitExtractor: Invalid Git URL Extension')
+    }
+
+    if (enabledProviders.includes(Providers.GITEXTRACTOR) && !gitExtractorRepoId) {
+      errs.push('GitExtractor: Repository Column ID Code is required')
+    }
+
     if (enabledProviders.length === 0) {
       errs.push('Pipeline: Invalid/Empty Configuration')
     }
@@ -92,6 +111,8 @@ function usePipelineValidation ({
     boardId,
     owner,
     repositoryName,
+    gitExtractorUrl,
+    gitExtractorRepoId,
     sourceId
   ])
 

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -381,6 +381,7 @@ const CreatePipeline = (props) => {
       const GitHubTask = tasks.find(t => t.plugin === Providers.GITHUB)
       const JiraTask = tasks.filter(t => t.plugin === Providers.JIRA)
       const JenkinsTask = tasks.find(t => t.plugin === Providers.JENKINS)
+      const GitExtractorTask = tasks.find(t => t.plugin === Providers.GITEXTRACTOR)
       const configuredProviders = []
       if (GitLabTask && GitLabTask.length > 0) {
         configuredProviders.push(Providers.GITLAB)
@@ -404,6 +405,11 @@ const CreatePipeline = (props) => {
       }
       if (JenkinsTask) {
         configuredProviders.push(Providers.JENKINS)
+      }
+      if (GitExtractorTask) {
+        setGitExtractorRepoId(GitExtractorTask.options?.repoId)
+        setGitExtractorUrl(GitExtractorTask.options?.url)
+        configuredProviders.push(Providers.GITEXTRACTOR)
       }
       setEnabledProviders(eP => [...eP, ...configuredProviders])
     } else {

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -22,7 +22,7 @@ import {
   Providers,
   ProviderIcons
 } from '@/data/Providers'
-import { integrationsData } from '@/data/integrations'
+import { integrationsData, pluginsData } from '@/data/integrations'
 import usePipelineManager from '@/hooks/usePipelineManager'
 import usePipelineValidation from '@/hooks/usePipelineValidation'
 import useConnectionManager from '@/hooks/useConnectionManager'
@@ -51,7 +51,7 @@ const CreatePipeline = (props) => {
   const location = useLocation()
   // const { providerId } = useParams()
   // const [activeProvider, setActiveProvider] = useState(integrationsData[0])
-  const [integrations, setIntegrations] = useState(integrationsData)
+  const [integrations, setIntegrations] = useState([...integrationsData, ...pluginsData])
   const [jiraIntegration, setJiraIntegration] = useState(integrationsData.find(p => p.id === Providers.JIRA))
 
   const [today, setToday] = useState(new Date())
@@ -86,6 +86,8 @@ const CreatePipeline = (props) => {
   const [selectedSource, setSelectedSource] = useState()
   const [repositoryName, setRepositoryName] = useState('')
   const [owner, setOwner] = useState('')
+  const [gitExtractorUrl, setGitExtractorUrl] = useState('')
+  const [gitExtractorRepoId, setGitExtractorRepoId] = useState('')
 
   const [autoRedirect, setAutoRedirect] = useState(true)
   const [restartDetected, setRestartDetected] = useState(false)
@@ -117,6 +119,8 @@ const CreatePipeline = (props) => {
     owner,
     repositoryName,
     sourceId,
+    gitExtractorUrl,
+    gitExtractorRepoId,
     tasks: runTasks,
     tasksAdvanced: runTasksAdvanced,
     advancedMode
@@ -132,7 +136,7 @@ const CreatePipeline = (props) => {
   })
 
   useEffect(() => {
-    integrationsData.forEach((i, idx) => {
+    [...integrationsData, ...pluginsData].forEach((i, idx) => {
       setTimeout(() => {
         setReadyProviders(r => [...r, i.id])
       }, idx * 50)
@@ -197,11 +201,17 @@ const CreatePipeline = (props) => {
           projectId: parseInt(projectId, 10)
         }
         break
+      case Providers.GITEXTRACTOR:
+        options = {
+          url: gitExtractorUrl,
+          repoId: gitExtractorRepoId
+        }
+        break
       default:
         break
     }
     return options
-  }, [boardId, owner, projectId, repositoryName, sourceId])
+  }, [boardId, owner, projectId, repositoryName, sourceId, gitExtractorUrl, gitExtractorRepoId])
 
   const configureProvider = useCallback((providerId) => {
     let providerConfig = {}
@@ -246,6 +256,8 @@ const CreatePipeline = (props) => {
     setSelectedSource(null)
     setRepositoryName('')
     setOwner('')
+    setGitExtractorUrl('')
+    setGitExtractorRepoId('')
     setAdvancedMode(false)
     setRawConfiguration('[[]]')
   }
@@ -880,11 +892,15 @@ const CreatePipeline = (props) => {
                               selectedSource={selectedSource}
                               setSelectedSource={setSelectedSource}
                               boardId={boardId}
+                              gitExtractorUrl={gitExtractorUrl}
+                              gitExtractorRepoId={gitExtractorRepoId}
                               setProjectId={setProjectId}
                               setOwner={setOwner}
                               setRepositoryName={setRepositoryName}
                               setSourceId={setSourceId}
                               setBoardId={setBoardId}
+                              setGitExtractorUrl={setGitExtractorUrl}
+                              setGitExtractorRepoId={setGitExtractorRepoId}
                               isEnabled={isProviderEnabled}
                               isRunning={isRunning}
                             />

--- a/config-ui/src/styles/integration.scss
+++ b/config-ui/src/styles/integration.scss
@@ -2,6 +2,7 @@
   border: 0;
   display: flex;
   width: 80%;
+  min-width: 520px;
   align-self: flex-start;
   padding: 10px;
 
@@ -23,7 +24,7 @@
       background-color: #eeeeee;
       opacity: 1.0;
 
-      svg:first-of-type {
+      svg:first-of-type,img:first-of-type {
         transform: scale(1.05);
       }
 
@@ -32,7 +33,7 @@
         font-weight: bold;
       }
 
-      svg:first-of-type {
+      svg:first-of-type,img:first-of-type {
         transition: all 0.3s ease-out;
       }
 
@@ -46,6 +47,8 @@
 
     .providerIcon {
       cursor: pointer;
+      min-height: 48px;
+      min-width: 48px;
     }
   }
 }

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -1,5 +1,5 @@
 .data-providers {
-  min-width: 514px;
+  min-width: 875px;
 }
 
 .data-provider-row {

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -72,7 +72,7 @@
     .provider-icon {
       transition: all 0.3s ease;
 
-      >svg {
+      >svg, >img {
         transition: all 0.3s ease;
       }
     }
@@ -334,6 +334,10 @@
     &.bp3-active {
       box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.40);
     }
+  }
+
+  .bp3-button-text {
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
### Config UI / Pipelines / Create New Pipeline RUN `GitExtractor`

- [x] Create Pipeline UI : Support `GitExtractor` Plugin
- [x] Update **Pipeline Validation Hook** Rules
   - Validate `url`
   - Validate `repoId`
- [x] Test GitExtractor Settings
- [x] Test Create Pipeline Workflow

### Description
This PR adds **GitExtractor** as a **Pipeline** **Provider** in Visual/UI Mode when creating a new Pipeline Run. It requires 2 parameters, `URL` and `RepoId`. Previously `gitextractor` was only detected in Advanced Mode, now it will be available in both Visual and Advanced modes.

### Does this close any open issues?
#1194

### Screenshots

<img width="1035" alt="Screen Shot 2022-03-09 at 9 12 01 AM" src="https://user-images.githubusercontent.com/1742233/157459429-6bd1d960-b58b-400c-95c5-2d691c07f9cd.png">
<img width="1341" alt="Screen Shot 2022-03-09 at 9 12 28 AM" src="https://user-images.githubusercontent.com/1742233/157459423-38b6952e-2f68-41f6-a3c8-c5418d0aea26.png">
<img width="1217" alt="Screen Shot 2022-03-09 at 9 13 19 AM" src="https://user-images.githubusercontent.com/1742233/157459741-6d93019e-16c1-4c5d-8984-ae12fff3cab1.png">

