### PR TITLE
`feat`: create pipeline ui - add refdiff plugin support

### DIFF
--- a/config-ui/src/components/menus/RefDiffTasksMenu.jsx
+++ b/config-ui/src/components/menus/RefDiffTasksMenu.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import {
+  Menu,
+  MenuItem,
+  Checkbox,
+  Intent
+} from '@blueprintjs/core'
+
+const RefDiffTasksMenu = (props) => {
+  const {
+    tasks = [
+      { task: 'calculateCommitsDiff', label: 'Calculate Commits Diff' },
+      { task: 'calculateIssuesDiff', label: 'Calculate Issues Diff' }],
+    selected = [],
+    onSelect = () => {}
+  } = props
+  return (
+    <Menu className='tasks-menu refdiff-tasks-menu' minimal='true'>
+      <label style={{
+        fontSize: '10px',
+        fontWeight: 800,
+        fontFamily: '"Montserrat", sans-serif',
+        textTransform: 'uppercase',
+        padding: '6px 8px',
+        display: 'block'
+      }}
+      >AVAILABLE PLUGIN TASKS
+      </label>
+      {tasks.map((t, tIdx) => (
+        <MenuItem
+          key={`refdiff-item-task-key-${tIdx}`}
+          intent={Intent.DANGER}
+          minimal='true'
+          active={Boolean(selected.includes(t.task))}
+          // onClick={(e) => e.preventDefault()}
+          data-task={t}
+          text={(
+            <>
+              <Checkbox
+                intent={Intent.WARNING}
+                checked={Boolean(selected.includes(t.task))}
+                label={t.label}
+                onChange={(e) => onSelect(e, t)}
+              />
+            </>
+          )}
+        />
+      ))}
+    </Menu>
+  )
+}
+
+export default RefDiffTasksMenu

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -452,7 +452,14 @@ const ProviderSettings = (props) => {
                   <InputGroup
                     id='refdiff-pair-newref'
                     round='true'
-                    leftElement={<Tag intent={Intent.WARNING}>New Ref</Tag>}
+                    leftElement={(
+                      <Tag
+                        intent={Intent.WARNING} style={{
+                          opacity: isEnabled(providerId) ? 1 : 0.3
+                        }}
+                      >New Ref
+                      </Tag>
+                    )}
                     inline={true}
                     disabled={isRunning || !isEnabled(providerId)}
                     placeholder='eg. refs/tags/v0.6.0'
@@ -468,7 +475,14 @@ const ProviderSettings = (props) => {
                   <InputGroup
                     id='refdiff-pair-oldref'
                     round='true'
-                    leftElement={<Tag>Old Ref</Tag>}
+                    leftElement={(
+                      <Tag
+                        style={{
+                          opacity: isEnabled(providerId) ? 1 : 0.3
+                        }}
+                      >Old Ref
+                      </Tag>
+                    )}
                     inline={true}
                     disabled={isRunning || !isEnabled(providerId)}
                     placeholder='eg. refs/tags/v0.5.0'

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -79,54 +79,12 @@ const ProviderSettings = (props) => {
   }
 
   const removeRefDiffPairObject = (oldRef, newRef) => {
-    console.log('>>> REMOVE PAIR', 'old: ' + oldRef, 'new: ' + newRef)
     setRefDiffPairs(pairs => pairs.filter(p => !(p.oldRef === oldRef && p.newRef === newRef)))
   }
 
-  // const refdiffTasksMenu = (
-  //   <Menu className='tasks-menu refdiff-tasks-menu'>
-  //     <MenuItem
-  //       minimal='true'
-  //       active={refDiffTasks.includes('calculateCommitsDiff')}
-  //       // onClick={(e) => e.preventDefault()}
-  //       data-task='calculateCommitsDiff'
-  //       style={{ marginBottom: '2px' }}
-  //       text={(
-  //         <>
-  //           <Checkbox
-  //             intent={Intent.WARNING}
-  //             checked={Boolean(refDiffTasks.includes('calculateCommitsDiff'))}
-  //             label='Calculate Commits Diff'
-  //             onChange={() => setRefDiffTasks(t => t.includes('calculateCommitsDiff')
-  //               ? t.filter(t2 => t2 !== 'calculateCommitsDiff')
-  //               : [...new Set([...t, 'calculateCommitsDiff'])])}
-  //           />
-  //         </>
-  //       )}
-  //     />
-  //     <MenuItem
-  //       minimal='true'
-  //       active={refDiffTasks.includes('calculateIssuesDiff')}
-  //       // onClick={(e) => e.preventDefault()}
-  //       data-task='calculateIssuesDiff'
-  //       text={(
-  //         <>
-  //           <Checkbox
-  //             checked={Boolean(refDiffTasks.includes('calculateIssuesDiff'))}
-  //             label='Calculate Issues Diff'
-  //             onChange={() => setRefDiffTasks(t => t.includes('calculateIssuesDiff')
-  //               ? t.filter(t2 => t2 !== 'calculateIssuesDiff')
-  //               : [...new Set([...t, 'calculateIssuesDiff'])])}
-  //           />
-  //         </>
-  //       )}
-  //     />
-  //   </Menu>
-  // )
-
-  useEffect(() => {
-    console.log('>>>> REF DIFF PAIRS ARRAY...', refDiffPairs)
-  }, [refDiffPairs])
+  // useEffect(() => {
+  //   console.log('>>>> REF DIFF PAIRS ARRAY...', refDiffPairs)
+  // }, [refDiffPairs])
 
   switch (providerId) {
     case Providers.JENKINS:

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -6,20 +6,21 @@ import {
   Button,
   ButtonGroup,
   FormGroup,
-  Popover,
+  // Popover,
   InputGroup,
   MenuItem,
-  Menu,
+  // Menu,
   Intent,
   TagInput,
-  Checkbox,
-  Tag,
-  Switch,
+  // Checkbox,
+  // Tag,
+  // Switch,
   Tooltip,
-  Colors,
+  // Colors,
 } from '@blueprintjs/core'
 import { Select } from '@blueprintjs/select'
-import RefDiffTasksMenu from '@/components/menus/RefDiffTasksMenu'
+// import RefDiffTasksMenu from '@/components/menus/RefDiffTasksMenu'
+import RefDiffSettings from '@/components/pipelines/pipeline-settings/refdiff'
 
 const ProviderSettings = (props) => {
   const {
@@ -54,33 +55,33 @@ const ProviderSettings = (props) => {
 
   let providerSettings = null
 
-  const [refDiffOldTag, setRefDiffOldTag] = useState('')
-  const [refDiffNewTag, setRefDiffNewTag] = useState('')
+  // const [refDiffOldTag, setRefDiffOldTag] = useState('')
+  // const [refDiffNewTag, setRefDiffNewTag] = useState('')
 
-  const handleRefDiffTaskSelect = (e, task) => {
-    setRefDiffTasks(t => t.includes(task.task)
-      ? t.filter(t2 => t2 !== task.task)
-      : [...new Set([...t, task.task])])
-  }
+  // const handleRefDiffTaskSelect = (e, task) => {
+  //   setRefDiffTasks(t => t.includes(task.task)
+  //     ? t.filter(t2 => t2 !== task.task)
+  //     : [...new Set([...t, task.task])])
+  // }
 
-  const createRefDiffPair = (oldRef, newRef) => {
-    return {
-      oldRef,
-      newRef
-    }
-  }
+  // const createRefDiffPair = (oldRef, newRef) => {
+  //   return {
+  //     oldRef,
+  //     newRef
+  //   }
+  // }
 
-  const addRefDiffPairObject = (oldRef, newRef) => {
-    setRefDiffPairs(pairs => (!pairs.some(p => p.oldRef === oldRef && p.newRef === newRef))
-      ? [...pairs, { oldRef, newRef }]
-      : [...pairs])
-    setRefDiffNewTag('')
-    setRefDiffOldTag('')
-  }
+  // const addRefDiffPairObject = (oldRef, newRef) => {
+  //   setRefDiffPairs(pairs => (!pairs.some(p => p.oldRef === oldRef && p.newRef === newRef))
+  //     ? [...pairs, { oldRef, newRef }]
+  //     : [...pairs])
+  //   setRefDiffNewTag('')
+  //   setRefDiffOldTag('')
+  // }
 
-  const removeRefDiffPairObject = (oldRef, newRef) => {
-    setRefDiffPairs(pairs => pairs.filter(p => !(p.oldRef === oldRef && p.newRef === newRef)))
-  }
+  // const removeRefDiffPairObject = (oldRef, newRef) => {
+  //   setRefDiffPairs(pairs => pairs.filter(p => !(p.oldRef === oldRef && p.newRef === newRef)))
+  // }
 
   // useEffect(() => {
   //   console.log('>>>> REF DIFF PAIRS ARRAY...', refDiffPairs)
@@ -368,211 +369,21 @@ const ProviderSettings = (props) => {
       break
     case Providers.REFDIFF:
       providerSettings = (
-        <>
-          <FormGroup
-            disabled={isRunning || !isEnabled(providerId)}
-            label={<strong>Repository ID<span className='requiredStar'>*</span></strong>}
-            labelInfo={<span style={{ display: 'block' }}>Enter Repo Column ID</span>}
-            inline={false}
-            labelFor='refdiff-repo-id'
-            className=''
-            contentClassName=''
-            style={{ minWidth: '280px', marginBottom: 'auto' }}
-            fill
-          >
-            <InputGroup
-              id='refdiff-repo-id'
-              disabled={isRunning || !isEnabled(providerId)}
-              placeholder='eg. github:GithubRepo:384111310'
-              value={refDiffRepoId}
-              onChange={(e) => setRefDiffRepoId(e.target.value)}
-              className='input-refdiff-repo-id'
-              autoComplete='off'
-              fill={false}
-              style={{ marginBottom: '10px' }}
-            />
-          </FormGroup>
-          <FormGroup
-            disabled={isRunning || !isEnabled(providerId)}
-            label={(
-              <strong>Tasks<span className='requiredStar'>*</span>
-                <span
-                  className='badge-count'
-                  style={{
-                    opacity: isEnabled(providerId) ? 0.5 : 0.1
-                  }}
-                >{refDiffTasks.length}
-                </span>
-              </strong>
-              )}
-            labelInfo={<span style={{ display: 'block' }}>Select Tasks to Execute</span>}
-            inline={false}
-            labelFor='refdiff-tasks'
-            className=''
-            contentClassName=''
-            style={{ marginLeft: '12px', marginRight: '12px', marginBottom: 'auto' }}
-            fill
-          >
-
-            <Popover
-              className='provider-tasks-popover'
-              disabled={isRunning || !isEnabled(providerId)}
-              content={(
-                <RefDiffTasksMenu onSelect={handleRefDiffTaskSelect} selected={refDiffTasks} />
-              )}
-              placement='top-center'
-            >
-              <ButtonGroup disabled={isRunning || !isEnabled(providerId)}>
-                <Button
-                  disabled={isRunning || !isEnabled(providerId)}
-                  icon='menu'
-                  // text='Choose Tasks'
-                  text={refDiffTasks.length > 0
-                    ? <>Choose Tasks <Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
-                    : 'Choose Tasks'}
-                />
-                <Button
-                  icon='eraser'
-                  // text={refDiffTasks.length > 0
-                  //   ? <><Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
-                  //   : ''}
-                  intent={Intent.WARNING}
-                  disabled={isRunning || !isEnabled(providerId) || refDiffTasks.length === 0}
-                  onClick={() => setRefDiffTasks([])}
-                />
-              </ButtonGroup>
-            </Popover>
-          </FormGroup>
-          <div style={{ display: 'flex', flex: 1, width: '100%' }}>
-            <FormGroup
-              disabled={isRunning || !isEnabled(providerId)}
-              label={(
-                <strong>Tags<span className='requiredStar'>*</span>
-                  <span
-                    className='badge-count'
-                    style={{
-                      opacity: isEnabled(providerId) ? 0.5 : 0.1
-                    }}
-                  >{refDiffPairs.length}
-                  </span>
-                </strong>
-              )}
-              labelInfo={<span style={{ display: 'block' }}>Specify tag Ref Pairs</span>}
-              inline={false}
-              labelFor='refdiff-pair-newref'
-              className=''
-              contentClassName=''
-              style={{ minWidth: '588px', marginBottom: 'auto' }}
-              fill={false}
-            >
-              <div style={{ display: 'flex' }}>
-                <div>
-                  <InputGroup
-                    id='refdiff-pair-newref'
-                    // round='true'
-                    leftElement={(
-                      <Tag
-                        intent={Intent.WARNING} style={{
-                          opacity: isEnabled(providerId) ? 1 : 0.3
-                        }}
-                      >New Ref
-                      </Tag>
-                    )}
-                    inline={true}
-                    disabled={isRunning || !isEnabled(providerId)}
-                    placeholder='eg. refs/tags/v0.6.0'
-                    value={refDiffNewTag}
-                    onChange={(e) => setRefDiffNewTag(e.target.value)}
-                    autoComplete='off'
-                    fill={false}
-                    // small
-                  />
-                </div>
-                <div style={{ marginLeft: '10px', marginRight: '10px' }}>
-                  {/* <label>Old Ref</label> */}
-                  <InputGroup
-                    id='refdiff-pair-oldref'
-                    // round='true'
-                    leftElement={(
-                      <Tag
-                        style={{
-                          opacity: isEnabled(providerId) ? 1 : 0.3
-                        }}
-                      >Old Ref
-                      </Tag>
-                    )}
-                    inline={true}
-                    disabled={isRunning || !isEnabled(providerId)}
-                    placeholder='eg. refs/tags/v0.5.0'
-                    value={refDiffOldTag}
-                    onChange={(e) => setRefDiffOldTag(e.target.value)}
-                    autoComplete='off'
-                    fill={false}
-                    rightElement={(
-                      <Tooltip content='Add Tag Pair'>
-                        <Button
-                          className='btn-add-tagpair'
-                          intent={Intent.PRIMARY}
-                          disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
-                          icon='plus'
-                          small
-                          style={{}}
-                          onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
-                        />
-                      </Tooltip>
-
-                    )}
-                    // small
-                  />
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                  {/* <Button icon='remove' minimal small style={{ marginTop: 'auto', alignSelf: 'center' }} /> */}
-                  {/* <Button
-                    intent={Intent.PRIMARY}
-                    disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
-                    icon='add'
-                    small
-                    style={{ marginTop: 'auto', alignSelf: 'center' }}
-                    onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
-                  /> */}
-                </div>
-              </div>
-              <div
-                style={{
-                  borderRadius: '4px',
-                  padding: '10px',
-                  margin: '5px 0'
-                }}
-              >
-                {refDiffPairs.map((pair, pairIdx) => (
-                  <div key={`refdiff-added-pairs-itemkey-$${pairIdx}`} style={{ display: 'flex' }}>
-                    <div style={{ flex: 1 }}>
-                      <Tag intent={Intent.WARNING} round='false' small>new</Tag> {pair.newRef}
-                    </div>
-                    <div style={{ flex: 1, marginLeft: '10px', marginRight: '10px' }}>
-                      <Tag round='false' small>old</Tag> {pair.oldRef}
-                    </div>
-                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                      <Button
-                        className='btn-remove-tagpair'
-                        icon='remove'
-                        minimal
-                        small
-                        style={{ marginTop: 'auto', alignSelf: 'center' }}
-                        onClick={() => removeRefDiffPairObject(pair.oldRef, pair.newRef)}
-                      />
-                    </div>
-                  </div>
-                ))}
-                {refDiffPairs.length === 0 && <><span style={{ color: Colors.GRAY3 }}>( No Tag Pairs Added)</span></>}
-              </div>
-            </FormGroup>
-          </div>
-        </>
-
+        <RefDiffSettings
+          providerId={providerId}
+          repoId={refDiffRepoId}
+          tasks={refDiffTasks}
+          pairs={refDiffPairs}
+          setRepoId={setRefDiffRepoId}
+          setTasks={setRefDiffTasks}
+          setPairs={setRefDiffPairs}
+          isRunning={isRunning}
+          isEnabled={isEnabled}
+        />
       )
       break
     default:
+      providerSettings = null
       break
   }
 

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -469,7 +469,7 @@ const ProviderSettings = (props) => {
                 <div>
                   <InputGroup
                     id='refdiff-pair-newref'
-                    round='true'
+                    // round='true'
                     leftElement={(
                       <Tag
                         intent={Intent.WARNING} style={{
@@ -492,7 +492,7 @@ const ProviderSettings = (props) => {
                   {/* <label>Old Ref</label> */}
                   <InputGroup
                     id='refdiff-pair-oldref'
-                    round='true'
+                    // round='true'
                     leftElement={(
                       <Tag
                         style={{
@@ -511,6 +511,7 @@ const ProviderSettings = (props) => {
                     rightElement={(
                       <Tooltip content='Add Tag Pair'>
                         <Button
+                          className='btn-add-tagpair'
                           intent={Intent.PRIMARY}
                           disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
                           icon='plus'
@@ -546,13 +547,14 @@ const ProviderSettings = (props) => {
                 {refDiffPairs.map((pair, pairIdx) => (
                   <div key={`refdiff-added-pairs-itemkey-$${pairIdx}`} style={{ display: 'flex' }}>
                     <div style={{ flex: 1 }}>
-                      <Tag intent={Intent.WARNING} round='true' small>new</Tag> {pair.newRef}
+                      <Tag intent={Intent.WARNING} round='false' small>new</Tag> {pair.newRef}
                     </div>
                     <div style={{ flex: 1, marginLeft: '10px', marginRight: '10px' }}>
-                      <Tag round='true' small>old</Tag> {pair.oldRef}
+                      <Tag round='false' small>old</Tag> {pair.oldRef}
                     </div>
                     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                       <Button
+                        className='btn-remove-tagpair'
                         icon='remove'
                         minimal
                         small

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import {
   Providers,
 } from '@/data/Providers'
@@ -6,20 +6,13 @@ import {
   Button,
   ButtonGroup,
   FormGroup,
-  // Popover,
   InputGroup,
   MenuItem,
-  // Menu,
   Intent,
   TagInput,
-  // Checkbox,
-  // Tag,
-  // Switch,
   Tooltip,
-  // Colors,
 } from '@blueprintjs/core'
 import { Select } from '@blueprintjs/select'
-// import RefDiffTasksMenu from '@/components/menus/RefDiffTasksMenu'
 import RefDiffSettings from '@/components/pipelines/pipeline-settings/refdiff'
 
 const ProviderSettings = (props) => {
@@ -55,38 +48,6 @@ const ProviderSettings = (props) => {
 
   let providerSettings = null
 
-  // const [refDiffOldTag, setRefDiffOldTag] = useState('')
-  // const [refDiffNewTag, setRefDiffNewTag] = useState('')
-
-  // const handleRefDiffTaskSelect = (e, task) => {
-  //   setRefDiffTasks(t => t.includes(task.task)
-  //     ? t.filter(t2 => t2 !== task.task)
-  //     : [...new Set([...t, task.task])])
-  // }
-
-  // const createRefDiffPair = (oldRef, newRef) => {
-  //   return {
-  //     oldRef,
-  //     newRef
-  //   }
-  // }
-
-  // const addRefDiffPairObject = (oldRef, newRef) => {
-  //   setRefDiffPairs(pairs => (!pairs.some(p => p.oldRef === oldRef && p.newRef === newRef))
-  //     ? [...pairs, { oldRef, newRef }]
-  //     : [...pairs])
-  //   setRefDiffNewTag('')
-  //   setRefDiffOldTag('')
-  // }
-
-  // const removeRefDiffPairObject = (oldRef, newRef) => {
-  //   setRefDiffPairs(pairs => pairs.filter(p => !(p.oldRef === oldRef && p.newRef === newRef)))
-  // }
-
-  // useEffect(() => {
-  //   console.log('>>>> REF DIFF PAIRS ARRAY...', refDiffPairs)
-  // }, [refDiffPairs])
-
   switch (providerId) {
     case Providers.JENKINS:
       providerSettings = <p><strong style={{ fontWeight: 900 }}>AUTO-CONFIGURED</strong><br />No Additional Settings</p>
@@ -104,16 +65,6 @@ const ProviderSettings = (props) => {
             contentClassName=''
             fill
           >
-            {/* <InputGroup
-              id='source-id'
-              disabled={isRunning || !isEnabled(providerId)}
-              placeholder='eg. 54'
-              value={sourceId}
-              onChange={(e) => setSourceId(e.target.value)}
-              className='input-source-id'
-              autoComplete='off'
-              fill={false}
-            /> */}
             <ButtonGroup>
               <Select
                 disabled={isRunning || !isEnabled(providerId)}
@@ -175,17 +126,6 @@ const ProviderSettings = (props) => {
             style={{ marginLeft: '12px' }}
             fill
           >
-            {/* (DISABLED) Single Input */}
-            {/* <InputGroup
-              id='board-id'
-              disabled={isRunning || !isEnabled(providerId)}
-              placeholder='eg. 8'
-              value={boardId}
-              onChange={(e) => setBoardId(e.target.value)}
-              className='input-board-id'
-              autoComplete='off'
-              fill={false}
-            /> */}
             <div style={{ width: '100%' }}>
               <TagInput
                 id='board-id'
@@ -282,16 +222,6 @@ const ProviderSettings = (props) => {
             className=''
             contentClassName=''
           >
-            {/* (DISABLED) Single Input */}
-            {/* <InputGroup
-              id='project-id'
-              disabled={isRunning || !isEnabled(providerId)}
-              placeholder='eg. 937810831'
-              value={projectId}
-              onChange={(e) => setProjectId(pId => e.target.value)}
-              className='input-project-id'
-              autoComplete='off'
-            /> */}
             <div style={{ width: '100%' }}>
               <TagInput
                 id='project-id'

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -444,7 +444,7 @@ const ProviderSettings = (props) => {
               labelFor='refdiff-pair-newref'
               className=''
               contentClassName=''
-              style={{ minWidth: '600px', marginBottom: 'auto' }}
+              style={{ minWidth: '588px', marginBottom: 'auto' }}
               fill={false}
             >
               <div style={{ display: 'flex' }}>

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -422,7 +422,25 @@ const ProviderSettings = (props) => {
               )}
               placement='top-center'
             >
-              <Button icon='menu' text='Choose Tasks' disabled={isRunning || !isEnabled(providerId)} />
+              <ButtonGroup disabled={isRunning || !isEnabled(providerId)}>
+                <Button
+                  disabled={isRunning || !isEnabled(providerId)}
+                  icon='menu'
+                  // text='Choose Tasks'
+                  text={refDiffTasks.length > 0
+                    ? <>Choose Tasks <Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
+                    : 'Choose Tasks'}
+                />
+                <Button
+                  icon='eraser'
+                  // text={refDiffTasks.length > 0
+                  //   ? <><Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
+                  //   : ''}
+                  intent={Intent.WARNING}
+                  disabled={isRunning || !isEnabled(providerId) || refDiffTasks.length === 0}
+                  onClick={() => setRefDiffTasks([])}
+                />
+              </ButtonGroup>
             </Popover>
           </FormGroup>
           <div style={{ display: 'flex', flex: 1, width: '100%' }}>

--- a/config-ui/src/components/pipelines/ProviderSettings.jsx
+++ b/config-ui/src/components/pipelines/ProviderSettings.jsx
@@ -490,19 +490,32 @@ const ProviderSettings = (props) => {
                     onChange={(e) => setRefDiffOldTag(e.target.value)}
                     autoComplete='off'
                     fill={false}
+                    rightElement={(
+                      <Tooltip content='Add Tag Pair'>
+                        <Button
+                          intent={Intent.PRIMARY}
+                          disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
+                          icon='plus'
+                          small
+                          style={{}}
+                          onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
+                        />
+                      </Tooltip>
+
+                    )}
                     // small
                   />
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                   {/* <Button icon='remove' minimal small style={{ marginTop: 'auto', alignSelf: 'center' }} /> */}
-                  <Button
+                  {/* <Button
                     intent={Intent.PRIMARY}
                     disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
                     icon='add'
                     small
                     style={{ marginTop: 'auto', alignSelf: 'center' }}
                     onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
-                  />
+                  /> */}
                 </div>
               </div>
               <div

--- a/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
+++ b/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
@@ -1,0 +1,260 @@
+import React, { useState } from 'react'
+import {
+  Button,
+  ButtonGroup,
+  FormGroup,
+  Popover,
+  InputGroup,
+  Intent,
+  Tag,
+  Tooltip,
+  Colors,
+} from '@blueprintjs/core'
+import RefDiffTasksMenu from '@/components/menus/RefDiffTasksMenu'
+
+const RefDiffSettings = (props) => {
+  const {
+    providerId,
+    repoId,
+    tasks = [],
+    pairs = [],
+    isRunning,
+    isEnabled,
+    setRepoId = () => {},
+    setTasks = () => {},
+    setPairs = () => {},
+  } = props
+
+  const [refDiffOldTag, setOldTag] = useState('')
+  const [refDiffNewTag, setNewTag] = useState('')
+
+  const handleRefDiffTaskSelect = (e, task) => {
+    setTasks(t => t.includes(task.task)
+      ? t.filter(t2 => t2 !== task.task)
+      : [...new Set([...t, task.task])])
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  const createRefDiffPair = (oldRef, newRef) => {
+    return {
+      oldRef,
+      newRef
+    }
+  }
+
+  const addRefDiffPairObject = (oldRef, newRef) => {
+    setPairs(pairs => (!pairs.some(p => p.oldRef === oldRef && p.newRef === newRef))
+      ? [...pairs, { oldRef, newRef }]
+      : [...pairs])
+    setNewTag('')
+    setOldTag('')
+  }
+
+  const removeRefDiffPairObject = (oldRef, newRef) => {
+    setPairs(pairs => pairs.filter(p => !(p.oldRef === oldRef && p.newRef === newRef)))
+  }
+
+  return (
+    <>
+      <FormGroup
+        disabled={isRunning || !isEnabled(providerId)}
+        label={<strong>Repository ID<span className='requiredStar'>*</span></strong>}
+        labelInfo={<span style={{ display: 'block' }}>Enter Repo Column ID</span>}
+        inline={false}
+        labelFor='refdiff-repo-id'
+        className=''
+        contentClassName=''
+        style={{ minWidth: '280px', marginBottom: 'auto' }}
+        fill
+      >
+        <InputGroup
+          id='refdiff-repo-id'
+          disabled={isRunning || !isEnabled(providerId)}
+          placeholder='eg. github:GithubRepo:384111310'
+          value={repoId}
+          onChange={(e) => setRepoId(e.target.value)}
+          className='input-refdiff-repo-id'
+          autoComplete='off'
+          fill={false}
+          style={{ marginBottom: '10px' }}
+        />
+      </FormGroup>
+      <FormGroup
+        disabled={isRunning || !isEnabled(providerId)}
+        label={(
+          <strong>Tasks<span className='requiredStar'>*</span>
+            <span
+              className='badge-count'
+              style={{
+                opacity: isEnabled(providerId) ? 0.5 : 0.1
+              }}
+            >{tasks.length}
+            </span>
+          </strong>
+        )}
+        labelInfo={<span style={{ display: 'block' }}>Select Tasks to Execute</span>}
+        inline={false}
+        labelFor='refdiff-tasks'
+        className=''
+        contentClassName=''
+        style={{ marginLeft: '12px', marginRight: '12px', marginBottom: 'auto' }}
+        fill
+      >
+
+        <Popover
+          className='provider-tasks-popover'
+          disabled={isRunning || !isEnabled(providerId)}
+          content={(
+            <RefDiffTasksMenu onSelect={handleRefDiffTaskSelect} selected={tasks} />
+        )}
+          placement='top-center'
+        >
+          <ButtonGroup disabled={isRunning || !isEnabled(providerId)}>
+            <Button
+              disabled={isRunning || !isEnabled(providerId)}
+              icon='menu'
+              // text='Choose Tasks'
+              text={tasks.length > 0
+                ? <>Choose Tasks <Tag intent={Intent.PRIMARY} round>{tasks.length}</Tag></>
+                : 'Choose Tasks'}
+            />
+            <Button
+              icon='eraser'
+              // text={refDiffTasks.length > 0
+              //   ? <><Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
+              //   : ''}
+              intent={Intent.WARNING}
+              disabled={isRunning || !isEnabled(providerId) || tasks.length === 0}
+              onClick={() => setTasks([])}
+            />
+          </ButtonGroup>
+        </Popover>
+      </FormGroup>
+      <div style={{ display: 'flex', flex: 1, width: '100%' }}>
+        <FormGroup
+          disabled={isRunning || !isEnabled(providerId)}
+          label={(
+            <strong>Tags<span className='requiredStar'>*</span>
+              <span
+                className='badge-count'
+                style={{
+                  opacity: isEnabled(providerId) ? 0.5 : 0.1
+                }}
+              >{pairs.length}
+              </span>
+            </strong>
+        )}
+          labelInfo={<span style={{ display: 'block' }}>Specify tag Ref Pairs</span>}
+          inline={false}
+          labelFor='refdiff-pair-newref'
+          className=''
+          contentClassName=''
+          style={{ minWidth: '588px', marginBottom: 'auto' }}
+          fill={false}
+        >
+          <div style={{ display: 'flex' }}>
+            <div>
+              <InputGroup
+                id='refdiff-pair-newref'
+                // round='true'
+                leftElement={(
+                  <Tag
+                    intent={Intent.WARNING} style={{
+                      opacity: isEnabled(providerId) ? 1 : 0.3
+                    }}
+                  >New Ref
+                  </Tag>
+              )}
+                inline={true}
+                disabled={isRunning || !isEnabled(providerId)}
+                placeholder='eg. refs/tags/v0.6.0'
+                value={refDiffNewTag}
+                onChange={(e) => setNewTag(e.target.value)}
+                autoComplete='off'
+                fill={false}
+              />
+            </div>
+            <div style={{ marginLeft: '10px', marginRight: '10px' }}>
+              {/* <label>Old Ref</label> */}
+              <InputGroup
+                id='refdiff-pair-oldref'
+                // round='true'
+                leftElement={(
+                  <Tag
+                    style={{
+                      opacity: isEnabled(providerId) ? 1 : 0.3
+                    }}
+                  >Old Ref
+                  </Tag>
+              )}
+                inline={true}
+                disabled={isRunning || !isEnabled(providerId)}
+                placeholder='eg. refs/tags/v0.5.0'
+                value={refDiffOldTag}
+                onChange={(e) => setOldTag(e.target.value)}
+                autoComplete='off'
+                fill={false}
+                rightElement={(
+                  <Tooltip content='Add Tag Pair'>
+                    <Button
+                      className='btn-add-tagpair'
+                      intent={Intent.PRIMARY}
+                      disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
+                      icon='plus'
+                      small
+                      style={{}}
+                      onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
+                    />
+                  </Tooltip>
+
+              )}
+              />
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              {/* <Button icon='remove' minimal small style={{ marginTop: 'auto', alignSelf: 'center' }} /> */}
+              {/* <Button
+              intent={Intent.PRIMARY}
+              disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
+              icon='add'
+              small
+              style={{ marginTop: 'auto', alignSelf: 'center' }}
+              onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
+            /> */}
+            </div>
+          </div>
+          <div
+            style={{
+              borderRadius: '4px',
+              padding: '10px',
+              margin: '5px 0'
+            }}
+          >
+            {pairs.map((pair, pairIdx) => (
+              <div key={`refdiff-added-pairs-itemkey-$${pairIdx}`} style={{ display: 'flex' }}>
+                <div style={{ flex: 1 }}>
+                  <Tag intent={Intent.WARNING} round='false' small>new</Tag> {pair.newRef}
+                </div>
+                <div style={{ flex: 1, marginLeft: '10px', marginRight: '10px' }}>
+                  <Tag round='false' small>old</Tag> {pair.oldRef}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <Button
+                    className='btn-remove-tagpair'
+                    icon='remove'
+                    minimal
+                    small
+                    style={{ marginTop: 'auto', alignSelf: 'center' }}
+                    onClick={() => removeRefDiffPairObject(pair.oldRef, pair.newRef)}
+                  />
+                </div>
+              </div>
+            ))}
+            {pairs.length === 0 && <><span style={{ color: Colors.GRAY3 }}>( No Tag Pairs Added)</span></>}
+          </div>
+        </FormGroup>
+      </div>
+    </>
+  )
+}
+
+export default RefDiffSettings

--- a/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
+++ b/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
@@ -201,12 +201,10 @@ const RefDiffSettings = (props) => {
                       intent={Intent.PRIMARY}
                       disabled={!refDiffOldTag || !refDiffNewTag || refDiffOldTag === refDiffNewTag}
                       icon='plus'
-                      small
                       style={{}}
                       onClick={() => addRefDiffPairObject(refDiffOldTag, refDiffNewTag)}
                     />
                   </Tooltip>
-
               )}
               />
             </div>
@@ -242,7 +240,7 @@ const RefDiffSettings = (props) => {
                     className='btn-remove-tagpair'
                     icon='remove'
                     minimal
-                    small
+                    small='true'
                     style={{ marginTop: 'auto', alignSelf: 'center' }}
                     onClick={() => removeRefDiffPairObject(pair.oldRef, pair.newRef)}
                   />

--- a/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
+++ b/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
@@ -115,7 +115,7 @@ const RefDiffSettings = (props) => {
               icon='menu'
               text={tasks.length > 0
                 ? <>Choose Tasks <Tag intent={Intent.PRIMARY} round>{tasks.length}</Tag></>
-                : 'Choose Tasks'}
+                : <>Choose Tasks <Tag intent={Intent.PRIMARY} round>None</Tag></>}
             />
             <Button
               icon='eraser'

--- a/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
+++ b/config-ui/src/components/pipelines/pipeline-settings/refdiff.jsx
@@ -64,7 +64,7 @@ const RefDiffSettings = (props) => {
         labelFor='refdiff-repo-id'
         className=''
         contentClassName=''
-        style={{ minWidth: '280px', marginBottom: 'auto' }}
+        style={{ minWidth: '280px', marginBottom: 'auto', whiteSpace: 'nowrap' }}
         fill
       >
         <InputGroup
@@ -97,7 +97,7 @@ const RefDiffSettings = (props) => {
         labelFor='refdiff-tasks'
         className=''
         contentClassName=''
-        style={{ marginLeft: '12px', marginRight: '12px', marginBottom: 'auto' }}
+        style={{ marginLeft: '12px', marginRight: '12px', marginBottom: 'auto', whiteSpace: 'nowrap' }}
         fill
       >
 
@@ -113,16 +113,12 @@ const RefDiffSettings = (props) => {
             <Button
               disabled={isRunning || !isEnabled(providerId)}
               icon='menu'
-              // text='Choose Tasks'
               text={tasks.length > 0
                 ? <>Choose Tasks <Tag intent={Intent.PRIMARY} round>{tasks.length}</Tag></>
                 : 'Choose Tasks'}
             />
             <Button
               icon='eraser'
-              // text={refDiffTasks.length > 0
-              //   ? <><Tag intent={Intent.PRIMARY} round>{refDiffTasks.length}</Tag></>
-              //   : ''}
               intent={Intent.WARNING}
               disabled={isRunning || !isEnabled(providerId) || tasks.length === 0}
               onClick={() => setTasks([])}
@@ -149,14 +145,13 @@ const RefDiffSettings = (props) => {
           labelFor='refdiff-pair-newref'
           className=''
           contentClassName=''
-          style={{ minWidth: '588px', marginBottom: 'auto' }}
+          style={{ minWidth: '582px', marginBottom: 'auto' }}
           fill={false}
         >
           <div style={{ display: 'flex' }}>
             <div>
               <InputGroup
                 id='refdiff-pair-newref'
-                // round='true'
                 leftElement={(
                   <Tag
                     intent={Intent.WARNING} style={{
@@ -174,11 +169,9 @@ const RefDiffSettings = (props) => {
                 fill={false}
               />
             </div>
-            <div style={{ marginLeft: '10px', marginRight: '10px' }}>
-              {/* <label>Old Ref</label> */}
+            <div style={{ marginLeft: '10px', marginRight: 0 }}>
               <InputGroup
                 id='refdiff-pair-oldref'
-                // round='true'
                 leftElement={(
                   <Tag
                     style={{

--- a/config-ui/src/data/integrations.jsx
+++ b/config-ui/src/data/integrations.jsx
@@ -99,7 +99,18 @@ const pluginsData = [
       null
     )
   },
-
+  {
+    id: Providers.REFDIFF,
+    type: ProviderTypes.PIPELINE,
+    enabled: true,
+    multiSource: false,
+    name: ProviderLabels.REFDIFF,
+    icon: <img src={RefDiffProvider} className='providerIconPng' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
+    iconDashboard: <img src={RefDiffProvider} className='providerIconPng' width='48' height='48' />,
+    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+      null
+    )
+  },
 ]
 
 export {

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -107,6 +107,10 @@ function usePipelineValidation ({
       errs.push('RefDiff: Repository Column ID Code is required')
     }
 
+    if (enabledProviders.includes(Providers.REFDIFF) && refDiffTasks.length === 0) {
+      errs.push('RefDiff: Please select at least ONE (1) Plugin Task')
+    }
+
     if (enabledProviders.length === 0) {
       errs.push('Pipeline: Invalid/Empty Configuration')
     }

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -13,6 +13,9 @@ function usePipelineValidation ({
   repositoryName,
   gitExtractorUrl,
   gitExtractorRepoId,
+  refDiffRepoId,
+  refDiffTasks,
+  refDiffPairs,
   sourceId,
   tasks,
   tasksAdvanced,
@@ -100,6 +103,10 @@ function usePipelineValidation ({
       errs.push('GitExtractor: Repository Column ID Code is required')
     }
 
+    if (enabledProviders.includes(Providers.REFDIFF) && !refDiffRepoId) {
+      errs.push('RefDiff: Repository Column ID Code is required')
+    }
+
     if (enabledProviders.length === 0) {
       errs.push('Pipeline: Invalid/Empty Configuration')
     }
@@ -113,6 +120,9 @@ function usePipelineValidation ({
     repositoryName,
     gitExtractorUrl,
     gitExtractorRepoId,
+    refDiffRepoId,
+    refDiffTasks,
+    refDiffPairs,
     sourceId
   ])
 

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -111,6 +111,10 @@ function usePipelineValidation ({
       errs.push('RefDiff: Please select at least ONE (1) Plugin Task')
     }
 
+    if (enabledProviders.includes(Providers.REFDIFF) && refDiffPairs.length === 0) {
+      errs.push('RefDiff: Please enter at least ONE (1) Tag Ref Pair')
+    }
+
     if (enabledProviders.length === 0) {
       errs.push('Pipeline: Invalid/Empty Configuration')
     }

--- a/config-ui/src/hooks/usePipelineValidation.jsx
+++ b/config-ui/src/hooks/usePipelineValidation.jsx
@@ -14,11 +14,11 @@ function usePipelineValidation ({
   gitExtractorUrl,
   gitExtractorRepoId,
   refDiffRepoId,
-  refDiffTasks,
-  refDiffPairs,
+  refDiffTasks = [],
+  refDiffPairs = [],
   sourceId,
-  tasks,
-  tasksAdvanced,
+  tasks = [],
+  tasksAdvanced = [],
   advancedMode
 }) {
   const [errors, setErrors] = useState([])

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -649,7 +649,7 @@ const PipelineActivity = (props) => {
                                       <Icon icon='nest' size={12} color={Colors.GRAY4} style={{ marginRight: '0' }} /> <Tag style={{ fontSize: '9px', marginLeft: '0', backgroundColor: '#eee', color: '#777' }}>TAG PAIRS</Tag>
                                       <ul style={{ fontSize: '9px' }}>
                                         {t.options.pairs.map((ref, refIdx) => (
-                                          <li key={`option-subtask-key${refIdx}`}><strong>old</strong> {ref.oldRef} &nbsp; <strong>new</strong> {ref.oldRef} </li>
+                                          <li key={`option-subtask-key${refIdx}`}><strong>old</strong> {ref.oldRef} &nbsp; <strong>new</strong> {ref.newRef} </li>
                                         ))}
                                       </ul>
                                     </div>

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -409,6 +409,7 @@ const CreatePipeline = (props) => {
       const JiraTask = tasks.filter(t => t.plugin === Providers.JIRA)
       const JenkinsTask = tasks.find(t => t.plugin === Providers.JENKINS)
       const GitExtractorTask = tasks.find(t => t.plugin === Providers.GITEXTRACTOR)
+      const RefDiffTask = tasks.find(t => t.plugin === Providers.REFDIFF)
       const configuredProviders = []
       if (GitLabTask && GitLabTask.length > 0) {
         configuredProviders.push(Providers.GITLAB)
@@ -437,6 +438,12 @@ const CreatePipeline = (props) => {
         setGitExtractorRepoId(GitExtractorTask.options?.repoId)
         setGitExtractorUrl(GitExtractorTask.options?.url)
         configuredProviders.push(Providers.GITEXTRACTOR)
+      }
+      if (RefDiffTask) {
+        setRefDiffRepoId(RefDiffTask.options?.repoId)
+        setRefDiffTasks(RefDiffTask.options?.tasks || [])
+        setRefDiffPairs(RefDiffTask.options?.pairs || [])
+        configuredProviders.push(Providers.REFDIFF)
       }
       setEnabledProviders(eP => [...eP, ...configuredProviders])
     } else {

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -20,6 +20,7 @@ import {
 } from '@blueprintjs/core'
 import {
   Providers,
+  ProviderTypes,
   ProviderIcons
 } from '@/data/Providers'
 import { integrationsData, pluginsData } from '@/data/integrations'
@@ -88,6 +89,9 @@ const CreatePipeline = (props) => {
   const [owner, setOwner] = useState('')
   const [gitExtractorUrl, setGitExtractorUrl] = useState('')
   const [gitExtractorRepoId, setGitExtractorRepoId] = useState('')
+  const [refDiffRepoId, setRefDiffRepoId] = useState('')
+  const [refDiffPairs, setRefDiffPairs] = useState([])
+  const [refDiffTasks, setRefDiffTasks] = useState(['calculateCommitsDiff'])
 
   const [autoRedirect, setAutoRedirect] = useState(true)
   const [restartDetected, setRestartDetected] = useState(false)
@@ -121,6 +125,9 @@ const CreatePipeline = (props) => {
     sourceId,
     gitExtractorUrl,
     gitExtractorRepoId,
+    refDiffRepoId,
+    refDiffTasks,
+    refDiffPairs,
     tasks: runTasks,
     tasksAdvanced: runTasksAdvanced,
     advancedMode
@@ -207,11 +214,28 @@ const CreatePipeline = (props) => {
           repoId: gitExtractorRepoId
         }
         break
+      case Providers.REFDIFF:
+        options = {
+          repoId: refDiffRepoId,
+          pairs: refDiffPairs,
+          tasks: refDiffTasks,
+        }
+        break
       default:
         break
     }
     return options
-  }, [boardId, owner, projectId, repositoryName, sourceId, gitExtractorUrl, gitExtractorRepoId])
+  }, [boardId,
+    owner,
+    projectId,
+    repositoryName,
+    sourceId,
+    gitExtractorUrl,
+    gitExtractorRepoId,
+    refDiffRepoId,
+    refDiffTasks,
+    refDiffPairs
+  ])
 
   const configureProvider = useCallback((providerId) => {
     let providerConfig = {}
@@ -258,6 +282,9 @@ const CreatePipeline = (props) => {
     setOwner('')
     setGitExtractorUrl('')
     setGitExtractorRepoId('')
+    setRefDiffRepoId('')
+    setRefDiffTasks([])
+    setRefDiffPairs([])
     setAdvancedMode(false)
     setRawConfiguration('[[]]')
   }
@@ -900,6 +927,9 @@ const CreatePipeline = (props) => {
                               boardId={boardId}
                               gitExtractorUrl={gitExtractorUrl}
                               gitExtractorRepoId={gitExtractorRepoId}
+                              refDiffRepoId={refDiffRepoId}
+                              refDiffTasks={refDiffTasks}
+                              refDiffPairs={refDiffPairs}
                               setProjectId={setProjectId}
                               setOwner={setOwner}
                               setRepositoryName={setRepositoryName}
@@ -907,15 +937,20 @@ const CreatePipeline = (props) => {
                               setBoardId={setBoardId}
                               setGitExtractorUrl={setGitExtractorUrl}
                               setGitExtractorRepoId={setGitExtractorRepoId}
+                              setRefDiffRepoId={setRefDiffRepoId}
+                              setRefDiffPairs={setRefDiffPairs}
+                              setRefDiffTasks={setRefDiffTasks}
                               isEnabled={isProviderEnabled}
                               isRunning={isRunning}
                             />
                           </div>
                           <div className='provider-actions'>
                             <ButtonGroup minimal rounded='true'>
-                              <Button className='pipeline-action-btn' minimal onClick={() => history.push(`/integrations/${provider.id}`)}>
-                                <Icon icon='cog' color={Colors.GRAY4} size={16} />
-                              </Button>
+                              {provider.type === ProviderTypes.INTEGRATION && (
+                                <Button className='pipeline-action-btn' minimal onClick={() => history.push(`/integrations/${provider.id}`)}>
+                                  <Icon icon='cog' color={Colors.GRAY4} size={16} />
+                                </Button>
+                              )}
                               <Popover
                                 key={`popover-help-key-provider-${provider.id}`}
                                 className='trigger-provider-help'

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -958,7 +958,7 @@ const CreatePipeline = (props) => {
                                 position={Position.RIGHT}
                                 autoFocus={false}
                                 enforceFocus={false}
-                                usePortal={false}
+                                usePortal={true}
                               >
                                 <Button className='pipeline-action-btn' minimal><Icon icon='help' color={Colors.GRAY4} size={16} /></Button>
                                 <>
@@ -1005,6 +1005,36 @@ const CreatePipeline = (props) => {
                                               src={GithubHelpNote}
                                               alt={provider.name} style={{ maxHeight: '64px', maxWidth: '100%' }}
                                             />
+                                          )
+                                          break
+                                        case Providers.GITEXTRACTOR:
+                                          helpContext = (
+                                            <>
+                                              <div><strong>GitExtractor README</strong></div>
+                                              <p>This plugin extract commits and references from a remote or local git repository.</p>
+                                              <a
+                                                className='bp3-button bp3-small'
+                                                rel='noreferrer'
+                                                target='_blank'
+                                                href='https://github.com/merico-dev/lake/tree/main/plugins/gitextractor'
+                                              >Learn More
+                                              </a>
+                                            </>
+                                          )
+                                          break
+                                        case Providers.REFDIFF:
+                                          helpContext = (
+                                            <>
+                                              <div><strong>RefDiff README</strong></div>
+                                              <p>You need to run gitextractor before the refdiff plugin.</p>
+                                              <a
+                                                className='bp3-button bp3-small'
+                                                rel='noreferrer'
+                                                target='_blank'
+                                                href='https://github.com/merico-dev/lake/tree/main/plugins/refdiff'
+                                              >Learn More
+                                              </a>
+                                            </>
                                           )
                                           break
                                       }

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -91,7 +91,7 @@ const CreatePipeline = (props) => {
   const [gitExtractorRepoId, setGitExtractorRepoId] = useState('')
   const [refDiffRepoId, setRefDiffRepoId] = useState('')
   const [refDiffPairs, setRefDiffPairs] = useState([])
-  const [refDiffTasks, setRefDiffTasks] = useState(['calculateCommitsDiff'])
+  const [refDiffTasks, setRefDiffTasks] = useState(['calculateCommitsDiff', 'calculateIssuesDiff'])
 
   const [autoRedirect, setAutoRedirect] = useState(true)
   const [restartDetected, setRestartDetected] = useState(false)

--- a/config-ui/src/styles/common.scss
+++ b/config-ui/src/styles/common.scss
@@ -269,15 +269,19 @@ h3 {
 }
 
 .badge-count {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   display: inline-block;
   border-radius: 50%;
   background-color: rgba(0, 0, 255, 0.9);
   color: #ffffff;
-  line-height: 18px;
+  line-height: 20px;
   text-align: center;
   margin-left: 5px;
   font-weight: 300;
+  font-size: 10px;
   opacity: 1.0;
+  float: right;
+  margin-top: -3px;
+  transform: scale(0.85);
 }

--- a/config-ui/src/styles/libraries/blueprint.scss
+++ b/config-ui/src/styles/libraries/blueprint.scss
@@ -126,3 +126,13 @@ button, .bp3-button {
     }
   }
 }
+
+.bp3-menu-item {
+  .bp3-control {
+    margin-bottom: 0;
+  }
+}
+
+.bp3-control.bp3-checkbox input:checked~.bp3-control-indicator:before {
+	background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='rgba(255,255,255,1)'/%3E%3C/svg%3E")
+}

--- a/config-ui/src/styles/pipelines.scss
+++ b/config-ui/src/styles/pipelines.scss
@@ -100,6 +100,7 @@
     padding: 0 20px;
     align-items: flex-end;
     display: flex;
+    flex-wrap: wrap;
 
     .bp3-form-group {
       margin-bottom: 0;
@@ -399,6 +400,21 @@
         &:hover {
           background-color: rgba(66, 66, 66, 0.08);
           color: darken(#007cff, 5%);
+        }
+      }
+    }
+  }
+  &.refdiff-tasks-menu {
+    > li {
+      margin-bottom: 2px;
+      border-radius: 8px;
+      outline: none !important;
+
+      .bp3-menu-item {
+        outline: none !important;
+        border-radius: inherit;
+        &.bp3-active {
+          font-weight: bold;
         }
       }
     }


### PR DESCRIPTION
### Config UI / Pipelines / Create New Pipeline RUN `RefDiff`

- [x] Create Pipeline UI : Support `RefDiff` Plugin
- [x] Update **Pipeline Validation Hook** Rules
   - Validate `repoId` (Non-Empty)
   - Validate `Tasks` (At least 1 selected)
   - Validate `Pairs` (At least 1 pair defined)
- [x] Restart Detection
- [x] `BUGFIX` #1314 
- [x] Test **RefDiff** Settings
- [x] Test Create Pipeline Workflow

### Description
This PR adds **RefDiff** as a **Pipeline** **Provider** in Visual/UI Mode when creating a new Pipeline Run. It requires 3 parameters, `RepoId` , `Pairs` and `Tasks`. Previously `refdiff` was only detected in Advanced Mode, now it will be available in both Visual and Advanced modes.

Users are able to select from a Preset list of **Tasks** for the RefDiff Plugin:
- `calculateCommitsDiff`
- `calculateIssuesDiff`

Currently there is no max limit placed on the Ref TagPairs that can be added, we could restrict this value in the future.

### Does this close any open issues?
#1195, #1314

### Screenshots
<img width="1269" alt="Screen Shot 2022-03-10 at 7 08 05 PM" src="https://user-images.githubusercontent.com/1742233/157776595-ca03bd1a-d26d-4e55-95d1-ead99a413c94.png">
<img width="1268" alt="Screen Shot 2022-03-10 at 7 09 20 PM" src="https://user-images.githubusercontent.com/1742233/157776589-6848a603-26af-4f87-9e37-7966f9d0a3d0.png">
<img width="1253" alt="Screen Shot 2022-03-10 at 7 09 48 PM" src="https://user-images.githubusercontent.com/1742233/157776579-314a0769-5ec1-4be5-811a-d204c00beb7e.png">
<img width="1334" alt="Screen Shot 2022-03-11 at 12 12 14 PM" src="https://user-images.githubusercontent.com/1742233/157914795-aca3f4ae-a182-422c-9093-1a4ad3673d2c.png">


