### PR TITLE
fix: github secondary rate limit when too many retries

### DIFF
--- a/plugins/core/apiclient.go
+++ b/plugins/core/apiclient.go
@@ -133,9 +133,9 @@ func (apiClient *ApiClient) logError(format string, a ...interface{}) {
 func (apiClient *ApiClient) Do(
 	method string,
 	path string,
-	query *url.Values,
+	query url.Values,
 	body interface{},
-	headers *url.Values,
+	headers http.Header,
 ) (*http.Response, error) {
 	uri, err := GetURIStringPointer(apiClient.endpoint, path, query)
 	if err != nil {
@@ -168,7 +168,7 @@ func (apiClient *ApiClient) Do(
 		}
 	}
 	if headers != nil {
-		for name, values := range *headers {
+		for name, values := range headers {
 			for _, value := range values {
 				req.Header.Add(name, value)
 			}
@@ -224,8 +224,8 @@ func (apiClient *ApiClient) Do(
 
 func (apiClient *ApiClient) Get(
 	path string,
-	query *url.Values,
-	headers *url.Values,
+	query url.Values,
+	headers http.Header,
 ) (*http.Response, error) {
 	return apiClient.Do("GET", path, query, nil, headers)
 }
@@ -243,7 +243,7 @@ func UnmarshalResponse(res *http.Response, v interface{}) error {
 	return nil
 }
 
-func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.Values) (*string, error) {
+func GetURIStringPointer(baseUrl string, relativePath string, query url.Values) (*string, error) {
 	// If the base URL doesn't end with a slash, and has a relative path attached
 	// the values will be removed by the Go package, therefore we need to add a missing slash.
 	AddMissingSlashToURL(&baseUrl)
@@ -257,9 +257,9 @@ func GetURIStringPointer(baseUrl string, relativePath string, queryParams *url.V
 	if err != nil {
 		return nil, err
 	}
-	if queryParams != nil {
+	if query != nil {
 		queryString := u.Query()
-		for key, value := range *queryParams {
+		for key, value := range query {
 			queryString.Set(key, strings.Join(value, ""))
 		}
 		u.RawQuery = queryString.Encode()
@@ -292,9 +292,9 @@ func RemoveStartingSlashFromPath(relativePath string) string {
 func (apiClient *ApiClient) DoAsync(
 	method string,
 	path string,
-	query *url.Values,
+	query url.Values,
 	body interface{},
-	header *url.Values,
+	header http.Header,
 	handler func(*http.Response) error,
 	retry int,
 ) error {
@@ -313,7 +313,7 @@ func (apiClient *ApiClient) DoAsync(
 	})
 }
 
-func (apiClient *ApiClient) GetAsync(path string, query *url.Values, header *url.Values, handler func(*http.Response) error) error {
+func (apiClient *ApiClient) GetAsync(path string, query url.Values, header http.Header, handler func(*http.Response) error) error {
 	return apiClient.DoAsync(http.MethodGet, path, query, nil, header, handler, 0)
 }
 
@@ -323,7 +323,7 @@ func (apiClient *ApiClient) WaitAsync() {
 }
 
 type AsyncApiClient interface {
-	GetAsync(path string, queryParams *url.Values, headerParams *url.Values, handler func(*http.Response) error) error
+	GetAsync(path string, query url.Values, header http.Header, handler func(*http.Response) error) error
 	WaitAsync()
 }
 

--- a/plugins/jira/api/jira_proxy.go
+++ b/plugins/jira/api/jira_proxy.go
@@ -35,7 +35,7 @@ func Proxy(input *core.ApiResourceInput) (*core.ApiResourceOutput, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.Get(input.Params["path"], &input.Query, nil)
+	resp, err := client.Get(input.Params["path"], input.Query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/jira/tasks/jira_api_changelog_collector.go
+++ b/plugins/jira/tasks/jira_api_changelog_collector.go
@@ -70,8 +70,8 @@ func CollectApiChangelogs(taskCtx core.SubTaskContext) error {
 		Incremental: incremental,
 		Input:       iterator,
 		UrlTemplate: "api/3/issue/{{ .Input.IssueId }}/changelog",
-		Query: func(pager *helper.Pager) (*url.Values, error) {
-			query := &url.Values{}
+		Query: func(pager *helper.Pager) (url.Values, error) {
+			query := url.Values{}
 			query.Set("startAt", fmt.Sprintf("%v", pager.Skip))
 			query.Set("maxResults", fmt.Sprintf("%v", pager.Size))
 			return query, nil

--- a/plugins/jira/tasks/jira_api_client.go
+++ b/plugins/jira/tasks/jira_api_client.go
@@ -72,9 +72,9 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 
 	// 获取issue总数
 	// get issue count
-	pageQuery := &url.Values{}
+	pageQuery := url.Values{}
 	for key, value := range *query {
-		(*pageQuery)[key] = value
+		pageQuery[key] = value
 	}
 	pageQuery.Set("maxResults", "0")
 	// make a call to the api just to get the paging details
@@ -97,7 +97,7 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 		}
 		queryCopy.Set("maxResults", strconv.Itoa(pageSize))
 		queryCopy.Set("startAt", strconv.Itoa(nextStartTmp))
-		err = jiraApiClient.GetAsync(path, &queryCopy, nil, handler)
+		err = jiraApiClient.GetAsync(path, queryCopy, nil, handler)
 		if err != nil {
 			return err
 		}
@@ -115,13 +115,13 @@ func (jiraApiClient *JiraApiClient) FetchPages(path string, query *url.Values, h
 // us whether or not to continue making requests. This is why we created JiraSearchPaginationHandler.
 func (jiraApiClient *JiraApiClient) FetchWithoutPaginationHeaders(
 	path string,
-	query *url.Values,
+	query url.Values,
 	handler JiraSearchPaginationHandler,
 ) error {
 	// this method is sequential, data would be collected page by page
 	// because all collectors using this method do not contains many records.
 	if query == nil {
-		query = &url.Values{}
+		query = url.Values{}
 	}
 	// these are the names from the jira search api for pagination
 	// eg: https://merico.atlassian.net/rest/api/2/user/assignable/search?project=EE&maxResults=100&startAt=1

--- a/plugins/jira/tasks/jira_api_issues_collector.go
+++ b/plugins/jira/tasks/jira_api_issues_collector.go
@@ -84,8 +84,8 @@ func CollectApiIssues(taskCtx core.SubTaskContext) error {
 		/*
 			(Optional) Return query string for request, or you can plug them into UrlTemplate directly
 		*/
-		Query: func(pager *helper.Pager) (*url.Values, error) {
-			query := &url.Values{}
+		Query: func(pager *helper.Pager) (url.Values, error) {
+			query := url.Values{}
 			query.Set("jql", jql)
 			query.Set("startAt", fmt.Sprintf("%v", pager.Skip))
 			query.Set("maxResults", fmt.Sprintf("%v", pager.Size))

--- a/plugins/jira/tasks/jira_server_api_client.go
+++ b/plugins/jira/tasks/jira_server_api_client.go
@@ -32,7 +32,7 @@ func (v8 *ServerVersion8) FetchPages(path string, query *url.Values, handler Jir
 	}
 	return v8.client.FetchPages(path, query, f)
 }
-func (v8 *ServerVersion8) FetchWithoutPaginationHeaders(path string, query *url.Values, handler JiraSearchPaginationHandler) error {
+func (v8 *ServerVersion8) FetchWithoutPaginationHeaders(path string, query url.Values, handler JiraSearchPaginationHandler) error {
 	return v8.client.FetchWithoutPaginationHeaders(path, query, handler)
 }
 


### PR DESCRIPTION
# Summary

Fix secondary rate limit

## how to verify
1. dial down your plugin api client timeout to a low value to simulate a massive failure situation
2. run plugin, and retry should be working
3. reset timeout
4. run plugin, and retry should be gone

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
api client retry on failure automatically, and, directly without scheduler, this is problematic when network connectivity is bad, which causes too many api request sent in a short peroid of time.
this fix moves retry logic under schedulers control to avoid such a problem.

### Does this close any open issues?
 Closes #1322
