### PR TITLE
Refactor git extractor

### DIFF
--- a/plugins/gitextractor/README-zh-CN.md
+++ b/plugins/gitextractor/README-zh-CN.md
@@ -33,3 +33,13 @@ curl --location --request POST 'localhost:8080/pipelines' \
 - `password`: 可选, 通过HTTP/HTTPS协议克隆私有代码库时使用
 - `privateKey`: 可选, 通过SSH协议克隆代码库时使用, 值为经过base64编码的`PEM`文件
 - `passphrase`: 可选, 私钥的密码
+
+## 独立运行本插件
+
+本插件可以作为独立于DevLake服务的命令行工具使用:
+
+```
+go run plugins/gitextractor/main.go -url https://github.com/merico-dev/lake.git -id github:GithubRepo:384111310 -db "merico:merico@tcp(127.0.0.1:3306)/lake?charset=utf8mb4&parseTime=True"
+```
+
+如果想了解命令行工具的更多选项，比如如何输出收集结果到csv文件，请直接阅读`plugins/gitextractor/main.go`。

--- a/plugins/gitextractor/README.md
+++ b/plugins/gitextractor/README.md
@@ -40,6 +40,16 @@ curl --location --request POST 'localhost:8080/pipelines' \
 - `passphrase`: optional, passphrase for the private key
 
 
+## Standalone Mode
+
+You call also run this plugin in a standalone mode without any DevLake service running using the following command:
+
+```
+go run plugins/gitextractor/main.go -url https://github.com/merico-dev/lake.git -id github:GithubRepo:384111310 -db "merico:merico@tcp(127.0.0.1:3306)/lake?charset=utf8mb4&parseTime=True"
+```
+
+For more options (e.g., saving to a csv file instead of a db), please read `plugins/gitextractor/main.go`.
+
 ## Development
 
 This plugin depends on `libgit2`, you need to install version 1.3.0 in order to run and debug this plugin on your local

--- a/plugins/gitextractor/gitextractor.go
+++ b/plugins/gitextractor/gitextractor.go
@@ -2,43 +2,13 @@ package main
 
 import (
 	"context"
-	"errors"
-	"strings"
 
 	lakeErrors "github.com/merico-dev/lake/errors"
 	"github.com/merico-dev/lake/plugins/helper"
 	"github.com/merico-dev/lake/plugins/core"
-	"github.com/merico-dev/lake/plugins/gitextractor/parser"
-	"github.com/merico-dev/lake/plugins/gitextractor/store"
+	"github.com/merico-dev/lake/plugins/gitextractor/tasks"
 	"github.com/mitchellh/mapstructure"
 )
-
-type GitExtractorOptions struct {
-	RepoId     string `json:"repoId"`
-	Url        string `json:"url"`
-	User       string `json:"user"`
-	Password   string `json:"password"`
-	PrivateKey string `json:"privateKey"`
-	Passphrase string `json:"passphrase"`
-	Proxy      string `json:"proxy"`
-}
-
-func (o GitExtractorOptions) Valid() error {
-	if o.RepoId == "" {
-		return errors.New("empty repoId")
-	}
-	if o.Url == "" {
-		return errors.New("empty url")
-	}
-	url := strings.TrimPrefix(o.Url, "ssh://")
-	if !(strings.HasPrefix(o.Url, "http") || strings.HasPrefix(url, "git@") || strings.HasPrefix(o.Url, "/")) {
-		return errors.New("wrong url")
-	}
-	if o.Proxy != "" && !strings.HasPrefix(o.Proxy, "http://") {
-		return errors.New("only support http proxy")
-	}
-	return nil
-}
 
 type GitExtractor struct{}
 
@@ -51,33 +21,12 @@ func (plugin GitExtractor) Init() {
 	logger.Info("INFO >>> init git extractor")
 }
 
-func collectGitRepo(taskCtx core.SubTaskContext) error {
-	db := taskCtx.GetDb()
-	storage := store.NewDatabase(db)
-	defer storage.Close()
-	op := taskCtx.GetData().(GitExtractorOptions)
-	ctx := taskCtx.GetContext()
-	p := parser.NewLibGit2(storage)
-	var err error
-	if strings.HasPrefix(op.Url, "http") {
-		err = p.CloneOverHTTP(ctx, op.RepoId, op.Url, op.User, op.Password, op.Proxy)
-	} else if url := strings.TrimPrefix(op.Url, "ssh://"); strings.HasPrefix(url, "git@") {
-		err = p.CloneOverSSH(ctx, op.RepoId, url, op.PrivateKey, op.Passphrase)
-	} else if strings.HasPrefix(op.Url, "/") {
-		err = p.LocalRepo(ctx, op.Url, op.RepoId)
-	}
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (plugin GitExtractor) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
 	logger := helper.NewDefaultTaskLogger(nil, "git extractor")
 	logger.Info("INFO >>> start git extractor plugin execution")
 
 	// decode options into op
-	var op GitExtractorOptions
+	var op tasks.GitExtractorOptions
 	err := mapstructure.Decode(options, &op)
 	if err != nil {
 		return err
@@ -88,17 +37,17 @@ func (plugin GitExtractor) Execute(options map[string]interface{}, progress chan
 	}
 
 	// construct task context
-	subtasksToRun := map[string]bool{"collectGitRepo": true}
+	subtasksToRun := map[string]bool{"CollectGitRepo": true}
 	taskCtx := helper.NewDefaultTaskContext("git", ctx, logger, op, subtasksToRun)
 	// only 1 subtask to be executed, set current progress to 0 and total to 1
 	taskCtx.SetProgress(0, 1)
 
 	// execute subtasks, only one subtask for now
-	c, err := taskCtx.SubTaskContext("collectGitRepo")
+	c, err := taskCtx.SubTaskContext("CollectGitRepo")
 	if err != nil {
 		return err
 	}
-	err = collectGitRepo(c)
+	err = tasks.CollectGitRepo(c)
 	if err != nil {
 		return &lakeErrors.SubTaskError{
 			SubTaskName: "collectGitRepo",

--- a/plugins/gitextractor/gitextractor.go
+++ b/plugins/gitextractor/gitextractor.go
@@ -86,12 +86,12 @@ func (plugin GitExtractor) Execute(options map[string]interface{}, progress chan
 	if err != nil {
 		return err
 	}
-	progress <- 0.1
 
 	// construct task context
 	subtasksToRun := map[string]bool{"collectGitRepo": true}
 	taskCtx := helper.NewDefaultTaskContext("git", ctx, logger, op, subtasksToRun)
-	taskCtx.SetProgress(10, 100)
+	// only 1 subtask to be executed, set current progress to 0 and total to 1
+	taskCtx.SetProgress(0, 1)
 
 	// execute subtasks, only one subtask for now
 	c, err := taskCtx.SubTaskContext("collectGitRepo")
@@ -105,7 +105,7 @@ func (plugin GitExtractor) Execute(options map[string]interface{}, progress chan
 			Message: err.Error(),
 		}
 	}
-	progress <- 1
+	taskCtx.IncProgress(1)
 	return nil
 }
 

--- a/plugins/gitextractor/gitextractor.go
+++ b/plugins/gitextractor/gitextractor.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/merico-dev/lake/logger"
+	"github.com/merico-dev/lake/plugins/helper"
 	lakeModels "github.com/merico-dev/lake/models"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/gitextractor/parser"
@@ -47,11 +47,13 @@ func (plugin GitExtractor) Description() string {
 }
 
 func (plugin GitExtractor) Init() {
-	logger.Info("INFO >>> init git extractor", true)
+	logger := helper.NewDefaultTaskLogger(nil, "git extractor")
+	logger.Info("INFO >>> init git extractor")
 }
 
 func (plugin GitExtractor) Execute(options map[string]interface{}, progress chan<- float32, ctx context.Context) error {
-	logger.Print("start gitlab plugin execution")
+	logger := helper.NewDefaultTaskLogger(nil, "git extractor")
+	logger.Info("INFO >>> start git extractor plugin execution")
 	var op GitExtractorOptions
 	err := mapstructure.Decode(options, &op)
 	if err != nil {

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -46,7 +46,13 @@ func main() {
 	}
 	defer storage.Close()
 	ctx := context.Background()
-	p := parser.NewLibGit2(storage, helper.NewDefaultTaskLogger(nil, "git extractor"))
+	subTaskCtx := helper.NewStandaloneSubTaskContext(
+		"git extractor",
+		ctx,
+		helper.NewDefaultTaskLogger(nil, "git extractor"),
+		nil,
+	)
+	p := parser.NewLibGit2(storage, subTaskCtx)
 	if strings.HasPrefix(*url, "http") {
 		err = p.CloneOverHTTP(ctx, *url, *id, *user, *password, *proxy)
 		if err != nil {

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -54,7 +54,7 @@ func main() {
 	)
 	p := parser.NewLibGit2(storage, subTaskCtx)
 	if strings.HasPrefix(*url, "http") {
-		err = p.CloneOverHTTP(*url, *id, *user, *password, *proxy)
+		err = p.CloneOverHTTP(*id, *url, *user, *password, *proxy)
 		if err != nil {
 			panic(err)
 		}

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/merico-dev/lake/plugins/helper"
 	"github.com/merico-dev/lake/plugins/gitextractor/models"
 	"github.com/merico-dev/lake/plugins/gitextractor/parser"
 	"github.com/merico-dev/lake/plugins/gitextractor/store"
@@ -45,7 +46,7 @@ func main() {
 	}
 	defer storage.Close()
 	ctx := context.Background()
-	p := parser.NewLibGit2(storage)
+	p := parser.NewLibGit2(storage, helper.NewDefaultTaskLogger(nil, "git extractor"))
 	if strings.HasPrefix(*url, "http") {
 		err = p.CloneOverHTTP(ctx, *url, *id, *user, *password, *proxy)
 		if err != nil {

--- a/plugins/gitextractor/main.go
+++ b/plugins/gitextractor/main.go
@@ -54,13 +54,13 @@ func main() {
 	)
 	p := parser.NewLibGit2(storage, subTaskCtx)
 	if strings.HasPrefix(*url, "http") {
-		err = p.CloneOverHTTP(ctx, *url, *id, *user, *password, *proxy)
+		err = p.CloneOverHTTP(*url, *id, *user, *password, *proxy)
 		if err != nil {
 			panic(err)
 		}
 	}
 	if strings.HasPrefix(*url, "/") {
-		err = p.LocalRepo(ctx, *url, *id)
+		err = p.LocalRepo(*url, *id)
 		if err != nil {
 			panic(err)
 		}

--- a/plugins/gitextractor/parser/clone.go
+++ b/plugins/gitextractor/parser/clone.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -36,7 +35,7 @@ func cloneOverSSH(url, dir, passphrase string, pk []byte) error {
 	return nil
 }
 
-func (l *LibGit2) CloneOverHTTP(ctx context.Context, repoId, url, user, password, proxy string) error {
+func (l *LibGit2) CloneOverHTTP(repoId, url, user, password, proxy string) error {
 	cloneOptions := &git.CloneOptions{Bare: true}
 	if proxy != "" {
 		cloneOptions.FetchOptions.ProxyOptions.Type = git.ProxyTypeSpecified
@@ -55,10 +54,10 @@ func (l *LibGit2) CloneOverHTTP(ctx context.Context, repoId, url, user, password
 	if err != nil {
 		return err
 	}
-	return l.run(ctx, repo, repoId)
+	return l.run(repo, repoId)
 }
 
-func (l *LibGit2) CloneOverSSH(ctx context.Context, repoId, url, privateKey, passphrase string) error {
+func (l *LibGit2) CloneOverSSH(repoId, url, privateKey, passphrase string) error {
 	dir, err := ioutil.TempDir("", "gitextractor")
 	if err != nil {
 		return err
@@ -72,5 +71,5 @@ func (l *LibGit2) CloneOverSSH(ctx context.Context, repoId, url, privateKey, pas
 	if err != nil {
 		return err
 	}
-	return l.LocalRepo(ctx, dir, repoId)
+	return l.LocalRepo(dir, repoId)
 }

--- a/plugins/gitextractor/parser/libgit2.go
+++ b/plugins/gitextractor/parser/libgit2.go
@@ -106,7 +106,7 @@ func (l *LibGit2) run(repo *git.Repository, repoId string) error {
 		return nil
 	}
 	err = odb.ForEach(func(id *git.Oid) error {
-		l.logger.Info("process commit:", id.String())
+		l.logger.Info("process commit: %s", id.String())
 		select {
 		case <-l.ctx.Done():
 			return l.ctx.Err()

--- a/plugins/gitextractor/parser/libgit2.go
+++ b/plugins/gitextractor/parser/libgit2.go
@@ -19,10 +19,15 @@ const (
 type LibGit2 struct {
 	store models.Store
 	logger core.Logger
+	ctx context.Context // for canceling
+	subTaskCtx core.SubTaskContext // for updating progress
 }
 
-func NewLibGit2(store models.Store, logger core.Logger) *LibGit2 {
-	return &LibGit2{store: store, logger: logger}
+func NewLibGit2(store models.Store, subTaskCtx core.SubTaskContext) *LibGit2 {
+	return &LibGit2{store: store,
+				    logger: subTaskCtx.GetLogger(),
+				    ctx: subTaskCtx.GetContext(),
+					subTaskCtx: subTaskCtx}
 }
 
 func (l *LibGit2) LocalRepo(ctx context.Context, repoPath, repoId string) error {

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -36,13 +36,13 @@ func (o GitExtractorOptions) Valid() error {
 	return nil
 }
 
-func CollectGitRepo(taskCtx core.SubTaskContext) error {
-	db := taskCtx.GetDb()
+func CollectGitRepo(subTaskCtx core.SubTaskContext) error {
+	db := subTaskCtx.GetDb()
 	storage := store.NewDatabase(db)
 	defer storage.Close()
-	op := taskCtx.GetData().(GitExtractorOptions)
-	ctx := taskCtx.GetContext()
-	p := parser.NewLibGit2(storage)
+	op := subTaskCtx.GetData().(GitExtractorOptions)
+	ctx := subTaskCtx.GetContext()
+	p := parser.NewLibGit2(storage, subTaskCtx.GetLogger())
 	var err error
 	if strings.HasPrefix(op.Url, "http") {
 		err = p.CloneOverHTTP(ctx, op.RepoId, op.Url, op.User, op.Password, op.Proxy)

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -1,0 +1,58 @@
+package tasks
+
+import (
+	"strings"
+	"errors"
+
+	"github.com/merico-dev/lake/plugins/core"
+	"github.com/merico-dev/lake/plugins/gitextractor/parser"
+	"github.com/merico-dev/lake/plugins/gitextractor/store"
+)
+
+type GitExtractorOptions struct {
+	RepoId     string `json:"repoId"`
+	Url        string `json:"url"`
+	User       string `json:"user"`
+	Password   string `json:"password"`
+	PrivateKey string `json:"privateKey"`
+	Passphrase string `json:"passphrase"`
+	Proxy      string `json:"proxy"`
+}
+
+func (o GitExtractorOptions) Valid() error {
+	if o.RepoId == "" {
+		return errors.New("empty repoId")
+	}
+	if o.Url == "" {
+		return errors.New("empty url")
+	}
+	url := strings.TrimPrefix(o.Url, "ssh://")
+	if !(strings.HasPrefix(o.Url, "http") || strings.HasPrefix(url, "git@") || strings.HasPrefix(o.Url, "/")) {
+		return errors.New("wrong url")
+	}
+	if o.Proxy != "" && !strings.HasPrefix(o.Proxy, "http://") {
+		return errors.New("only support http proxy")
+	}
+	return nil
+}
+
+func CollectGitRepo(taskCtx core.SubTaskContext) error {
+	db := taskCtx.GetDb()
+	storage := store.NewDatabase(db)
+	defer storage.Close()
+	op := taskCtx.GetData().(GitExtractorOptions)
+	ctx := taskCtx.GetContext()
+	p := parser.NewLibGit2(storage)
+	var err error
+	if strings.HasPrefix(op.Url, "http") {
+		err = p.CloneOverHTTP(ctx, op.RepoId, op.Url, op.User, op.Password, op.Proxy)
+	} else if url := strings.TrimPrefix(op.Url, "ssh://"); strings.HasPrefix(url, "git@") {
+		err = p.CloneOverSSH(ctx, op.RepoId, url, op.PrivateKey, op.Passphrase)
+	} else if strings.HasPrefix(op.Url, "/") {
+		err = p.LocalRepo(ctx, op.Url, op.RepoId)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -42,14 +42,13 @@ func CollectGitRepo(subTaskCtx core.SubTaskContext) error {
 	defer storage.Close()
 	op := subTaskCtx.GetData().(GitExtractorOptions)
 	p := parser.NewLibGit2(storage, subTaskCtx)
-	ctx := subTaskCtx.GetContext()
 	var err error
 	if strings.HasPrefix(op.Url, "http") {
-		err = p.CloneOverHTTP(ctx, op.RepoId, op.Url, op.User, op.Password, op.Proxy)
+		err = p.CloneOverHTTP(op.RepoId, op.Url, op.User, op.Password, op.Proxy)
 	} else if url := strings.TrimPrefix(op.Url, "ssh://"); strings.HasPrefix(url, "git@") {
-		err = p.CloneOverSSH(ctx, op.RepoId, url, op.PrivateKey, op.Passphrase)
+		err = p.CloneOverSSH(op.RepoId, url, op.PrivateKey, op.Passphrase)
 	} else if strings.HasPrefix(op.Url, "/") {
-		err = p.LocalRepo(ctx, op.Url, op.RepoId)
+		err = p.LocalRepo(op.Url, op.RepoId)
 	}
 	if err != nil {
 		return err

--- a/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/plugins/gitextractor/tasks/git_repo_collector.go
@@ -41,8 +41,8 @@ func CollectGitRepo(subTaskCtx core.SubTaskContext) error {
 	storage := store.NewDatabase(db)
 	defer storage.Close()
 	op := subTaskCtx.GetData().(GitExtractorOptions)
+	p := parser.NewLibGit2(storage, subTaskCtx)
 	ctx := subTaskCtx.GetContext()
-	p := parser.NewLibGit2(storage, subTaskCtx.GetLogger())
 	var err error
 	if strings.HasPrefix(op.Url, "http") {
 		err = p.CloneOverHTTP(ctx, op.RepoId, op.Url, op.User, op.Password, op.Proxy)

--- a/plugins/helper/default_task_context.go
+++ b/plugins/helper/default_task_context.go
@@ -139,6 +139,22 @@ func (c *DefaultTaskContext) SubTaskContext(subtask string) (core.SubTaskContext
 	return nil, fmt.Errorf("subtask %s doesn't exist", subtask)
 }
 
+// This returns a stand-alone core.SubTaskContext,
+// not attached to any core.TaskContext.
+// Use this if you need to run/debug a subtask without
+// going through the usual workflow. 
+func NewStandaloneSubTaskContext(
+	name string,
+	ctx context.Context,
+	logger core.Logger,
+	data interface{},
+) core.SubTaskContext {
+	return &DefaultSubTaskContext{
+		newDefaultExecContext(name, ctx, data, logger),
+		nil,
+	}
+}
+
 func (c *DefaultTaskContext) SetData(data interface{}) {
 	c.data = data
 }


### PR DESCRIPTION
# Summary

This is a minor refactor PR to get the git extractor conformed to the new `SubTaskEntryPoint` interface. It also removes usage of progress channel and global logger to prepare for the migration to Temporal.

## Verification

After the refactor, I truncated the related tables and re-run the plugin for verification. The number of rows for each table is summarized below (data collected against DevLake git repo):

| Table     | COUNT |
| ----------- | ----------- |
| refs      | 20       |
| commits   | 2757       |
| repo_commits | 2757 | 
| commit_files | 17810 | 
| commit_parents | 3460 | 


