### PR TITLE
fix: didgen not working when being called by plugin.main

### DIFF
--- a/runner/directrun.go
+++ b/runner/directrun.go
@@ -29,6 +29,10 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask core.PluginTask, op
 	if pluginInit, ok := pluginTask.(core.PluginInit); ok {
 		pluginInit.Init(cfg, log, db)
 	}
+	err = core.RegisterPlugin(cmd.Use, pluginTask.(core.PluginMeta))
+	if err != nil {
+		panic(err)
+	}
 	err = RunPluginSubTasks(
 		cfg,
 		log,


### PR DESCRIPTION
# Summary

`DomainIdGenerator` needed plugin to be registered into `core` , this step is missing from `directrun.go` logic, causing `Converter` not able to work.
This shoud fix the problem, but I dont have existing `Converter` to test, please rebase and test it out.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
