### PR TITLE
`fix` v0.9.0 github settings - field saving issues

### DIFF
--- a/config-ui/src/data/integrations.jsx
+++ b/config-ui/src/data/integrations.jsx
@@ -21,11 +21,12 @@ const integrationsData = [
     name: ProviderLabels.GITLAB,
     icon: <GitlabProvider className='providerIconSvg' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
     iconDashboard: <GitlabProvider className='providerIconSvg' width='48' height='48' />,
-    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+    settings: ({ activeProvider, activeConnection, isSaving, isSavingConnection, setSettings }) => (
       <GitlabSettings
         provider={activeProvider}
         connection={activeConnection}
         isSaving={isSaving}
+        isSavingConnection={isSavingConnection}
         onSettingsChange={setSettings}
       />
     )
@@ -37,11 +38,12 @@ const integrationsData = [
     name: ProviderLabels.JENKINS,
     icon: <JenkinsProvider className='providerIconSvg' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
     iconDashboard: <JenkinsProvider className='providerIconSvg' width='48' height='48' />,
-    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+    settings: ({ activeProvider, activeConnection, isSaving, isSavingConnection, setSettings }) => (
       <JenkinsSettings
         provider={activeProvider}
         connection={activeConnection}
         isSaving={isSaving}
+        isSavingConnection={isSavingConnection}
         onSettingsChange={setSettings}
       />
     )
@@ -53,11 +55,12 @@ const integrationsData = [
     name: ProviderLabels.JIRA,
     icon: <JiraProvider className='providerIconSvg' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
     iconDashboard: <JiraProvider className='providerIconSvg' width='48' height='48' />,
-    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+    settings: ({ activeProvider, activeConnection, isSaving, isSavingConnection, setSettings }) => (
       <JiraSettings
         provider={activeProvider}
         connection={activeConnection}
         isSaving={isSaving}
+        isSavingConnection={isSavingConnection}
         onSettingsChange={setSettings}
       />
     )
@@ -69,11 +72,12 @@ const integrationsData = [
     name: ProviderLabels.GITHUB,
     icon: <GitHubProvider className='providerIconSvg' width='30' height='30' style={{ float: 'left', marginTop: '5px' }} />,
     iconDashboard: <GitHubProvider className='providerIconSvg' width='48' height='48' />,
-    settings: ({ activeProvider, activeConnection, isSaving, setSettings }) => (
+    settings: ({ activeProvider, activeConnection, isSaving, isSavingConnection, setSettings }) => (
       <GithubSettings
         provider={activeProvider}
         connection={activeConnection}
         isSaving={isSaving}
+        isSavingConnection={isSavingConnection}
         onSettingsChange={setSettings}
       />
     )

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -94,21 +94,22 @@ function useConnectionManager ({
     runTest()
   }
 
-  const saveConnection = () => {
+  const saveConnection = (configurationSettings = {}) => {
     setIsSaving(true)
-    let connectionPayload
+    let connectionPayload = { ...configurationSettings }
     switch (activeProvider.id) {
       case Providers.JIRA:
-        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, Proxy: proxy }
+        connectionPayload = { name: name, Endpoint: endpointUrl, BasicAuthEncoded: token, Proxy: proxy, ...connectionPayload }
         break
       case Providers.GITHUB:
-        connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token, GITHUB_PROXY: proxy }
+        connectionPayload = { name: name, GITHUB_ENDPOINT: endpointUrl, GITHUB_AUTH: token, GITHUB_PROXY: proxy, ...connectionPayload }
         break
       case Providers.JENKINS:
-        connectionPayload = { name: name, JENKINS_ENDPOINT: endpointUrl, JENKINS_USERNAME: username, JENKINS_PASSWORD: password }
+        // eslint-disable-next-line max-len
+        connectionPayload = { name: name, JENKINS_ENDPOINT: endpointUrl, JENKINS_USERNAME: username, JENKINS_PASSWORD: password, ...connectionPayload }
         break
       case Providers.GITLAB:
-        connectionPayload = { name: name, GITLAB_ENDPOINT: endpointUrl, GITLAB_AUTH: token, GITLAB_PROXY: proxy }
+        connectionPayload = { name: name, GITLAB_ENDPOINT: endpointUrl, GITLAB_AUTH: token, GITLAB_PROXY: proxy, ...connectionPayload }
         break
     }
 

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -132,7 +132,8 @@ function useSettingsManager ({
     setIsTesting,
     setErrors,
     setShowError,
-    buildConnectionPayload
+    buildConnectionPayload,
+    settings
   }
 }
 

--- a/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
+++ b/config-ui/src/pages/configure/connections/ConfigureConnection.jsx
@@ -121,6 +121,7 @@ export default function ConfigureConnection () {
         activeProvider,
         activeConnection,
         isSaving,
+        isSavingConnection,
         setSettings
       })
     } else {
@@ -128,7 +129,7 @@ export default function ConfigureConnection () {
       console.log('>> WARNING: NO PROVIDER SETTINGS RENDERED, PROVIDER = ', activeProvider)
     }
     return settingsComponent
-  }, [activeConnection, isSaving])
+  }, [activeConnection, isSaving, isSavingConnection])
 
   useEffect(() => {
     console.log('>>>> DETECTED PROVIDER ID = ', providerId)
@@ -252,7 +253,8 @@ export default function ConfigureConnection () {
                             token={token}
                             username={username}
                             password={password}
-                            onSave={saveConnection}
+                            // JIRA is a multi-source plugin, for now we intentially won't include additional settings during save...
+                            onSave={() => saveConnection(activeProvider.id !== Providers.JIRA ? settings : {})}
                             onTest={testConnection}
                             onCancel={cancel}
                             onValidate={validate}

--- a/config-ui/src/pages/configure/settings/github.jsx
+++ b/config-ui/src/pages/configure/settings/github.jsx
@@ -6,6 +6,8 @@ import {
 import {
   FormGroup,
   InputGroup,
+  Button,
+  Intent,
   Label,
   Tag
 } from '@blueprintjs/core'
@@ -14,7 +16,7 @@ import '@/styles/integration.scss'
 import '@/styles/connections.scss'
 
 export default function GithubSettings (props) {
-  const { connection, provider, isSaving, onSettingsChange } = props
+  const { connection, provider, isSaving, isSavingConnection, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
   const [prType, setPrType] = useState('')
@@ -84,7 +86,7 @@ export default function GithubSettings (props) {
       <div style={{ maxWidth: '60%' }}>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-pr-type'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -97,7 +99,8 @@ export default function GithubSettings (props) {
               placeholder='type/(.*)$'
               defaultValue={prType}
               onChange={(e) => setPrType(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setPrType('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -105,7 +108,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-pr-component'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -118,7 +121,8 @@ export default function GithubSettings (props) {
               placeholder='component/(.*)$'
               defaultValue={prComponent}
               onChange={(e) => setPrComponent(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setPrComponent('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -131,7 +135,7 @@ export default function GithubSettings (props) {
       <div style={{ maxWidth: '60%' }}>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-severity'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -141,10 +145,11 @@ export default function GithubSettings (props) {
             </Label>
             <InputGroup
               id='github-issue-severity'
-              placeholder='type/(.*)$'
+              placeholder='severity/(.*)$'
               defaultValue={issueSeverity}
               onChange={(e) => setIssueSeverity(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssueSeverity('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -152,7 +157,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-component'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -165,7 +170,8 @@ export default function GithubSettings (props) {
               placeholder='component/(.*)$'
               defaultValue={issueComponent}
               onChange={(e) => setIssueComponent(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssueComponent('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -173,7 +179,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-priority'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -186,7 +192,8 @@ export default function GithubSettings (props) {
               placeholder='(highest|high|medium|low)$'
               defaultValue={issuePriority}
               onChange={(e) => setIssuePriority(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssuePriority('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -194,7 +201,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-requirement'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -207,7 +214,8 @@ export default function GithubSettings (props) {
               placeholder='(feat|feature|proposal|requirement)$'
               defaultValue={issueTypeRequirement}
               onChange={(e) => setIssueTypeRequirement(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssueTypeRequirement('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -215,7 +223,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-bug'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -228,7 +236,8 @@ export default function GithubSettings (props) {
               placeholder='(bug|broken)$'
               defaultValue={issueTypeBug}
               onChange={(e) => setIssueTypeBug(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssueTypeBug('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -236,7 +245,7 @@ export default function GithubSettings (props) {
         </div>
         <div className='formContainer'>
           <FormGroup
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             labelFor='github-issue-bug'
             className='formGroup'
             contentClassName='formGroupContent'
@@ -249,7 +258,8 @@ export default function GithubSettings (props) {
               placeholder='(incident|p0|p1|p2)$'
               defaultValue={issueTypeIncident}
               onChange={(e) => setIssueTypeIncident(e.target.value)}
-              disabled={isSaving}
+              onKeyUp={(e) => e.target.value.length === 0 ? setIssueTypeIncident('') : null}
+              disabled={isSaving || isSavingConnection}
               className='input'
               maxLength={255}
             />
@@ -260,7 +270,7 @@ export default function GithubSettings (props) {
       <p className=''>Optional</p>
       <div className='formContainer'>
         <FormGroup
-          disabled={isSaving}
+          disabled={isSaving || isSavingConnection}
           labelFor='github-proxy'
           helperText='PROXY'
           className='formGroup'
@@ -274,7 +284,7 @@ export default function GithubSettings (props) {
             placeholder='http://your-proxy-server.com:1080'
             defaultValue={githubProxy}
             onChange={(e) => setGithubProxy(e.target.value)}
-            disabled={isSaving}
+            disabled={isSaving || isSavingConnection}
             className='input'
           />
         </FormGroup>

--- a/config-ui/src/pages/configure/settings/gitlab.jsx
+++ b/config-ui/src/pages/configure/settings/gitlab.jsx
@@ -30,7 +30,7 @@ import '@/styles/connections.scss'
 // import '@blueprintjs/popover2/lib/css/blueprint-popover2.css'
 
 export default function GitlabSettings (props) {
-  const { connection, provider, isSaving, onSettingsChange } = props
+  const { connection, provider, isSaving, isSavingConnection, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
   const [jiraBoardGitlabProjects, setJiraBoardGitlabProjects] = useState('')

--- a/config-ui/src/pages/configure/settings/jenkins.jsx
+++ b/config-ui/src/pages/configure/settings/jenkins.jsx
@@ -8,7 +8,7 @@ import '@/styles/integration.scss'
 import '@/styles/connections.scss'
 
 export default function JenkinsSettings (props) {
-  const { connection, provider, isSaving, onSettingsChange } = props
+  const { connection, provider, isSaving, isSavingConnection, onSettingsChange } = props
   const history = useHistory()
   const { providerId, connectionId } = useParams()
 

--- a/config-ui/src/pages/configure/settings/jira.jsx
+++ b/config-ui/src/pages/configure/settings/jira.jsx
@@ -26,7 +26,7 @@ const MAPPING_TYPES = {
 }
 
 export default function JiraSettings (props) {
-  const { connection, provider, isSaving, onSettingsChange } = props
+  const { connection, provider, isSaving, isSavingConnection, onSettingsChange } = props
   // const { providerId, connectionId } = useParams()
   // const history = useHistory()
 


### PR DESCRIPTION
### Config-UI / Data Integrations / **GitHub**

- [x] Bundle Configuration Settings on **Connection Save** (Except **JIRA**)
- [x] Resolve state changes with GitHub Settings Fields
  - Track _Empty_ field Changes with `onKeyUp` handlers
  - Update `disabled` attribute for `isSavingConnection` event
- [x] `Bugfix` #1384
- [x] Test **GitHub Settings** Integration 
   
### Description
**[V0.9.0 RELEASE TARGET]** `release-v0.9`

This **Hotfix PR** for the `v0.9.x` **DevLake** release branch resolves problems related to the **GitHub** Data Provider with regard to saving Connection and Configuration Settings. When saving the connection additional configuration settings will be bundled with the payload so the BE API has all relevant fields for processing. The issue of **emptying** or _blanking_ a field has also been fixed, depending on the nature of how _backspace_ or _delete_ is used the `onChange` event will not fire as intended, causing an unwanted side-effect of the old value being preserved during save even though the user-controlled value was erased.

ℹ️ **NOTE**: This hotfix will also be cherry-picked and applied to the `main` branch under a separate Pull Request to maintain consistency.

### Does this close any open issues?
#1380
