### PR TITLE
`fix` v0.9.1 cannot save jira connection

### DIFF
--- a/config-ui/src/pages/configure/connections/AddConnection.jsx
+++ b/config-ui/src/pages/configure/connections/AddConnection.jsx
@@ -155,7 +155,7 @@ export default function AddConnection () {
                   token={token}
                   username={username}
                   password={password}
-                  onSave={saveConnection}
+                  onSave={() => saveConnection({})}
                   onTest={testConnection}
                   onCancel={cancel}
                   onValidate={validate}


### PR DESCRIPTION
### Config-UI / Data Integrations / JIRA / **Add Connection**

- [x] Fix `onSave` arguments for **new JIRA Connection**
- [x] Test **JIRA** Integration

### Description
**[V0.9.0 RELEASE TARGET]** `release-v0.9`

This Hotfix PR provides a supporting fix to the `v0.9.1` release branch that resolves a `JSON` error warning when a user attempts to **Save** a new **JIRA** Connection source. 

### Does this close any open issues?
#1396
