### PR TITLE
fix: dynamic rate limit not actually working

### DIFF
--- a/plugins/github/tasks/github_api_client.go
+++ b/plugins/github/tasks/github_api_client.go
@@ -51,7 +51,7 @@ func CreateApiClient(taskCtx core.TaskContext) (*helper.ApiAsyncClient, error) {
 	// create rate limit calculator
 	rateLimiter := &helper.ApiRateLimitCalculator{
 		UserRateLimitPerHour: userRateLimit,
-		DynamicRateLimitPerHour: func(res *http.Response) (int, time.Duration, error) {
+		DynamicRateLimit: func(res *http.Response) (int, time.Duration, error) {
 			/* calculate by number of remaining requests
 			remaining, err := strconv.Atoi(res.Header.Get("X-RateLimit-Remaining"))
 			if err != nil {

--- a/plugins/gitlab/tasks/gitlab_api_client.go
+++ b/plugins/gitlab/tasks/gitlab_api_client.go
@@ -45,7 +45,7 @@ func NewGitlabApiClient(taskCtx core.TaskContext) (*helper.ApiAsyncClient, error
 	// create rate limit calculator
 	rateLimiter := &helper.ApiRateLimitCalculator{
 		UserRateLimitPerHour: userRateLimit,
-		DynamicRateLimitPerHour: func(res *http.Response) (int, time.Duration, error) {
+		DynamicRateLimit: func(res *http.Response) (int, time.Duration, error) {
 			rateLimitHeader := res.Header.Get("RateLimit-Limit")
 			if rateLimitHeader == "" {
 				// unlimited

--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -46,6 +46,7 @@ func CreateAsyncApiClient(
 		rateLimiter = &ApiRateLimitCalculator{}
 	}
 	rateLimiter.GlobalRateLimitPerHour = globalRateLimitPerHour
+	rateLimiter.MaxRetry = retry
 
 	// ok, calculate api rate limit based on response (normally from headers)
 	requests, duration, err := rateLimiter.Calculate(apiClient)
@@ -61,6 +62,13 @@ func CreateAsyncApiClient(
 	d := duration / RESPONSE_TIME
 	numOfWorkers := requests / int(d)
 
+	taskCtx.GetLogger().Info(
+		"scheduler for api %s worker: %d, request: %d, duration: %v",
+		apiClient.GetEndpoint(),
+		numOfWorkers,
+		requests,
+		duration,
+	)
 	scheduler, err := NewWorkerScheduler(numOfWorkers, requests, duration, taskCtx.GetContext())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scheduler: %w", err)

--- a/plugins/helper/api_ratelimit_calc.go
+++ b/plugins/helper/api_ratelimit_calc.go
@@ -7,12 +7,12 @@ import (
 
 // A helper to calculate api rate limit dynamically, assuming api returning remaining/resettime information
 type ApiRateLimitCalculator struct {
-	UserRateLimitPerHour    int
-	GlobalRateLimitPerHour  int
-	MaxRetry                int
-	Method                  string
-	ApiPath                 string
-	DynamicRateLimitPerHour func(res *http.Response) (int, time.Duration, error)
+	UserRateLimitPerHour   int
+	GlobalRateLimitPerHour int
+	MaxRetry               int
+	Method                 string
+	ApiPath                string
+	DynamicRateLimit       func(res *http.Response) (int, time.Duration, error)
 }
 
 func (c *ApiRateLimitCalculator) Calculate(apiClient *ApiClient) (int, time.Duration, error) {
@@ -21,7 +21,7 @@ func (c *ApiRateLimitCalculator) Calculate(apiClient *ApiClient) (int, time.Dura
 		return c.UserRateLimitPerHour, 1 * time.Hour, nil
 	}
 	// plugin dynamical rate limit is medium priority
-	if c.DynamicRateLimitPerHour != nil {
+	if c.DynamicRateLimit != nil {
 		method := c.Method
 		if method == "" {
 			method = http.MethodOptions
@@ -34,7 +34,7 @@ func (c *ApiRateLimitCalculator) Calculate(apiClient *ApiClient) (int, time.Dura
 			if err != nil {
 				continue
 			}
-			return c.DynamicRateLimitPerHour(res)
+			return c.DynamicRateLimit(res)
 		}
 	}
 


### PR DESCRIPTION
# Summary

Due to `MaxRetry` was not set, the `DynamicRateLimit` was never actaully worked, so it always fallbacked to `GlobalRateLimitPerHour` setting

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
