### PR TITLE
`fix` `v0.9.2` : lookup online status for connections table

### DIFF
--- a/config-ui/src/pages/configure/integration/manage.jsx
+++ b/config-ui/src/pages/configure/integration/manage.jsx
@@ -8,6 +8,8 @@ import {
   Button, Card, Elevation, Colors,
   Tooltip,
   Position,
+  Spinner,
+  Intent,
   Icon,
 } from '@blueprintjs/core'
 import Nav from '@/components/Nav'
@@ -39,13 +41,14 @@ export default function ManageIntegration () {
     sourceLimits,
     Providers,
     allConnections: connections,
+    testedConnections,
     isFetching: isLoading,
     isDeleting: isDeletingConnection,
     deleteConnection,
     fetchAllConnections,
     errors,
     deleteComplete,
-    // testConnection
+    testAllConnections,
   } = useConnectionManager({
     activeProvider
   })
@@ -89,15 +92,38 @@ export default function ManageIntegration () {
   }
 
   const refreshConnections = () => {
-    fetchAllConnections(true)
+    fetchAllConnections(false)
   }
 
   const maxConnectionsExceeded = (limit, totalConnections) => {
     return totalConnections > 0 && totalConnections >= limit
   }
 
+  const getTestedConnection = (connection) => {
+    return testedConnections.find(tC => tC.ID === connection.ID)
+  }
+
+  const getConnectionStatus = (connection) => {
+    let s = null
+    const connectionAfterTest = testedConnections.find(tC => tC.ID === connection.ID)
+    switch (parseInt(connectionAfterTest?.status, 10)) {
+      case 1:
+        s = <strong style={{ color: Colors.GREEN3 }}>Online</strong>
+        break
+      case 2:
+        s = <strong style={{ color: Colors.RED3 }}>Error</strong>
+        break
+      case 0:
+      default:
+        // eslint-disable-next-line max-len
+        s = <strong style={{ color: Colors.GRAY4 }}><span style={{ float: 'right' }}><Spinner size={11} intent={Intent.NONE} /></span> Offline</strong>
+        break
+    }
+    return s
+  }
+
   useEffect(() => {
-    fetchAllConnections(true)
+    fetchAllConnections(false)
   }, [activeProvider, fetchAllConnections])
 
   useEffect(() => {
@@ -122,6 +148,11 @@ export default function ManageIntegration () {
 
     return () => clearTimeout(flushTimeout)
   }, [deleteComplete, fetchAllConnections])
+
+  useEffect(() => {
+    console.log('>> TESTING CONNECTION SOURCES...')
+    testAllConnections(connections)
+  }, [connections])
 
   return (
     <>
@@ -225,7 +256,8 @@ export default function ManageIntegration () {
                         {connections.map((connection, idx) => (
                           <tr
                             key={`connection-row-${idx}`}
-                            className={connection.status === 0 ? 'connection-offline' : ''}
+                            // eslint-disable-next-line max-len
+                            className={getTestedConnection(connection) && getTestedConnection(connection).status !== 1 ? 'connection-offline' : ''}
                           >
                             {activeProvider.id === Providers.JIRA && (
                               <td
@@ -264,20 +296,7 @@ export default function ManageIntegration () {
                               {!connection.endpoint && !connection.Endpoint && (<span style={{ color: Colors.GRAY4 }}>( Empty )</span>)}
                             </td>
                             <td className='cell-status'>
-                              {connection.status === 0 && (
-                                <strong style={{ color: Colors.GRAY4 }}>Offline</strong>
-                              )}
-                              {connection.status === 1 && (
-                                <strong style={{ color: Colors.GREEN3 }}>Online</strong>
-                              )}
-                              {connection.status === 2 && (
-                                <strong style={{ color: Colors.RED3 }}>Error</strong>
-                              )}
-                              {connection.status === 3 && (
-                                <strong style={{ color: Colors.BLUE3 }}>
-                                  <Icon icon='array' size={14} color={Colors.GRAY2} /> Collecting...
-                                </strong>
-                              )}
+                              {getConnectionStatus(connection)}
                             </td>
                             <td className='cell-actions'>
                               <a


### PR DESCRIPTION
### `v0.9.2` Config-UI / Data Integrations / Connections "ONLINE" Status 

- [x] Update **ConnectionManager** Hook
     - Extend `testConnection` with manual Payload Support
     - Add `testAllConnections` function to maintain tested connections list 
- [x] Update **Data Connections Table** `Online` Column
- [x] Test Data Integrations 

### Description
**[V0.9.0 RELEASE TARGET]** `release-v0.9`

This PR fixes the "**Online**" status column indicator for a Data Connection record on all Data Provider Tables. Previously the indicator would assume online based on a 200 Response from the API sources endpoint, which is not very meaningful. Now a connection **Test** is performed with the saved parameters for a data source after all the connections are fetched.

The default state would be "**Offline**" (`status=0`) for a connection, once a test is completed it will be updated to "**Online**" (`status=1`) or sometimes "**Failed**" (`status=2`) based on the TestResponse results.

ℹ️ **NOTE**: This hotfix will also be cherry-picked and applied to the `main` branch under a separate Pull Request to maintain consistency.

### Does this close any open issues?
#1409

### Screenshots
<img width="1264" alt="Screen Shot 2022-03-29 at 1 21 05 PM" src="https://user-images.githubusercontent.com/1742233/160713958-fb59d78a-d265-4ac0-b377-886be81e3b6a.png">
<img width="1264" alt="Screen Shot 2022-03-29 at 6 04 06 PM" src="https://user-images.githubusercontent.com/1742233/160714762-1996576f-7c6c-46eb-8053-bfcbff0ffdd4.png">

 