### PR TITLE
`fix` `v0.9.2` triggers page typo with "legacy feature notice"

### DIFF
--- a/config-ui/src/pages/triggers/index.jsx
+++ b/config-ui/src/pages/triggers/index.jsx
@@ -193,7 +193,7 @@ export default function Triggers () {
                   <div className='bp3-callout' style={{ maxWidth: '600px', margin: '5px 0', fontSize: '11px' }}>
                     <h4 className='bp3-heading' style={{ fontSize: '15px' }}>
                       <Icon icon='warning-sign' color='#ffcc00' size={16} style={{ marginRight: '5px', marginBottom: '3px' }} />
-                      Leacy Feature Notice
+                      Legacy Feature Notice
                     </h4>
                     This is a legacy service and will soon be deprecated in favor of <strong>Pipelines</strong> Feature.
                     See <a href='/pipelines/create' style={{ textDecoration: 'underline' }}>Create a Pipeline</a> for more details.


### PR DESCRIPTION
### Config-UI / Triggers

- [x] Fix typo with "**Legacy**" word in H4 Title

### Description
This PR corrects a small typo with the "Legacy Feature Notice" text on the Triggers page.

### Does this close any open issues?
#1408

### Screenshots
<img width="622" alt="Screen Shot 2022-03-30 at 9 30 13 AM" src="https://user-images.githubusercontent.com/1742233/160846224-91fc18a3-62a9-4357-a8d0-b310ed242cc5.png">

