### PR TITLE
`fix` `v0.9.2` config ui - update menu labels and titles for pipelines

### DIFF
--- a/config-ui/src/components/Sidebar/MenuConfiguration.jsx
+++ b/config-ui/src/components/Sidebar/MenuConfiguration.jsx
@@ -55,16 +55,16 @@ const MenuConfiguration = (activeRoute) => {
     //   children: [
     //   ]
     // },
-     {
-       id: 2,
-       label: 'Triggers',
-       icon: 'asterisk',
-       classNames: [],
-       route: '/triggers',
-       active: activeRoute.url === '/triggers',
-       children: [
-       ]
-     },
+    {
+      id: 2,
+      label: 'Triggers',
+      icon: 'asterisk',
+      classNames: [],
+      route: '/triggers',
+      active: activeRoute.url === '/triggers',
+      children: [
+      ]
+    },
     {
       id: 3,
       label: 'Pipelines',
@@ -75,7 +75,7 @@ const MenuConfiguration = (activeRoute) => {
       children: [
         {
           id: 0,
-          label: 'Create New Pipeline',
+          label: 'Create Pipeline Run',
           route: '/pipelines/create',
           active: activeRoute.url.endsWith('/pipelines/create'),
           icon: 'git-pull',

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -444,7 +444,7 @@ const CreatePipeline = (props) => {
               items={[
                 { href: '/', icon: false, text: 'Dashboard' },
                 { href: '/pipelines', icon: false, text: 'Pipelines' },
-                { href: '/pipelines/create', icon: false, text: 'RUN Pipeline', current: true },
+                { href: '/pipelines/create', icon: false, text: 'Create Pipeline Run', current: true },
               ]}
             />
 
@@ -470,7 +470,7 @@ const CreatePipeline = (props) => {
                 </div>
                 <div>
                   <h1 style={{ margin: 0 }}>
-                    Run New Pipeline
+                    Create Pipeline Run
                     <Popover
                       key='popover-help-key-create-pipeline'
                       className='trigger-delete-connection'

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -201,7 +201,7 @@ const Pipelines = (props) => {
               items={[
                 { href: '/', icon: false, text: 'Dashboard' },
                 { href: '/pipelines', icon: false, text: 'Pipelines' },
-                { href: '/pipelines', icon: false, text: 'Manage Pipeline Runs', current: true },
+                { href: '/pipelines', icon: false, text: 'All Pipeline Runs', current: true },
               ]}
             />
             <div className='headlineContainer'>
@@ -216,7 +216,7 @@ const Pipelines = (props) => {
                 </div>
                 <div>
                   <h1 style={{ margin: 0 }}>
-                    Pipeline Runs
+                    All Pipeline Runs
                     <Popover
                       className='trigger-manage-pipelines-help'
                       popoverClassName='popover-help-manage-pipelines'
@@ -242,7 +242,7 @@ const Pipelines = (props) => {
                   <p className=''>The most recent runs are shown first, filter by key status types.</p>
                 </div>
                 <div style={{ marginLeft: 'auto' }}>
-                  <Button icon='add' intent={Intent.PRIMARY} text='Create Run' onClick={() => history.push('/pipelines/create')} />
+                  <Button icon='add' intent={Intent.PRIMARY} text='Create Pipeline Run' onClick={() => history.push('/pipelines/create')} />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Config-UI / Pipelines UX Copy

- [x] Unify _Menu_, _Page Title_ and active _BreadCrumb_ texts for **Pipelines**

### Description
**[V0.9.0 RELEASE TARGET]** `release-v0.9`

This PR applies UX copy updates to the **Pipelines** service(s).

ℹ️ **NOTE**: This hotfix will also be cherry-picked and applied to the `main` branch under a separate Pull Request to maintain consistency.

### Does this close any open issues?
#1387 

### Screenshots
<img width="1247" alt="Screen Shot 2022-03-31 at 8 08 57 PM" src="https://user-images.githubusercontent.com/1742233/161171055-b64b3feb-1145-427c-b066-136355c2ece9.png">
<img width="1199" alt="Screen Shot 2022-03-31 at 8 20 25 PM" src="https://user-images.githubusercontent.com/1742233/161170859-cf9d4f91-08ce-42cd-bda5-79b62d1f1bd0.png">


