### PR TITLE
fix(github): add repo not found remind

### DIFF
--- a/plugins/github/tasks/api_repositories_extractor.go
+++ b/plugins/github/tasks/api_repositories_extractor.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/github/models"
@@ -52,6 +53,9 @@ func ExtractApiRepositories(taskCtx core.SubTaskContext) error {
 			err := json.Unmarshal(row.Data, body)
 			if err != nil {
 				return nil, err
+			}
+			if body.GithubId == 0 {
+				return nil, fmt.Errorf("repo %s/%s not found", data.Options.Owner, data.Options.Repo)
 			}
 			results := make([]interface{}, 0, 1)
 			githubRepository := &models.GithubRepo{


### PR DESCRIPTION
# Summary

Sometimes we input a wrong repo, but get panic wrong date format, I think we'd better remind users that the repo is wrong


### Screenshots
<img width="351" alt="image" src="https://user-images.githubusercontent.com/39366025/162866103-d4e2a03e-fa4b-41c3-8d9e-edfc610e6fde.png">

### Other Information
Any other information that is important to this PR.
