### PR TITLE
refactor: rename some fields

### DIFF
--- a/models/domainlayer/code/pull_request.go
+++ b/models/domainlayer/code/pull_request.go
@@ -11,6 +11,7 @@ type PullRequest struct {
 	BaseRepoId     string `gorm:"index"`
 	HeadRepoId     string `gorm:"index"`
 	Status         string `gorm:"type:varchar(100);comment:open/closed or other"`
+	Number         int
 	Title          string
 	Description    string
 	Url            string `gorm:"type:char(255)"`

--- a/models/domainlayer/code/refs_commits_diff.go
+++ b/models/domainlayer/code/refs_commits_diff.go
@@ -1,8 +1,8 @@
 package code
 
 type RefsCommitsDiff struct {
-	NewRefName      string `gorm:"primaryKey;type:varchar(255)"`
-	OldRefName      string `gorm:"primaryKey;type:varchar(255)"`
+	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
 	CommitSha       string `gorm:"primaryKey;type:char(40)"`
 	NewRefCommitSha string `gorm:"type:char(40)"`
 	OldRefCommitSha string `gorm:"type:char(40)"`

--- a/models/domainlayer/crossdomain/refs_issues_diff.go
+++ b/models/domainlayer/crossdomain/refs_issues_diff.go
@@ -3,8 +3,8 @@ package crossdomain
 import "github.com/merico-dev/lake/models/common"
 
 type RefsIssuesDiffs struct {
-	NewRefName      string `gorm:"type:varchar(255)"`
-	OldRefName      string `gorm:"type:varchar(255)"`
+	NewRefId        string `gorm:"type:varchar(255)"`
+	OldRefId        string `gorm:"type:varchar(255)"`
 	NewRefCommitSha string `gorm:"type:char(40)"`
 	OldRefCommitSha string `gorm:"type:char(40)"`
 	IssueNumber     string `gorm:"type:varchar(255)"`

--- a/models/domainlayer/ticket/issue.go
+++ b/models/domainlayer/ticket/issue.go
@@ -9,7 +9,7 @@ import (
 type Issue struct {
 	domainlayer.DomainEntity
 	Url                     string `gorm:"type:char(255)"`
-	Key                     string `gorm:"type:char(255)"`
+	Number                  string `gorm:"type:char(255)"`
 	Title                   string
 	Description             string
 	EpicKey                 string `gorm:"type:char(255)"`

--- a/models/migrationscripts/archived/issue.go
+++ b/models/migrationscripts/archived/issue.go
@@ -10,7 +10,7 @@ import (
 type Issue struct {
 	domainlayer.DomainEntity
 	Url                     string `gorm:"type:char(255)"`
-	Key                     string `gorm:"type:char(255)"`
+	Number                  string `gorm:"type:char(255)"`
 	Title                   string
 	Description             string
 	EpicKey                 string `gorm:"type:char(255)"`

--- a/models/migrationscripts/archived/pull_request.go
+++ b/models/migrationscripts/archived/pull_request.go
@@ -12,6 +12,7 @@ type PullRequest struct {
 	BaseRepoId     string `gorm:"index"`
 	HeadRepoId     string `gorm:"index"`
 	Status         string `gorm:"type:varchar(100);comment:open/closed or other"`
+	Number         int
 	Title          string
 	Description    string
 	Url            string `gorm:"type:char(255)"`

--- a/models/migrationscripts/archived/ref.go
+++ b/models/migrationscripts/archived/ref.go
@@ -18,8 +18,8 @@ type Ref struct {
 }
 
 type RefsCommitsDiff struct {
-	NewRefName      string `gorm:"primaryKey;type:varchar(255)"`
-	OldRefName      string `gorm:"primaryKey;type:varchar(255)"`
+	NewRefId        string `gorm:"primaryKey;type:varchar(255)"`
+	OldRefId        string `gorm:"primaryKey;type:varchar(255)"`
 	CommitSha       string `gorm:"primaryKey;type:char(40)"`
 	NewRefCommitSha string `gorm:"type:char(40)"`
 	OldRefCommitSha string `gorm:"type:char(40)"`
@@ -27,8 +27,8 @@ type RefsCommitsDiff struct {
 }
 
 type RefsIssuesDiffs struct {
-	NewRefName      string `gorm:"type:varchar(255)"`
-	OldRefName      string `gorm:"type:varchar(255)"`
+	NewRefId        string `gorm:"type:varchar(255)"`
+	OldRefId        string `gorm:"type:varchar(255)"`
 	NewRefCommitSha string `gorm:"type:char(40)"`
 	OldRefCommitSha string `gorm:"type:char(40)"`
 	IssueNumber     string `gorm:"type:varchar(255)"`

--- a/plugins/github/tasks/issue_converter.go
+++ b/plugins/github/tasks/issue_converter.go
@@ -52,7 +52,7 @@ func ConvertIssues(taskCtx core.SubTaskContext) error {
 			issue := inputRow.(*githubModels.GithubIssue)
 			domainIssue := &ticket.Issue{
 				DomainEntity:    domainlayer.DomainEntity{Id: issueIdGen.Generate(issue.GithubId)},
-				Key:             strconv.Itoa(issue.Number),
+				Number:          strconv.Itoa(issue.Number),
 				Title:           issue.Title,
 				Description:     issue.Body,
 				Priority:        issue.Priority,

--- a/plugins/jira/tasks/issue_converter.go
+++ b/plugins/jira/tasks/issue_converter.go
@@ -54,7 +54,7 @@ func ConvertIssues(taskCtx core.SubTaskContext) error {
 					Id: issueIdGen.Generate(jiraIssue.SourceId, jiraIssue.IssueId),
 				},
 				Url:                     jiraIssue.Self,
-				Key:                     jiraIssue.Key,
+				Number:                  jiraIssue.Key,
 				Title:                   jiraIssue.Summary,
 				EpicKey:                 jiraIssue.EpicKey,
 				Type:                    jiraIssue.StdType,

--- a/plugins/refdiff/tasks/refs_commits_diffs_calculator.go
+++ b/plugins/refdiff/tasks/refs_commits_diffs_calculator.go
@@ -89,14 +89,14 @@ func CalculateCommitsDiff(taskCtx core.SubTaskContext) error {
 		// ref might advance, keep commit sha for debugging
 		commitsDiff.NewRefCommitSha = pair[0]
 		commitsDiff.OldRefCommitSha = pair[1]
-		commitsDiff.NewRefName = fmt.Sprintf("%s:%s", repoId, pair[2])
-		commitsDiff.OldRefName = fmt.Sprintf("%s:%s", repoId, pair[3])
+		commitsDiff.NewRefId = fmt.Sprintf("%s:%s", repoId, pair[2])
+		commitsDiff.OldRefId = fmt.Sprintf("%s:%s", repoId, pair[3])
 
 		// delete records before creation
 		err = db.Exec(
 			"DELETE FROM refs_commits_diffs WHERE new_ref_name = ? AND old_ref_name = ?",
-			commitsDiff.NewRefName,
-			commitsDiff.OldRefName,
+			commitsDiff.NewRefId,
+			commitsDiff.OldRefId,
 		).Error
 		if err != nil {
 			return err
@@ -108,8 +108,8 @@ func CalculateCommitsDiff(taskCtx core.SubTaskContext) error {
 				"refdiff",
 				fmt.Sprintf(
 					"skipping ref pair due to they are the same %s %s => %s",
-					commitsDiff.NewRefName,
-					commitsDiff.OldRefName,
+					commitsDiff.NewRefId,
+					commitsDiff.OldRefId,
 					commitsDiff.NewRefCommitSha,
 				),
 			)


### PR DESCRIPTION
# Summary
`issues.key` -> `issues.number`
new field `pull_requests.number`

rename `new_ref_name` and `old_ref_name` to `new_ref_id` and `old_ref_id`


- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
#1525 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
