### PR TITLE
fix(gitlab): fix pipeline

### DIFF
--- a/plugins/gitlab/tasks/gitlab_api_pipeline_collector.go
+++ b/plugins/gitlab/tasks/gitlab_api_pipeline_collector.go
@@ -32,7 +32,6 @@ func CollectApiPipelines(taskCtx core.SubTaskContext) error {
 		Incremental:        false,
 		UrlTemplate:        "projects/{{ .Params.ProjectId }}/pipelines",
 		Query:              GetQueryOrder,
-		GetTotalPages:      GetTotalPagesFromResponse,
 		ResponseParser:     GetRawMessageFromResponse,
 	})
 


### PR DESCRIPTION
# Summary
1. delete GetTotalPages in pipeline collector.
As there is no "X-Total-Pages" in response.header, but we set GetTotalPages for collector, so the request will be sent only once
### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
close #1575

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
<img width="737" alt="image" src="https://user-images.githubusercontent.com/39366025/163502295-41b54441-3d65-448b-b164-5cf96f40e8e8.png">


### Other Information
Any other information that is important to this PR.
