### PR TITLE
Fix gitlab invalid json text

### DIFF
--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -350,6 +350,7 @@ func (collector *ApiCollector) handleResponseWithPages(reqData *RequestData) Api
 
 func (collector *ApiCollector) saveRawData(res *http.Response, input interface{}) (int, error) {
 	items, err := collector.args.ResponseParser(res)
+	logger := collector.args.Ctx.GetLogger()
 	if err != nil {
 		return 0, err
 	}
@@ -371,7 +372,11 @@ func (collector *ApiCollector) saveRawData(res *http.Response, input interface{}
 			Input:  inputJson,
 		}
 	}
-	return len(dd), db.Table(collector.table).Create(dd).Error
+	err = db.Table(collector.table).Create(dd).Error
+	if err != nil {
+		logger.Error("failed to save raw data: %s", err)
+	}
+	return len(dd), err
 }
 
 func GetRawMessageDirectFromResponse(res *http.Response) ([]json.RawMessage, error) {

--- a/plugins/helper/api_ratelimit_calc.go
+++ b/plugins/helper/api_ratelimit_calc.go
@@ -42,7 +42,7 @@ func (c *ApiRateLimitCalculator) Calculate(apiClient *ApiClient) (int, time.Dura
 			if duration == 0 {
 				return c.GlobalRateLimitPerHour, 1 * time.Hour, nil
 			}
-
+			requests = int(float32(requests) * 0.95)
 			return requests, duration, err
 		}
 	}


### PR DESCRIPTION
# Summary

When we set the ratelimit to max, it might exceed a little sometimes, so we only use 95% of max.


### Does this close any open issues?
Closes #1596 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
