### PR TITLE
`fix`: create pipeline: auto-close blueprint dialog on save

### DIFF
--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -610,6 +610,7 @@ const CreatePipeline = (props) => {
   useEffect(() => {
     if (saveBlueprintComplete && saveBlueprintComplete?.id) {
       setDraftBlueprint(saveBlueprintComplete)
+      setBlueprintDialogIsOpen(false)
     }
   }, [saveBlueprintComplete])
 


### PR DESCRIPTION
### Config-UI / Pipelines / Create Pipeline

- [x] fix: auto-close blueprint dialog on save

### Description
This PR closes the Blueprint Dialog automatically after saving a blueprint.

### Does this close any open issues?
#1621

 