### PR TITLE
`fix`: open blueprint dialog on automation toggle

### DIFF
--- a/config-ui/src/hooks/useBlueprintManager.jsx
+++ b/config-ui/src/hooks/useBlueprintManager.jsx
@@ -14,7 +14,7 @@ function useBlueprintManager (blueprintName = `BLUEPRINT WEEKLY ${Date.now()}`, 
   const [blueprint, setBlueprint] = useState(null)
   const [errors, setErrors] = useState([])
 
-  const [name, setName] = useState('DAILY BLUEPRINT')
+  const [name, setName] = useState('MY BLUEPRINT')
   const [cronConfig, setCronConfig] = useState('0 0 * * *')
   const [customCronConfig, setCustomCronConfig] = useState('0 0 * * *')
   const [tasks, setTasks] = useState([])

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -118,7 +118,7 @@ const Blueprints = (props) => {
   const createNewBlueprint = () => {
     setDraftBlueprint(null)
     setExpandDetails(false)
-    setBlueprintName('DAILY BLUEPRINT')
+    setBlueprintName('MY BLUEPRINT')
     setCronConfig('0 0 * * *')
     setCustomCronConfig('0 0 * * *')
     setEnableBlueprint(true)

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useCallback, useState } from 'react'
+import React, { Fragment, useEffect, useCallback, useState, useRef } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import {
   useHistory,
@@ -102,6 +102,8 @@ const CreatePipeline = (props) => {
   const [refDiffRepoId, setRefDiffRepoId] = useState('')
   const [refDiffPairs, setRefDiffPairs] = useState([])
   const [refDiffTasks, setRefDiffTasks] = useState(['calculateCommitsDiff', 'calculateIssuesDiff'])
+
+  const addBlueprintRef = useRef()
 
   // eslint-disable-next-line no-unused-vars
   const [autoRedirect, setAutoRedirect] = useState(true)
@@ -598,6 +600,16 @@ const CreatePipeline = (props) => {
   useEffect(() => {
     console.log('>>>> DETECTED PROVIDERS TASKS....', detectedProviderTasks)
   }, [detectedProviderTasks])
+
+  useEffect(() => {
+    if (enableAutomation && !blueprintDialogIsOpen) {
+      if (addBlueprintRef) {
+        addBlueprintRef.current?.buttonRef.click()
+      }
+    }
+    // NOTE: do NOT include $blueprintDialogIsOpen to deps -- excluded intentionally!
+    // This will allow auto-open to fire only once when automation swtich is toggled.
+  }, [enableAutomation])
 
   return (
     <>
@@ -1194,9 +1206,11 @@ const CreatePipeline = (props) => {
               </p>
               {!saveBlueprintComplete && (
                 <Button
+                  ref={addBlueprintRef}
                   disabled={!enableAutomation || (advancedMode ? !isValidAdvancedPipeline() : !isValidPipeline())}
                   intent={enableAutomation ? Intent.WARNING : Intent.NONE}
                   small text='Add Blueprint'
+                  icon='plus'
                   style={{ marginLeft: '25px' }}
                   onClick={() => setBlueprintDialogIsOpen(opened => !opened)}
                 />
@@ -1204,6 +1218,7 @@ const CreatePipeline = (props) => {
               {saveBlueprintComplete && (
                 <ButtonGroup>
                   <Button
+                    ref={addBlueprintRef}
                     disabled={!enableAutomation}
                     intent={enableAutomation ? Intent.WARNING : Intent.NONE}
                     small


### PR DESCRIPTION
### Config-UI / Pipelines / Create Pipeline / (Enable Automation)

- [x] Auto-open **Blueprint Dialog** when pipeline automation is toggled ON
- [x] Change default blueprint name value to "**MY BLUEPRRINT**" to reduce confusion around the input's expected value, with regard to which Frequency is being selected.

### Description
This PR updates the Create Pipeline Automation switch to open the blueprint dialog automatically when the switch is toggled to the ON position. Additionally, the default value for a new blueprint's name has been changed to "MY BLUEPRINT"

### Does this close any open issues?
#1626, #1616

### Screenshots
<img width="1299" alt="Screen Shot 2022-04-15 at 10 44 36 AM" src="https://user-images.githubusercontent.com/1742233/163584942-7042d92e-5433-40df-901a-9abaeeb96513.png">

