### PR TITLE
`fix`: config-ui: connections - update active connection state after modify

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -154,7 +154,9 @@ function useConnectionManager ({
         setShowError(false)
         setErrors([])
         ToastNotification.clear()
-        const s = await request.put(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${activeConnection.ID}`, configPayload)
+        // eslint-disable-next-line max-len
+        const s = await request.put(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${activeConnection.id || activeConnection.ID}`, configPayload)
+        const silentRefetch = true
         console.log('>> CONFIGURATION MODIFIED SUCCESSFULLY', configPayload, s)
         saveResponse = {
           ...saveResponse,
@@ -162,6 +164,7 @@ function useConnectionManager ({
           connection: { ...s.data },
           errors: s.isAxiosError ? [s.message] : []
         }
+        fetchConnection(silentRefetch)
       } catch (e) {
         saveResponse.errors.push(e.message)
         setErrors(saveResponse.errors)
@@ -200,10 +203,10 @@ function useConnectionManager ({
     // Run Collection Tasks...
   }
 
-  const fetchConnection = useCallback(() => {
+  const fetchConnection = useCallback((silent = false, notify = false) => {
     console.log('>> FETCHING CONNECTION....')
     try {
-      setIsFetching(true)
+      setIsFetching(!silent)
       setErrors([])
       ToastNotification.clear()
       console.log('>> FETCHING CONNECTION SOURCE')
@@ -276,7 +279,7 @@ function useConnectionManager ({
       setIsDeleting(true)
       setErrors([])
       console.log('>> TRYING TO DELETE CONNECTION...', connection)
-      const d = await request.delete(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${connection.ID}`)
+      const d = await request.delete(`${DEVLAKE_ENDPOINT}/plugins/${activeProvider.id}/sources/${connection.ID || connection.id}`)
       console.log('>> CONNECTION DELETED...', d)
       setIsDeleting(false)
       setDeleteComplete({
@@ -365,7 +368,7 @@ function useConnectionManager ({
           break
       }
       ToastNotification.clear()
-      ToastNotification.show({ message: `Fetched settings for ${activeConnection.name}.`, intent: 'success', icon: 'small-tick' })
+      // ToastNotification.show({ message: `Fetched settings for ${activeConnection.name}.`, intent: 'success', icon: 'small-tick' })
       console.log('>> FETCHED CONNECTION FOR MODIFY', activeConnection)
     }
   }, [activeConnection, activeProvider.id])

--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   useHistory
 } from 'react-router-dom'
@@ -19,7 +19,50 @@ function useSettingsManager ({
   const [errors, setErrors] = useState([])
   const [showError, setShowError] = useState(false)
 
-  const saveSettings = () => {
+  const buildConnectionPayload = useCallback((connection) => {
+    let connectionPayload = {}
+    switch (activeProvider.id) {
+      case Providers.JIRA:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          Endpoint: connection.endpoint,
+          BasicAuthEncoded: connection.basicAuthEncoded,
+          Proxy: connection.proxy || connection.Proxy
+        }
+        break
+      case Providers.GITHUB:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          GITHUB_ENDPOINT: connection.endpoint,
+          GITHUB_AUTH: connection.Auth,
+          GITHUB_PROXY: connection.proxy || connection.Proxy
+        }
+        break
+      case Providers.JENKINS:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          JENKINS_ENDPOINT: connection.endpoint,
+          JENKINS_USERNAME: connection.username,
+          JENKINS_PASSWORD: connection.password
+        }
+        break
+      case Providers.GITLAB:
+        connectionPayload = {
+          ...connectionPayload,
+          name: connection.name,
+          GITLAB_ENDPOINT: connection.endpoint,
+          GITLAB_AUTH: connection.Auth,
+          GITLAB_PROXY: connection.proxy || connection.Proxy
+        }
+        break
+    }
+    return connectionPayload
+  }, [activeProvider.id])
+
+  const saveSettings = useCallback(() => {
     setIsSaving(true)
     const settingsPayload = {
       ...buildConnectionPayload(activeConnection),
@@ -67,50 +110,7 @@ function useSettingsManager ({
         setIsSaving(false)
       }
     }, 2000)
-  }
-
-  const buildConnectionPayload = (connection) => {
-    let connectionPayload = {}
-    switch (activeProvider.id) {
-      case Providers.JIRA:
-        connectionPayload = {
-          ...connectionPayload,
-          name: connection.name,
-          Endpoint: connection.endpoint,
-          BasicAuthEncoded: connection.basicAuthEncoded,
-          Proxy: connection.proxy || connection.Proxy
-        }
-        break
-      case Providers.GITHUB:
-        connectionPayload = {
-          ...connectionPayload,
-          name: connection.name,
-          GITHUB_ENDPOINT: connection.endpoint,
-          GITHUB_AUTH: connection.Auth,
-          GITHUB_PROXY: connection.proxy || connection.Proxy
-        }
-        break
-      case Providers.JENKINS:
-        connectionPayload = {
-          ...connectionPayload,
-          name: connection.name,
-          JENKINS_ENDPOINT: connection.endpoint,
-          JENKINS_USERNAME: connection.username,
-          JENKINS_PASSWORD: connection.password
-        }
-        break
-      case Providers.GITLAB:
-        connectionPayload = {
-          ...connectionPayload,
-          name: connection.name,
-          GITLAB_ENDPOINT: connection.endpoint,
-          GITLAB_AUTH: connection.Auth,
-          GITLAB_PROXY: connection.proxy || connection.Proxy
-        }
-        break
-    }
-    return connectionPayload
-  }
+  }, [activeConnection, activeProvider.id, buildConnectionPayload, errors.length, settings])
 
   const clear = () => {
 


### PR DESCRIPTION
### Config-UI / Data Integrations / Configure Connection

- [x] Update **Active Connection** Object state after _Modification_
- [x] Test **GitHub** Settings
- [x] Test **JIRA** Settings ⚠️ (Known issues w/ base64 Auth)

### Description
This PR resolves an issue with the **Save Settings** routine for a Connection source where stale connection data is used as settings are saved/modified during the same session as when connection level settings are modified. This creates the undesirable situation of the user overriding previously saved connection data when the decoupled save settings action is used. The Active Connection object is now refreshed after modification so the connection payload is in-sync, preventing any data inconsistency.

### Does this close any open issues?
#1613

