### PR TITLE
`fix`: config-ui: hide triggers legacy feature on sidebar menu

### DIFF
--- a/config-ui/src/components/Sidebar/MenuConfiguration.jsx
+++ b/config-ui/src/components/Sidebar/MenuConfiguration.jsx
@@ -55,16 +55,16 @@ const MenuConfiguration = (activeRoute) => {
     //   children: [
     //   ]
     // },
-    {
-      id: 2,
-      label: 'Triggers',
-      icon: 'asterisk',
-      classNames: [],
-      route: '/triggers',
-      active: activeRoute.url === '/triggers',
-      children: [
-      ]
-    },
+    // {
+    //   id: 2,
+    //   label: 'Triggers',
+    //   icon: 'asterisk',
+    //   classNames: [],
+    //   route: '/triggers',
+    //   active: activeRoute.url === '/triggers',
+    //   children: [
+    //   ]
+    // },
     {
       id: 3,
       label: 'Pipelines',


### PR DESCRIPTION
### Config-UI / Sidebar Menu / ❌ Triggers

- [x] Hide **Triggers** legacy feature on Sidebar Menu

### Description
This PR hides/deactivates the Triggers feature on the Sidebar Menu for Config-UI.

### Does this close any open issues?
#1590 

### Screenshots
<img width="1016" alt="Screen Shot 2022-04-15 at 6 03 45 PM" src="https://user-images.githubusercontent.com/1742233/163643673-53afe331-bda5-4a2c-a23d-7bfb61e0f1a3.png">

