### PR TITLE
`fix`: blueprints: update cron preset frequency options + fixes

### DIFF
--- a/config-ui/src/components/blueprints/AddBlueprintDialog.jsx
+++ b/config-ui/src/components/blueprints/AddBlueprintDialog.jsx
@@ -5,7 +5,7 @@ import cron from 'cron-validate'
 import {
   Classes, FormGroup, InputGroup, ButtonGroup,
   Button, Icon, Intent, Popover, Position,
-  Dialog,
+  Dialog, Tooltip,
   RadioGroup, Radio,
   MenuItem,
   Elevation,
@@ -42,6 +42,8 @@ const AddBlueprintDialog = (props) => {
     saveBlueprint = () => {},
     fieldHasError = () => {},
     getFieldError = () => {},
+    getCronPreset = () => {},
+    getCronPresetByConfig = () => {},
     isSaving = false,
     isValidBlueprint = false,
     pipelines = [],
@@ -95,10 +97,17 @@ const AddBlueprintDialog = (props) => {
                       />
                   )}
                   />
-                  <Label style={{ display: 'inline', marginRight: 0, marginBottom: 0, fontWeight: 'bold' }}>
+                  <Label style={{ display: 'inline', lineHeight: '18px', marginRight: 0, marginBottom: 0, fontWeight: 'bold' }}>
                     Frequency
                     <span className='requiredStar'>*</span>
                   </Label>
+                  {getCronPresetByConfig(cronConfig)
+                    ? (
+                      <small style={{ fontSize: '10px', color: Colors.GRAY2, display: 'block' }}>
+                        {getCronPresetByConfig(cronConfig).description}
+                      </small>
+                      )
+                    : ''}
                   <RadioGroup
                     inline={true}
                     label={false}
@@ -107,13 +116,33 @@ const AddBlueprintDialog = (props) => {
                     selectedValue={cronConfig}
                     required
                   >
-                    <Radio label='Hourly' value='59 * * * 1-5' style={{ fontWeight: cronConfig === '59 * * * 1-5' ? 'bold' : 'normal' }} />
-                    <Radio label='Daily' value='0 0 * * *' style={{ fontWeight: cronConfig === '0 0 * * *' ? 'bold' : 'normal' }} />
+                    {/* Dynamic Presets from Connection Manager */}
+                    {[getCronPreset('hourly'),
+                      getCronPreset('daily'),
+                      getCronPreset('weekly'),
+                      getCronPreset('monthly')].map((preset, prIdx) => (
+                        <Radio
+                          key={`cron-preset-tooltip-key${prIdx}`}
+                          label={(
+                            <>
+                              <Tooltip
+                                position={Position.TOP}
+                                intent={Intent.PRIMARY}
+                                content={preset.description}
+                              >{preset.label}
+                              </Tooltip>
+                            </>
+                            )}
+                          value={preset.cronConfig}
+                          style={{ fontWeight: cronConfig === preset.cronConfig ? 'bold' : 'normal', outline: 'none !important' }}
+                        />
+
+                    ))}
+                    {/* <Radio label='Daily' value='0 0 * * *' style={{ fontWeight: cronConfig === '0 0 * * *' ? 'bold' : 'normal' }} />
                     <Radio label='Weekly' value='0 0 * * 1' style={{ fontWeight: cronConfig === '0 0 * * 1' ? 'bold' : 'normal' }} />
-                    <Radio label='Monthly' value='0 0 1 * *' style={{ fontWeight: cronConfig === '0 0 1 * *' ? 'bold' : 'normal' }} />
+                    <Radio label='Monthly' value='0 0 1 * *' style={{ fontWeight: cronConfig === '0 0 1 * *' ? 'bold' : 'normal' }} /> */}
                     <Radio label='Custom' value='custom' style={{ fontWeight: cronConfig === 'custom' ? 'bold' : 'normal' }} />
                   </RadioGroup>
-
                   <div style={{ display: 'flex' }}>
                     <FormGroup
                       disabled={cronConfig !== 'custom'}

--- a/config-ui/src/hooks/useBlueprintManager.jsx
+++ b/config-ui/src/hooks/useBlueprintManager.jsx
@@ -23,9 +23,9 @@ function useBlueprintManager (blueprintName = `BLUEPRINT WEEKLY ${Date.now()}`, 
 
   const [cronPresets, setCronPresets] = useState([
     // eslint-disable-next-line max-len
-    { id: 0, name: 'hourly', label: 'Hourly', cronConfig: '59 * * * 1-5', description: 'At minute 59 on every day-of-week from Monday through Friday.' },
+    { id: 0, name: 'hourly', label: 'Hourly', cronConfig: '59 * * * *', description: 'At minute 59 on every day-of-week from Monday through Sunday.' },
     // eslint-disable-next-line max-len
-    { id: 1, name: 'daily', label: 'Daily', cronConfig: '0 0 * * *', description: 'At 00:00 (Midnight) on every day-of-week from Monday through Friday.' },
+    { id: 1, name: 'daily', label: 'Daily', cronConfig: '0 0 * * *', description: 'At 00:00 (Midnight) on every day-of-week from Monday through Sunday.' },
     { id: 2, name: 'weekly', label: 'Weekly', cronConfig: '0 0 * * 1', description: 'At 00:00 (Midnight) on Monday.' },
     { id: 3, name: 'monthly', label: 'Monthly', cronConfig: '0 0 1 * *', description: 'At 00:00 (Midnight) on day-of-month 1.' },
   ])
@@ -199,6 +199,10 @@ function useBlueprintManager (blueprintName = `BLUEPRINT WEEKLY ${Date.now()}`, 
     return cronPresets.find(p => p.name === presetName)
   }, [cronPresets])
 
+  const getCronPresetByConfig = useCallback((cronConfig) => {
+    return cronPresets.find(p => p.cronConfig === cronConfig)
+  }, [cronPresets])
+
   const activateBlueprint = useCallback((blueprint) => {
     console.log('>> ACTIVATING BLUEPRINT....')
     try {
@@ -293,6 +297,7 @@ function useBlueprintManager (blueprintName = `BLUEPRINT WEEKLY ${Date.now()}`, 
     createCronExpression,
     getCronSchedule,
     getCronPreset,
+    getCronPresetByConfig,
     detectCronInterval,
     activateBlueprint,
     deactivateBlueprint,

--- a/config-ui/src/pages/blueprints/index.jsx
+++ b/config-ui/src/pages/blueprints/index.jsx
@@ -49,6 +49,7 @@ const Blueprints = (props) => {
     createCronExpression: createCron,
     getCronSchedule: getSchedule,
     getCronPreset,
+    getCronPresetByConfig,
     activateBlueprint,
     deactivateBlueprint,
     // eslint-disable-next-line no-unused-vars
@@ -427,6 +428,8 @@ const Blueprints = (props) => {
         selectedPipelineTemplate={selectedPipelineTemplate}
         setSelectedPipelineTemplate={setSelectedPipelineTemplate}
         detectedProviders={detectedProviderTasks}
+        getCronPreset={getCronPreset}
+        getCronPresetByConfig={getCronPresetByConfig}
       />
 
     </>

--- a/config-ui/src/pages/pipelines/activity.jsx
+++ b/config-ui/src/pages/pipelines/activity.jsx
@@ -283,7 +283,7 @@ const PipelineActivity = (props) => {
                             </span>
                           </h2>
                           <div className='pipeline-timestamp'>
-                            {dayjs(activePipeline.CreatedAt).utc().format()} (UTC)
+                            {dayjs(activePipeline.createdAt).utc().format()} (UTC)
                           </div>
                           {Object.keys(buildPipelineStages(activePipeline.tasks)).length > 1 && (
                             <div className='pipeline-multistage-tag' style={{ padding: '5px 0 0 0' }}>
@@ -456,7 +456,7 @@ const PipelineActivity = (props) => {
                       <span style={{ padding: '0 2px' }}>
                         <Icon icon='dot' size={10} color={Colors.GRAY3} style={{ marginBottom: '3px' }} />
                       </span>
-                      <strong>Created </strong> {activePipeline.CreatedAt}
+                      <strong>Created </strong> {activePipeline.createdAt}
                     </div>
                     <div>
                       {isFetching && (

--- a/config-ui/src/pages/pipelines/create.jsx
+++ b/config-ui/src/pages/pipelines/create.jsx
@@ -137,6 +137,8 @@ const CreatePipeline = (props) => {
     createCronExpression: createCron,
     // eslint-disable-next-line no-unused-vars
     getCronSchedule: getSchedule,
+    getCronPreset,
+    getCronPresetByConfig,
     saveBlueprint,
     deleteBlueprint,
     isDeleting: isDeletingBlueprint,
@@ -1384,6 +1386,8 @@ const CreatePipeline = (props) => {
         selectedPipelineTemplate={selectedPipelineTemplate}
         setSelectedPipelineTemplate={setSelectedPipelineTemplate}
         detectedProviders={detectedProviderTasks}
+        getCronPreset={getCronPreset}
+        getCronPresetByConfig={getCronPresetByConfig}
         tasksLocked={true}
       />
 

--- a/config-ui/src/pages/pipelines/index.jsx
+++ b/config-ui/src/pages/pipelines/index.jsx
@@ -383,11 +383,17 @@ const Pipelines = (props) => {
                               >
 
                                 {pipeline.name}
-                                {pipeline.blueprintId && (<Tooltip content={`Blueprint ID ${pipeline.blueprintId}`}><Icon icon='bold' color={Colors.BLUE4} size={12} style={{ margin: '3px' }} /></Tooltip>)}
-                                {pipeline.status === 'TASK_COMPLETED' && (<Icon
-                                  icon='tick' size={10} color={Colors.GREEN5}
-                                  style={{ margin: '0 10px', float: 'right', marginBottom: '2px' }}
-                                                                          />)}
+                                {parseInt(pipeline.blueprintId, 10) > 0 && (
+                                  <Tooltip content={`Blueprint ID ${pipeline.blueprintId}`}>
+                                    <Icon icon='bold' color={Colors.BLUE4} size={12} style={{ margin: '3px' }} />
+                                  </Tooltip>
+                                )}
+                                {pipeline.status === 'TASK_COMPLETED' && (
+                                  <Icon
+                                    icon='tick' size={10} color={Colors.GREEN5}
+                                    style={{ margin: '0 10px', float: 'right', marginBottom: '2px' }}
+                                  />
+                                )}
                               </strong>
 
                             </td>


### PR DESCRIPTION
### Config-UI / Blueprints / Crontab Preses + Fixes

- [x] Update **Cron Presets** Default Options
  - Generate presets dynamically from Blueprint Manager
  - Fix HOURLY mode to run all 7 Days instead of only M-F
  - Fix Incorrect Description Values
- [x] Add Description Tooltips for Cron Preset Form Radios
- [x] Fix Invalid. `createdAt` UTC Date(s) on Pipeline Activity (Partially fixes #1642)

### Description
This PR applies additional fixes and enhancements to the Blueprints v0.10.0 release with regard to Cron Preset Options.

### Does this close any open issues?
#1610
 
### Screenshots
<img width="763" alt="Screen Shot 2022-04-16 at 12 34 14 AM" src="https://user-images.githubusercontent.com/1742233/163662656-f73d6e83-df4d-4845-bcc4-b5a34f30ee49.png">
<img width="600" alt="Screen Shot 2022-04-16 at 1 01 04 AM" src="https://user-images.githubusercontent.com/1742233/163662654-efab2900-15fd-4d26-ad08-b6c3f61b34b5.png">


