### PR TITLE
fix: jira stuck at collectChangelog when if Input is empty

### DIFF
--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -135,6 +135,9 @@ func (collector *ApiCollector) Execute() error {
 		defer iterator.Close()
 		c := make(chan bool)
 		total := 0
+		if !iterator.HasNext() {
+			close(c)
+		}
 		for iterator.HasNext() {
 			input, err := iterator.Fetch()
 			if err != nil {


### PR DESCRIPTION
# Summary

Related to #1649


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated
