### PR TITLE
fix(jira): fix wrong assign to since

### DIFF
--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -108,7 +108,6 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		Options:        &op,
 		ApiClient:      jiraApiClient,
 		Source:         source,
-		Since:          &since,
 		JiraServerInfo: *info,
 	}
 	if !since.IsZero() {


### PR DESCRIPTION
# Summary

If since is zero, we don't assign it to taskData
Otherwise, we cannot assign a right value when creating cursor

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
relate to #1649

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
