### PR TITLE
`fix` `v0.10.0` jira provider - remove duplicate jira issue types from list

### DIFF
--- a/config-ui/src/hooks/useJIRA.jsx
+++ b/config-ui/src/hooks/useJIRA.jsx
@@ -74,7 +74,9 @@ const useJIRA = ({ apiProxyPath, issuesEndpoint, fieldsEndpoint }) => {
   }
 
   useEffect(() => {
-    setIssueTypes(issueTypesResponse ? createListData(issueTypesResponse) : [])
+    setIssueTypes(issueTypesResponse
+      ? createListData(issueTypesResponse).reduce((pV, cV) => !pV.some(i => i.value === cV.value) ? [...pV, cV] : [...pV], [])
+      : [])
   }, [issueTypesResponse])
 
   useEffect(() => {


### PR DESCRIPTION
### Config-UI / Data Integrations / JIRA / Configure Settings

- [x] Add a **Reducer** for de-duplicating **JIRA** IssueTypes fetched from `REST` `API`
- [x] **Test** Issue Types **Multi-tag Selector** List Render

### Description
[**V0.10.0** RELEASE TARGET] Ⓜ️ `main`
This PR removes duplicate **JIRA Issue Types** fetched from the `REST` `API` in cases where types of the same name such as "**Bug**" are unnecessarily duplicated within the response. This doesn't happen on all JIRA Instances, however in cases where the `Issuetype:name` property (ie `value` key) is repeated it will be removed from the list selection.

### Does this close any open issues?
#1641

### Screenshots
<img width="980" alt="Screen Shot 2022-04-19 at 10 18 13 AM" src="https://user-images.githubusercontent.com/1742233/164026666-17577c81-1f51-46e4-a867-8a269d324cbb.png">
<img width="1057" alt="Screen Shot 2022-04-19 at 10 19 19 AM" src="https://user-images.githubusercontent.com/1742233/164026689-203512a1-e82c-46d5-b1ca-23f10ebcb4cd.png">

