### PR TITLE
fix(api_collector): fix dead lock

### DIFF
--- a/plugins/helper/worker_scheduler_test.go
+++ b/plugins/helper/worker_scheduler_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewWorkerScheduler(t *testing.T) {
 	testChannel := make(chan int, 100)
 	ctx, cancel := context.WithCancel(context.Background())
-	s, _ := NewWorkerScheduler(5, 2, 1*time.Second, ctx)
+	s, _ := NewWorkerScheduler(5, 2, 1*time.Second, ctx, 0)
 	defer s.Release()
 	for i := 1; i <= 5; i++ {
 		t := i
@@ -47,7 +47,7 @@ func TestNewWorkerScheduler(t *testing.T) {
 func TestNewWorkerSchedulerWithoutSecond(t *testing.T) {
 	testChannel := make(chan int, 100)
 	ctx, cancel := context.WithCancel(context.Background())
-	s, _ := NewWorkerScheduler(5, 0, 1*time.Second, ctx)
+	s, _ := NewWorkerScheduler(5, 0, 1*time.Second, ctx, 0)
 	defer s.Release()
 	for i := 1; i <= 5; i++ {
 		t := i


### PR DESCRIPTION
close #1693

# Summary

Add a subpool for scheduler to hold retry requests
And to avoid rate limit, for main pool submit, we will sleep for a second if there are still some running goroutines in the subpool. 

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
close #1693 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/164035864-1bb76e53-624e-45e1-904d-8653f619cf12.png)

![image](https://user-images.githubusercontent.com/39366025/164035697-da6ee13d-13d6-47fb-bdd0-92989bf4a14b.png)

### Other Information
Any other information that is important to this PR.
