### PR TITLE
`feat` `v0.10.0` connection inputs: add validate-on-focus support

### DIFF
--- a/config-ui/src/components/validation/InputValidationError.jsx
+++ b/config-ui/src/components/validation/InputValidationError.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import {
   Colors,
   Icon,
@@ -9,7 +9,65 @@ import {
 } from '@blueprintjs/core'
 
 const InputValidationError = (props) => {
-  const { error, position = Position.TOP } = props
+  const {
+    error,
+    position = Position.TOP,
+    validateOnFocus = false,
+    elementRef, onError = () => {},
+    onSuccess = () => {}
+  } = props
+
+  const [elementIsFocused, setElementIsFocused] = useState(false)
+  const [inputElement, setInputElement] = useState(null)
+
+  const handleElementFocus = useCallback((isFocused, ref) => {
+    setElementIsFocused(isFocused)
+    if (error) {
+      elementRef?.current.parentElement.classList.remove('valid-field')
+      elementRef?.current.parentElement.classList.add('invalid-field')
+    } else {
+      elementRef?.current.parentElement.classList.remove('invalid-field')
+      elementRef?.current.parentElement.classList.add('valid-field')
+    }
+  }, [elementRef, error])
+
+  const handleElementBlur = useCallback((isFocused, ref) => {
+    setElementIsFocused(isFocused)
+    if (!error) {
+      elementRef?.current.parentElement.classList.remove('invalid-field')
+    }
+  }, [elementRef])
+
+  useEffect(() => {
+    console.log('cName Ref===', elementRef)
+    const iRef = elementRef?.current
+    if (iRef) {
+      setInputElement(iRef)
+      // iRef.addEventListener('focus', (e) => setElementIsFocused(true), true)
+      // iRef.addEventListener('blur', (e) => setElementIsFocused(false), true)
+      iRef.addEventListener('focus', (e) => handleElementFocus(true, iRef), true)
+      iRef.addEventListener('keyup', (e) => handleElementFocus(true, iRef), true)
+      iRef.addEventListener('blur', (e) => handleElementBlur(false, iRef), true)
+    } else {
+      setInputElement(null)
+    }
+
+    return () => {
+      iRef?.removeEventListener('focus', setElementIsFocused, true)
+      iRef?.removeEventListener('keyup', setElementIsFocused, true)
+      iRef?.removeEventListener('blur', setElementIsFocused, true)
+      setInputElement(null)
+    }
+  }, [elementRef, handleElementBlur, handleElementFocus])
+
+  useEffect(() => {
+    if (error && elementIsFocused) {
+      onError(elementRef?.current?.id ? elementRef?.current?.id : null)
+    } else {
+      onSuccess()
+    }
+  }, [error, onError, onSuccess, elementIsFocused, elementRef])
+
   return error
     ? (
       <div className='inline-input-error' style={{ outline: 'none', cursor: 'pointer', margin: '5px 5px 3px 5px' }}>
@@ -19,8 +77,16 @@ const InputValidationError = (props) => {
           openOnTargetFocus={true}
           intent={Intent.WARNING}
           interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+          enforceFocus={false}
+          // autoFocus={false}
         >
-          <Icon icon='warning-sign' size={12} color={Colors.RED5} style={{ outline: 'none' }} />
+          <Icon
+            icon='warning-sign'
+            size={12}
+            color={elementIsFocused ? Colors.RED5 : Colors.GRAY5}
+            style={{ outline: 'none' }}
+            onClick={(e) => e.stopPropagation()}
+          />
           <div style={{ outline: 'none', padding: '5px', borderTop: `2px solid ${Colors.RED5}` }}>{error}</div>
         </Popover>
       </div>

--- a/config-ui/src/components/validation/InputValidationError.jsx
+++ b/config-ui/src/components/validation/InputValidationError.jsx
@@ -12,12 +12,15 @@ const InputValidationError = (props) => {
   const {
     error,
     position = Position.TOP,
+    // eslint-disable-next-line no-unused-vars
     validateOnFocus = false,
     elementRef, onError = () => {},
-    onSuccess = () => {}
+    onSuccess = () => {},
+    interactionKind = PopoverInteractionKind.HOVER_TARGET_ONLY
   } = props
 
   const [elementIsFocused, setElementIsFocused] = useState(false)
+  // eslint-disable-next-line no-unused-vars
   const [inputElement, setInputElement] = useState(null)
 
   const handleElementFocus = useCallback((isFocused, ref) => {
@@ -36,15 +39,12 @@ const InputValidationError = (props) => {
     if (!error) {
       elementRef?.current.parentElement.classList.remove('invalid-field')
     }
-  }, [elementRef])
+  }, [elementRef, error])
 
   useEffect(() => {
-    console.log('cName Ref===', elementRef)
     const iRef = elementRef?.current
     if (iRef) {
       setInputElement(iRef)
-      // iRef.addEventListener('focus', (e) => setElementIsFocused(true), true)
-      // iRef.addEventListener('blur', (e) => setElementIsFocused(false), true)
       iRef.addEventListener('focus', (e) => handleElementFocus(true, iRef), true)
       iRef.addEventListener('keyup', (e) => handleElementFocus(true, iRef), true)
       iRef.addEventListener('blur', (e) => handleElementBlur(false, iRef), true)
@@ -61,12 +61,18 @@ const InputValidationError = (props) => {
   }, [elementRef, handleElementBlur, handleElementFocus])
 
   useEffect(() => {
-    if (error && elementIsFocused) {
+    if (error && validateOnFocus && elementIsFocused) {
+      onError(elementRef?.current?.id ? elementRef?.current?.id : null)
+    } else if (error && !validateOnFocus) {
       onError(elementRef?.current?.id ? elementRef?.current?.id : null)
     } else {
       onSuccess()
     }
-  }, [error, onError, onSuccess, elementIsFocused, elementRef])
+  }, [error, onError, onSuccess, elementIsFocused, validateOnFocus, elementRef])
+
+  useEffect(() => {
+
+  }, [validateOnFocus])
 
   return error
     ? (
@@ -76,14 +82,14 @@ const InputValidationError = (props) => {
           usePortal={true}
           openOnTargetFocus={true}
           intent={Intent.WARNING}
-          interactionKind={PopoverInteractionKind.HOVER_TARGET_ONLY}
+          interactionKind={interactionKind}
           enforceFocus={false}
           // autoFocus={false}
         >
           <Icon
             icon='warning-sign'
             size={12}
-            color={elementIsFocused ? Colors.RED5 : Colors.GRAY5}
+            color={(validateOnFocus && elementIsFocused) || (error && !validateOnFocus) ? Colors.RED5 : Colors.GRAY5}
             style={{ outline: 'none' }}
             onClick={(e) => e.stopPropagation()}
           />

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback, useRef } from 'react'
 import {
   Button, Colors,
   FormGroup, InputGroup, Label,
@@ -54,9 +54,15 @@ export default function ConnectionForm (props) {
     placeholders
   } = props
 
+  const connectionNameRef = useRef()
+  const connectionEndpointRef = useRef()
+  const connectionTokenRef = useRef()
+
   // const [isValidForm, setIsValidForm] = useState(true)
   const [allowedAuthTypes, setAllowedAuthTypes] = useState(['token', 'plain'])
   const [showTokenCreator, setShowTokenCreator] = useState(false)
+  const [stateErrored, setStateErrored] = useState(false)
+
   const getConnectionStatusIcon = () => {
     let statusIcon = <Icon icon='full-circle' size='10' color={Colors.RED3} />
     switch (testStatus) {
@@ -94,6 +100,10 @@ export default function ConnectionForm (props) {
 
   const getFieldError = (fieldId) => {
     return validationErrors.find(e => e.includes(fieldId))
+  }
+
+  const activateErrorStates = (elementId) => {
+    setStateErrored(elementId || false)
   }
 
   useEffect(() => {
@@ -184,17 +194,24 @@ export default function ConnectionForm (props) {
             </Label>
             <InputGroup
               id='connection-name'
+              inputRef={connectionNameRef}
               disabled={isTesting || isSaving || isLocked}
               readOnly={[Providers.GITHUB, Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id)}
               placeholder={placeholders ? placeholders.name : 'Enter Instance Name'}
               value={name}
               onChange={(e) => onNameChange(e.target.value)}
-              className={`input connection-name-input ${fieldHasError('Connection Source') ? 'invalid-field' : ''}`}
+              // className={`input connection-name-input ${fieldHasError('Connection Source') ? 'invalid-field' : ''}`}
+              // className='input connection-name-input'
+              className={`input connection-name-input ${stateErrored === 'connection-name' ? 'invalid-field' : ''}`}
               leftIcon={[Providers.GITHUB, Providers.GITLAB, Providers.JENKINS].includes(activeProvider.id) ? 'lock' : null}
               inline={true}
               rightElement={(
                 <InputValidationError
                   error={getFieldError('Connection Source')}
+                  elementRef={connectionNameRef}
+                  onError={activateErrorStates}
+                  onSuccess={() => setStateErrored(null)}
+                  validateOnFocus
                 />
               )}
               // fill
@@ -221,15 +238,20 @@ export default function ConnectionForm (props) {
             </Label>
             <InputGroup
               id='connection-endpoint'
+              inputRef={connectionEndpointRef}
               disabled={isTesting || isSaving || isLocked}
               placeholder={placeholders ? placeholders.endpoint : 'Enter Endpoint URL'}
               value={endpointUrl}
               onChange={(e) => onEndpointChange(e.target.value)}
-              className={`input endpoint-url-input ${fieldHasError('Endpoint') ? 'invalid-field' : ''}`}
+              className={`input endpoint-url-input ${stateErrored === 'connection-endpoint' ? 'invalid-field' : ''}`}
               fill
               rightElement={(
                 <InputValidationError
                   error={getFieldError('Endpoint')}
+                  elementRef={connectionEndpointRef}
+                  onError={activateErrorStates}
+                  onSuccess={() => setStateErrored(null)}
+                  validateOnFocus
                 />
               )}
             />
@@ -257,16 +279,21 @@ export default function ConnectionForm (props) {
               </Label>
               <InputGroup
                 id='connection-token'
+                inputRef={connectionTokenRef}
                 disabled={isTesting || isSaving || isLocked}
                 placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
                 value={token}
                 onChange={(e) => onTokenChange(e.target.value)}
-                className={`input auth-input ${fieldHasError('Auth') ? 'invalid-field' : ''}`}
+                className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
                 fill
                 required
                 rightElement={(
                   <InputValidationError
                     error={getFieldError('Auth')}
+                    elementRef={connectionTokenRef}
+                    onError={activateErrorStates}
+                    onSuccess={() => setStateErrored(null)}
+                    validateOnFocus
                   />
                 )}
               />


### PR DESCRIPTION
### Config-UI / Data Integrations / Connections

- [x] Add `validateOnFocus` Feature support to InputValidation Helper Component
- [x] Test Connection Form validation behavior

### Description
[**V0.10.0** RELEASE TARGET] Ⓜ️ `main`
This PR adds "**Validate On-Focus**" support to the primary **Connection Form Inputs** for JIRA and other Data Providers as well. In the case of JIRA, a multi-source provider, when Adding a New connection this will allow the input fields to appear with less "Severity" by default, only when focus is given to the primary Input element will the error states be fully activated.

### Does this close any open issues?
#1606

### Screenshots
<img width="1119" alt="Screen Shot 2022-04-19 at 8 19 10 PM" src="https://user-images.githubusercontent.com/1742233/164122217-92de3ab1-372a-412b-bab7-f860ddeacc45.png">
<img width="1238" alt="Screen Shot 2022-04-19 at 8 45 38 PM" src="https://user-images.githubusercontent.com/1742233/164124814-e3339b10-28c5-41bb-a622-06b84cb09007.png">
<img width="1073" alt="Screen Shot 2022-04-19 at 8 30 01 PM" src="https://user-images.githubusercontent.com/1742233/164122677-9fae7a8d-8921-4962-bb8b-079a42647a1b.png">

