### PR TITLE
fix: missing columns in `sprint_issues`

### DIFF
--- a/plugins/jira/tasks/issues_extractor.go
+++ b/plugins/jira/tasks/issues_extractor.go
@@ -88,9 +88,11 @@ func ExtractIssues(taskCtx core.SubTaskContext) error {
 			sprints, issue, _, worklogs, changelogs, changelogItems, users := apiIssue.ExtractEntities(data.Source.ID, data.Source.EpicKeyField, data.Source.StoryPointField)
 			for _, sprintId := range sprints {
 				sprintIssue := &models.JiraSprintIssue{
-					SourceId: data.Source.ID,
-					SprintId: sprintId,
-					IssueId:  issue.IssueId,
+					SourceId:         data.Source.ID,
+					SprintId:         sprintId,
+					IssueId:          issue.IssueId,
+					IssueCreatedDate: &issue.Created,
+					ResolutionDate:   issue.ResolutionDate,
 				}
 				results = append(results, sprintIssue)
 			}


### PR DESCRIPTION

# Summary
Closes #1698 
The two columns `issue_created_date` and `resolution_date` in `_tool_jira_sprint_issues` did not be populated during the extracting stage.


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
#1698 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
