### PR TITLE
fix: incorrect domain layer issue `created_date`

### DIFF
--- a/plugins/helper/data_converter.go
+++ b/plugins/helper/data_converter.go
@@ -3,8 +3,9 @@ package helper
 import (
 	"database/sql"
 	"fmt"
-	"github.com/merico-dev/lake/models/common"
 	"reflect"
+
+	"github.com/merico-dev/lake/models/common"
 
 	"github.com/merico-dev/lake/plugins/core"
 )
@@ -51,7 +52,6 @@ func (converter *DataConverter) Execute() error {
 	// load data from database
 	db := converter.args.Ctx.GetDb()
 
-	inputRow := reflect.New(converter.args.InputRowType).Interface()
 	// batch insertion divider
 	RAW_DATA_ORIGIN := "RawDataOrigin"
 	divider := NewBatchSaveDivider(db, converter.args.BatchSize)
@@ -85,6 +85,7 @@ func (converter *DataConverter) Execute() error {
 			return ctx.Err()
 		default:
 		}
+		inputRow := reflect.New(converter.args.InputRowType).Interface()
 		err := db.ScanRows(cursor, inputRow)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Summary

The reason of #1701 was `InputRow` being reuse between different record, so , when plugin try to use the address of `inputRow.createdAt`, they end up using same value.

We discussed following solution:

1. changing the type of `issue.CreatedDate` from pointer to direct value #1702 
2. changing the type of `pluginIssue.CreatedAt` from direct value to pointer
3. changing the design of `Converter` to let plugin author aware that `inputRow` is shared between `Convert` methods, so they can create another pointer.
4. not sharing `inputRow`

We opt for solution 4 , because the work is minimum, and future proof (plugin authors do not need to care these detail), at expense of a little bit more memory usage which is limited and acceptable.

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Closes #1701
Closes #1702 


