### PR TITLE
Kw 1706 task hangs

### DIFF
--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -179,7 +179,9 @@ func (collector *ApiCollector) Execute() error {
 				break
 			}
 		}
-		wg.Wait()
+		if err == nil {
+			wg.Wait()
+		}
 	} else {
 		// or we just did it once
 		err = collector.exec(nil)


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/61080/164473155-6aa7d1e6-c6fb-4214-a466-4d1eafb44ca6.png)

We execute `Input` in parallel, when multiple errors occured, there were chance that `waitGroup` become uneven.


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Does this close any open issues?
Fixes #1706

