### PR TITLE
feat(framework): print log to both file and console

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -1,11 +1,13 @@
 package logger
 
 import (
+	"fmt"
 	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/plugins/helper"
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+	"os"
 )
 
 var inner *logrus.Logger
@@ -30,5 +32,9 @@ func init() {
 		FullTimestamp:   true,
 	})
 
-	Global = helper.NewDefaultLogger(inner, "")
+	if err := os.Mkdir("logs", 0777); err != nil {
+		inner.Info(fmt.Sprintf("failed to create dir logs: %s", err))
+	}
+	loggerPool := make(map[string]*logrus.Logger)
+	Global = helper.NewDefaultLogger(inner, "", loggerPool)
 }

--- a/plugins/gitlab/gitlab.go
+++ b/plugins/gitlab/gitlab.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
+	_ "net/http/pprof"
 )
 
 var _ core.PluginMeta = (*Gitlab)(nil)

--- a/plugins/helper/default_logger.go
+++ b/plugins/helper/default_logger.go
@@ -2,18 +2,23 @@ package helper
 
 import (
 	"fmt"
-
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"regexp"
 )
 
 type DefaultLogger struct {
-	prefix string
-	log    *logrus.Logger
+	prefix     string
+	log        *logrus.Logger
+	loggerPool map[string]*logrus.Logger
 }
 
-func NewDefaultLogger(log *logrus.Logger, prefix string) *DefaultLogger {
-	return &DefaultLogger{prefix: prefix, log: log}
+func NewDefaultLogger(log *logrus.Logger, prefix string, loggerPool map[string]*logrus.Logger) *DefaultLogger {
+	newDefaultLogger := &DefaultLogger{prefix: prefix, log: log}
+	newDefaultLogger.loggerPool = loggerPool
+	return newDefaultLogger
 }
 
 func (l *DefaultLogger) IsLevelEnabled(level core.LogLevel) bool {
@@ -53,8 +58,32 @@ func (l *DefaultLogger) Error(format string, a ...interface{}) {
 	l.Log(core.LOG_ERROR, format, a...)
 }
 
+// bind two writer to logger
 func (l *DefaultLogger) Nested(name string) core.Logger {
-	return NewDefaultLogger(l.log, fmt.Sprintf("%s [%s]", l.prefix, name))
+	writerStd := os.Stdout
+	fileName := ""
+	loggerPrefixRegex := regexp.MustCompile(`(\[task #\d+]\s\[\w+])`)
+	groups := loggerPrefixRegex.FindStringSubmatch(fmt.Sprintf("%s [%s]", l.prefix, name))
+	if len(groups) > 1 {
+		fileName = groups[1]
+	}
+
+	if fileName == "" {
+		fileName = "devlake"
+	}
+
+	if l.loggerPool[fileName] != nil {
+		return NewDefaultLogger(l.loggerPool[fileName], fmt.Sprintf("%s [%s]", l.prefix, name), l.loggerPool)
+	}
+	newLog := logrus.New()
+	newLog.SetLevel(l.log.Level)
+	newLog.SetFormatter(l.log.Formatter)
+
+	if file, err := os.OpenFile(fmt.Sprintf("logs/%s.log", fileName), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666); err == nil {
+		newLog.SetOutput(io.MultiWriter(writerStd, file))
+	}
+	l.loggerPool[fileName] = newLog
+	return NewDefaultLogger(newLog, fmt.Sprintf("%s [%s]", l.prefix, name), l.loggerPool)
 }
 
 var _ core.Logger = (*DefaultLogger)(nil)

--- a/plugins/helper/default_task_logger.go
+++ b/plugins/helper/default_task_logger.go
@@ -8,6 +8,6 @@ import (
 // bridge to current implementation at this point
 // TODO: implement another TaskLogger for distributed runner/worker
 
-func NewDefaultTaskLogger(log *logrus.Logger, prefix string) core.Logger {
-	return NewDefaultLogger(log, prefix)
+func NewDefaultTaskLogger(log *logrus.Logger, prefix string, loggerPool map[string]*logrus.Logger) core.Logger {
+	return NewDefaultLogger(log, prefix, loggerPool)
 }


### PR DESCRIPTION
# Summary

Add a logger pool to DefaultLogger, whenever we need a nested logger, we use file name to check if the pool has that logger, if so, we just return it to create a  new default logger, otherwise, we create a new logger

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
closes #1716

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
<img width="281" alt="image" src="https://user-images.githubusercontent.com/39366025/164974237-3890ee16-5274-4e6d-82f5-551dcae447a0.png">
<img width="769" alt="image" src="https://user-images.githubusercontent.com/39366025/164974245-fb81c402-e293-47d4-bcaf-7123506eef76.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/39366025/164974253-4e38ad3b-fcaa-4754-af40-fe177b069c43.png">
<img width="732" alt="image" src="https://user-images.githubusercontent.com/39366025/164974266-8c59c874-4c80-42df-b439-c188bf05a4de.png">

### Other Information
Any other information that is important to this PR.
