### PR TITLE
feat(github): allow github override issue&pr enrichment options

### DIFF
--- a/plugins/github/tasks/issue_extractor.go
+++ b/plugins/github/tasks/issue_extractor.go
@@ -43,18 +43,37 @@ type IssuesResponse struct {
 
 func ExtractApiIssues(taskCtx core.SubTaskContext) error {
 	data := taskCtx.GetData().(*GithubTaskData)
+	config := data.Options.Config
 	var issueSeverityRegex *regexp.Regexp
 	var issueComponentRegex *regexp.Regexp
 	var issuePriorityRegex *regexp.Regexp
 	var issueTypeBugRegex *regexp.Regexp
 	var issueTypeRequirementRegex *regexp.Regexp
 	var issueTypeIncidentRegex *regexp.Regexp
-	var issueSeverity = taskCtx.GetConfig("GITHUB_ISSUE_SEVERITY")
-	var issueComponent = taskCtx.GetConfig("GITHUB_ISSUE_COMPONENT")
-	var issuePriority = taskCtx.GetConfig("GITHUB_ISSUE_PRIORITY")
-	var issueTypeBug = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_BUG")
-	var issueTypeRequirement = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_REQUIREMENT")
-	var issueTypeIncident = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_INCIDENT")
+	var issueSeverity = config.GITHUB_ISSUE_SEVERITY
+	if issueSeverity == "" {
+		issueSeverity = taskCtx.GetConfig("GITHUB_ISSUE_SEVERITY")
+	}
+	var issueComponent = config.GITHUB_ISSUE_COMPONENT
+	if issueComponent == "" {
+		issueComponent = taskCtx.GetConfig("GITHUB_ISSUE_COMPONENT")
+	}
+	var issuePriority = config.GITHUB_ISSUE_PRIORITY
+	if issuePriority == "" {
+		issuePriority = taskCtx.GetConfig("GITHUB_ISSUE_PRIORITY")
+	}
+	var issueTypeBug = config.GITHUB_ISSUE_TYPE_BUG
+	if issueTypeBug == "" {
+		issueTypeBug = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_BUG")
+	}
+	var issueTypeRequirement = config.GITHUB_ISSUE_TYPE_REQUIREMENT
+	if issueTypeRequirement == "" {
+		issueTypeRequirement = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_REQUIREMENT")
+	}
+	var issueTypeIncident = config.GITHUB_ISSUE_TYPE_INCIDENT
+	if issueTypeIncident == "" {
+		issueTypeIncident = taskCtx.GetConfig("GITHUB_ISSUE_TYPE_INCIDENT")
+	}
 	if len(issueSeverity) > 0 {
 		issueSeverityRegex = regexp.MustCompile(issueSeverity)
 	}

--- a/plugins/github/tasks/pr_extractor.go
+++ b/plugins/github/tasks/pr_extractor.go
@@ -51,10 +51,17 @@ type GithubApiPullRequest struct {
 
 func ExtractApiPullRequests(taskCtx core.SubTaskContext) error {
 	data := taskCtx.GetData().(*GithubTaskData)
+	config := data.Options.Config
 	var labelTypeRegex *regexp.Regexp
 	var labelComponentRegex *regexp.Regexp
-	var prType = taskCtx.GetConfig("GITHUB_PR_TYPE")
-	var prComponent = taskCtx.GetConfig("GITHUB_PR_COMPONENT")
+	var prType = config.GITHUB_PR_TYPE
+	if prType == "" {
+		prType = taskCtx.GetConfig("GITHUB_PR_TYPE")
+	}
+	var prComponent = config.GITHUB_PR_COMPONENT
+	if prComponent == "" {
+		prComponent = taskCtx.GetConfig("GITHUB_PR_COMPONENT")
+	}
 	if len(prType) > 0 {
 		labelTypeRegex = regexp.MustCompile(prType)
 	}

--- a/plugins/github/tasks/task_data.go
+++ b/plugins/github/tasks/task_data.go
@@ -12,6 +12,18 @@ type GithubOptions struct {
 	Since string
 	Owner string
 	Repo  string
+	Config
+}
+
+type Config struct {
+	GITHUB_PR_TYPE                string `json:"GITHUB_PR_TYPE,omitempty"`
+	GITHUB_PR_COMPONENT           string `json:"GITHUB_PR_COMPONENT,omitempty"`
+	GITHUB_ISSUE_SEVERITY         string `json:"GITHUB_ISSUE_SEVERITY,omitempty"`
+	GITHUB_ISSUE_COMPONENT        string `json:"GITHUB_ISSUE_COMPONENT,omitempty"`
+	GITHUB_ISSUE_PRIORITY         string `json:"GITHUB_ISSUE_PRIORITY,omitempty"`
+	GITHUB_ISSUE_TYPE_REQUIREMENT string `json:"GITHUB_ISSUE_TYPE_REQUIREMENT,omitempty"`
+	GITHUB_ISSUE_TYPE_BUG         string `json:"GITHUB_ISSUE_TYPE_BUG,omitempty"`
+	GITHUB_ISSUE_TYPE_INCIDENT    string `json:"GITHUB_ISSUE_TYPE_INCIDENT,omitempty"`
 }
 
 type GithubTaskData struct {


### PR DESCRIPTION
# Summary

Add a field config to GithubOptions
The config contains all about issue&pr enrichment options
In issue&pr extractor, we assign variable with value in config, and if it's empty, we assign it with value from .env

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
closes #1727

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/165046211-632b861b-cd78-4e90-bc64-28b34765d1ea.png)
<img width="340" alt="image" src="https://user-images.githubusercontent.com/39366025/165046233-e778ee35-067a-4aac-8e3f-169e71bfbf98.png">
<img width="679" alt="image" src="https://user-images.githubusercontent.com/39366025/165046325-e1e6496f-5972-49f3-b2f0-fee535ec0fb4.png">
<img width="331" alt="image" src="https://user-images.githubusercontent.com/39366025/165046540-53f9ff29-e134-47ff-a80f-379d89525bae.png">


### Other Information
Any other information that is important to this PR.
