### PR TITLE
feat: add version information based on git tag/sha

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/merico-dev/lake/api/push"
 	"github.com/merico-dev/lake/api/shared"
 	"github.com/merico-dev/lake/api/task"
+	"github.com/merico-dev/lake/api/version"
 	"github.com/merico-dev/lake/plugins/core"
 	"github.com/merico-dev/lake/services"
 )
@@ -29,6 +30,7 @@ func RegisterRouter(r *gin.Engine) {
 	r.PATCH("/blueprints/:blueprintId", blueprints.Patch)
 	r.GET("/pipelines/:pipelineId/tasks", task.Index)
 	r.GET("/ping", ping.Get)
+	r.GET("/version", version.Get)
 	r.POST("/push/:tableName", push.Post)
 	r.GET("/domainlayer/repos", domainlayer.ReposIndex)
 

--- a/api/version/version.go
+++ b/api/version/version.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/merico-dev/lake/version"
+)
+
+func Get(c *gin.Context) {
+	c.JSON(http.StatusOK, struct {
+		Version string `json:"version"`
+	}{
+		Version: version.Version,
+	})
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/merico-dev/lake/api"
+	_ "github.com/merico-dev/lake/version"
 )
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var Version = "dev"
+
+func init() {
+	println("Version: ", Version)
+}

--- a/worker/main.go
+++ b/worker/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/merico-dev/lake/config"
 	"github.com/merico-dev/lake/logger"
 	"github.com/merico-dev/lake/runner"
+	_ "github.com/merico-dev/lake/version"
 	"github.com/merico-dev/lake/worker/app"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"


### PR DESCRIPTION
# Summary

Backend part of issues #1747

1. Version is generated based on tag/commit sha of current commit
2. devlake server/worker would print `Version` on start up
3. devlake server provides `/version` to return version information


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
![Snipaste_2022-04-26_15-29-43](https://user-images.githubusercontent.com/61080/165246247-0568ad79-e3bc-454b-abbb-8989ad9a0f3e.png)

![Snipaste_2022-04-26_15-25-56](https://user-images.githubusercontent.com/61080/165246345-8e024842-a544-4a00-a583-faf658fa9f28.png)


![Snipaste_2022-04-26_15-27-58](https://user-images.githubusercontent.com/61080/165246267-a69fbc1e-a20e-4faf-9c3d-f1468da2b267.png)

