### PR TITLE
feat: config ui - add devlake api version tag to sidebar

### DIFF
--- a/config-ui/src/components/Sidebar.jsx
+++ b/config-ui/src/components/Sidebar.jsx
@@ -29,7 +29,7 @@ const Sidebar = () => {
           console.log('>>> API VERSION ERROR...', e)
           setVersionTag('dev+error')
         })
-        setVersionTag(res?.data ? res.data?.version : 'dev+error')
+        setVersionTag(res?.data ? res.data?.version : '')
       } catch (e) {
         setVersionTag('dev+error')
       }
@@ -60,7 +60,7 @@ const Sidebar = () => {
       </h3>
       <SidebarMenu menu={menu} />
       <span className='copyright-tag'>
-        <span className='version-tag'>{versionTag || 'dev+unknown'}</span><br />
+        <span className='version-tag'>{versionTag || ''}</span><br />
         <strong>Apache 2.0 License</strong><br />&copy; 2021 Merico
       </span>
     </Card>

--- a/config-ui/src/components/Sidebar.jsx
+++ b/config-ui/src/components/Sidebar.jsx
@@ -4,9 +4,10 @@ import {
   useRouteMatch,
 } from 'react-router-dom'
 import { Button, Card, Elevation } from '@blueprintjs/core'
+import request from '@/utils/request'
 import SidebarMenu from '@/components/Sidebar/SidebarMenu'
 import MenuConfiguration from '@/components/Sidebar/MenuConfiguration'
-import { GRAFANA_URL } from '@/utils/config'
+import { DEVLAKE_ENDPOINT, GRAFANA_URL } from '@/utils/config'
 
 import '@/styles/sidebar.scss'
 
@@ -14,10 +15,27 @@ const Sidebar = () => {
   const activeRoute = useRouteMatch()
 
   const [menu, setMenu] = useState(MenuConfiguration(activeRoute))
+  const [versionTag, setVersionTag] = useState()
 
   useEffect(() => {
     setMenu(MenuConfiguration(activeRoute))
   }, [activeRoute])
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      try {
+        const versionUrl = `${DEVLAKE_ENDPOINT}/version`
+        const res = await request.get(versionUrl).catch(e => {
+          console.log('>>> API VERSION ERROR...', e)
+          setVersionTag('dev+error')
+        })
+        setVersionTag(res?.data ? res.data?.version : 'dev+error')
+      } catch (e) {
+        setVersionTag('dev+error')
+      }
+    }
+    fetchVersion()
+  }, [])
 
   return (
     <Card interactive={false} elevation={Elevation.ZERO} className='card sidebar-card'>
@@ -41,8 +59,10 @@ const Sidebar = () => {
         <sup style={{ fontSize: '9px', color: '#cccccc', marginLeft: '-30px' }}>DEV</sup>LAKE
       </h3>
       <SidebarMenu menu={menu} />
-
-      <span className='copyright-tag'><strong>Apache 2.0 License</strong><br />&copy; 2021 Merico</span>
+      <span className='copyright-tag'>
+        <span className='version-tag'>{versionTag || 'dev+unknown'}</span><br />
+        <strong>Apache 2.0 License</strong><br />&copy; 2021 Merico
+      </span>
     </Card>
   )
 }


### PR DESCRIPTION
### Config-UI / Sidebar / API Version Tag

- [x] Add Version Tag to sidebar (provided by `/version` endpoint)

### Description
This PR adds a **Version Tag** to Config-UI's Sidebar so that users are aware of the current release version and commit hash being served.

### Does this close any open issues?
#1747

### Screenshots
<img width="828" alt="Screen Shot 2022-04-28 at 1 12 06 AM" src="https://user-images.githubusercontent.com/1742233/165680861-44c21e77-1d62-4f83-bdd7-466b6ac68919.png">

