### PR TITLE
feat: connections - test connection on save for multi-token providers

### DIFF
--- a/config-ui/src/components/Sidebar.jsx
+++ b/config-ui/src/components/Sidebar.jsx
@@ -15,7 +15,7 @@ const Sidebar = () => {
   const activeRoute = useRouteMatch()
 
   const [menu, setMenu] = useState(MenuConfiguration(activeRoute))
-  const [versionTag, setVersionTag] = useState()
+  const [versionTag, setVersionTag] = useState('')
 
   useEffect(() => {
     setMenu(MenuConfiguration(activeRoute))
@@ -27,11 +27,11 @@ const Sidebar = () => {
         const versionUrl = `${DEVLAKE_ENDPOINT}/version`
         const res = await request.get(versionUrl).catch(e => {
           console.log('>>> API VERSION ERROR...', e)
-          setVersionTag('dev+error')
+          setVersionTag('')
         })
         setVersionTag(res?.data ? res.data?.version : '')
       } catch (e) {
-        setVersionTag('dev+error')
+        setVersionTag('')
       }
     }
     fetchVersion()

--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -185,6 +185,9 @@ function useConnectionManager ({
         setShowError(false)
         setIsSaving(false)
         setSaveComplete(saveResponse.connection)
+        if ([Providers.GITHUB, Providers.JIRA].includes(activeProvider.id) && token !== '' && token?.toString().split(',').length > 1) {
+          testConnection()
+        }
         if (!updateMode) {
           history.push(`/integrations/${activeProvider.id}`)
         }


### PR DESCRIPTION
### Config-UI / Data Integrations / Configure Connection

- [x] Test Connection `onSave` for Multi-token Providers like **GitHub** and **JIRA**
- [x] `fix` set version tag to empty str if unavailable

### Description
This PR will perform a Connection test when a Connection Source is modified, but only for token based providers such as GitHub and JIRA. If a multi-token string is detected in the payload, a connection test will be performed afterwards to notify the user if there is a problem with one of the tokens.

### Does this close any open issues?
#1662