### PR TITLE
fix: use multi-line textarea on github token field

### DIFF
--- a/config-ui/src/data/Providers.js
+++ b/config-ui/src/data/Providers.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Tooltip } from '@blueprintjs/core'
+import { Tooltip, Icon } from '@blueprintjs/core'
 import { ReactComponent as GitlabProviderIcon } from '@/images/integrations/gitlab.svg'
 import { ReactComponent as JenkinsProviderIcon } from '@/images/integrations/jenkins.svg'
 import { ReactComponent as JiraProviderIcon } from '@/images/integrations/jira.svg'
@@ -90,12 +90,26 @@ const ProviderFormLabels = {
     proxy: 'Proxy URL',
     // token: 'Auth Token(s)',
     token: (
-      <Tooltip
-        content={(<span>Due to Github’s rate limit, input more tokens, <br />comma separated, to accelerate data collection.</span>)}
-        intent='primary'
-      >
+      <>
+        <Tooltip
+          content={(<span>Due to Github’s rate limit, input more tokens, <br />comma separated, to accelerate data collection.</span>)}
+          intent='primary'
+        >
+          <Icon
+            icon='info-sign'
+            size={12}
+            style={{
+              float: 'left',
+              display: 'inline-block',
+              alignContent: 'center',
+              marginBottom: '4px',
+              marginRight: '8px',
+              color: '#999'
+            }}
+          />
+        </Tooltip>
         Auth Token(s)
-      </Tooltip>),
+      </>),
     username: 'Username',
     password: 'Password'
   },

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -303,7 +303,7 @@ export default function ConnectionForm (props) {
                       fill
                       style={{ maxWidth: '99%' }}
                     />
-                    <span style={{ marginLeft: '-25px', zIndex: 1 }}>
+                    <span style={{ marginLeft: '-23px', zIndex: 1 }}>
                       <InputValidationError
                         error={getFieldError('Auth')}
                         elementRef={connectionTokenRef}

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react'
 import {
   Button, Colors,
   FormGroup, InputGroup, Label,
+  TextArea,
   Card,
   Icon,
   Tag,
@@ -277,26 +278,45 @@ export default function ConnectionForm (props) {
                     )}
                 <span className='requiredStar'>*</span>
               </Label>
-              <InputGroup
-                id='connection-token'
-                inputRef={connectionTokenRef}
-                disabled={isTesting || isSaving || isLocked}
-                placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
-                value={token}
-                onChange={(e) => onTokenChange(e.target.value)}
-                className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
-                fill
-                required
-                rightElement={(
-                  <InputValidationError
-                    error={getFieldError('Auth')}
-                    elementRef={connectionTokenRef}
-                    onError={activateErrorStates}
-                    onSuccess={() => setStateErrored(null)}
-                    validateOnFocus
+              {[Providers.GITHUB].includes(activeProvider.id)
+                ? (
+                  <TextArea
+                    id='connection-token'
+                    className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
+                    inputRef={connectionTokenRef}
+                    disabled={isTesting || isSaving || isLocked}
+                    placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
+                    growVertically={true}
+                    large={true}
+                    // intent={Intent.PRIMARY}
+                    onChange={(e) => onTokenChange(e.target.value)}
+                    value={token}
+                    required
+                    fill
                   />
+                  )
+                : (
+                  <InputGroup
+                    id='connection-token'
+                    inputRef={connectionTokenRef}
+                    disabled={isTesting || isSaving || isLocked}
+                    placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
+                    value={token}
+                    onChange={(e) => onTokenChange(e.target.value)}
+                    className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
+                    fill
+                    required
+                    rightElement={(
+                      <InputValidationError
+                        error={getFieldError('Auth')}
+                        elementRef={connectionTokenRef}
+                        onError={activateErrorStates}
+                        onSuccess={() => setStateErrored(null)}
+                        validateOnFocus
+                      />
                 )}
-              />
+                  />
+                  )}
               {
                 activeProvider.id === Providers.JIRA &&
                   <Popover

--- a/config-ui/src/pages/configure/connections/ConnectionForm.jsx
+++ b/config-ui/src/pages/configure/connections/ConnectionForm.jsx
@@ -280,20 +280,39 @@ export default function ConnectionForm (props) {
               </Label>
               {[Providers.GITHUB].includes(activeProvider.id)
                 ? (
-                  <TextArea
-                    id='connection-token'
-                    className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
-                    inputRef={connectionTokenRef}
-                    disabled={isTesting || isSaving || isLocked}
-                    placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
-                    growVertically={true}
-                    large={true}
-                    // intent={Intent.PRIMARY}
-                    onChange={(e) => onTokenChange(e.target.value)}
-                    value={token}
-                    required
-                    fill
-                  />
+                  <div
+                    className='bp3-input-group connection-token-group' style={{
+                      boxSizing: 'border-box',
+                      width: '99%',
+                      position: 'relative',
+                      display: 'flex'
+                    }}
+                  >
+                    <TextArea
+                      id='connection-token'
+                      className={`input auth-input ${stateErrored === 'connection-token' ? 'invalid-field' : ''}`}
+                      inputRef={connectionTokenRef}
+                      disabled={isTesting || isSaving || isLocked}
+                      placeholder={placeholders ? placeholders.token : 'Enter Auth Token eg. EJrLG8DNeXADQcGOaaaX4B47'}
+                      growVertically={true}
+                      large={true}
+                      // intent={Intent.PRIMARY}
+                      onChange={(e) => onTokenChange(e.target.value)}
+                      value={token}
+                      required
+                      fill
+                      style={{ maxWidth: '99%' }}
+                    />
+                    <span style={{ marginLeft: '-25px', zIndex: 1 }}>
+                      <InputValidationError
+                        error={getFieldError('Auth')}
+                        elementRef={connectionTokenRef}
+                        onError={activateErrorStates}
+                        onSuccess={() => setStateErrored(null)}
+                        validateOnFocus
+                      />
+                    </span>
+                  </div>
                   )
                 : (
                   <InputGroup

--- a/config-ui/src/styles/common.scss
+++ b/config-ui/src/styles/common.scss
@@ -285,3 +285,7 @@ h3 {
   margin-top: -3px;
   transform: scale(0.85);
 }
+
+textarea, textarea.bp3-input {
+  // box-shadow: 0 0 0 0 rgba(232, 71, 28, 0), 0 0 0 0 rgba(232, 71, 28, 0), inset 0 0 0 1px rgba(16, 22, 26, 0.15), inset 0 1px 1px rgba(16, 22, 26, 0.2)
+}

--- a/config-ui/src/styles/integration.scss
+++ b/config-ui/src/styles/integration.scss
@@ -137,7 +137,7 @@ table.connections-table {
 .bp3-input-group {
   &.invalid-field {
     + label { font-weight: bold }
-    > input {
+    > input, > textarea {
       box-shadow: rgb(232, 28, 28) 0px 0px 0px 1px, rgba(232, 71, 28, 0.3) 0px 0px 0px 3px, rgba(16, 22, 26, 0.2) 0px 1px 1px 0px inset;
       box-sizing: border-box;
       background-color: #ffeeee;


### PR DESCRIPTION
### Config-UI / Data Integrations / GitHub Connection - **Token Field**

- [x] Use Multi-line **TextArea** Input for **GitHub Token** Connection Field
- [x] Move Tooltip to separate `info` icon next to "Auth Token" label

### Description
This PR Updates the Token form field for a GitHub Data Source Connection. A multi-line TextArea will be used for GitHub provider specifically so multiple tokens can be easier managed.

### Does this close any open issues?
#1385

### Screenshots
<img width="908" alt="Screen Shot 2022-05-04 at 2 24 11 PM" src="https://user-images.githubusercontent.com/1742233/166801832-47a71c00-a0ec-45dc-9d81-8bf26e494f8e.png">
<img width="1204" alt="Screen Shot 2022-05-04 at 2 32 24 PM" src="https://user-images.githubusercontent.com/1742233/166802396-c65f55a9-bb37-4f50-999e-00235b4d4b57.png">
<img width="1366" alt="Screen Shot 2022-05-06 at 8 56 56 PM" src="https://user-images.githubusercontent.com/1742233/167231653-d13b7d22-dd9f-4b5d-9eb4-3142a0857f9e.png">

