### PR TITLE
fix: issue_assignee_history.assignee missing prefix

### DIFF
--- a/plugins/jira/tasks/sprint_issues_convertor.go
+++ b/plugins/jira/tasks/sprint_issues_convertor.go
@@ -293,12 +293,15 @@ func (c *SprintIssuesConverter) setupSprintIssue(connectionId, boardId uint64) e
 		issue, _ := c.getJiraIssue(connectionId, jiraSprintIssue.IssueId)
 		now := time.Now()
 		if issue != nil {
-			c.assigneeDefault[issueId] = &ticket.IssueAssigneeHistory{
+			issueAssigneeHistory := &ticket.IssueAssigneeHistory{
 				IssueId:   issueId,
-				Assignee:  issue.AssigneeAccountId,
 				StartDate: issue.Created,
 				EndDate:   &now,
 			}
+			if issue.AssigneeAccountId != "" {
+				issueAssigneeHistory.Assignee = c.userIdGen.Generate(connectionId, issue.AssigneeAccountId)
+			}
+			c.assigneeDefault[issueId] = issueAssigneeHistory
 		}
 	}
 	return nil


### PR DESCRIPTION
# Summary
Fix #1812 (missing prefix in `issue_assignee_history.assignee`)


### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated


### Does this close any open issues?
Close #1812 

### Screenshots
![image](https://user-images.githubusercontent.com/8455907/167256006-4d38793c-6df9-4834-a217-55152681c874.png)

