### PR TITLE
fix(jira): change subtask name `ConvertUsers` to `convertUsers`

### DIFF
--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -71,7 +71,7 @@ func (plugin Jira) SubTaskMetas() []core.SubTaskMeta {
 		{Name: "convertIssueCommits", EntryPoint: tasks.ConvertIssueCommits, EnabledByDefault: true, Description: "convert Jira issue commits"},
 		{Name: "convertIssueRepoCommits", EntryPoint: tasks.ConvertIssueRepoCommits, EnabledByDefault: false, Description: "convert Jira issue repo commits"},
 
-		{Name: "ConvertUsers", EntryPoint: tasks.ConvertUsers, EnabledByDefault: true, Description: "convert Jira users"},
+		{Name: "convertUsers", EntryPoint: tasks.ConvertUsers, EnabledByDefault: true, Description: "convert Jira users"},
 	}
 }
 


### PR DESCRIPTION
# Summary

change subtask name `ConvertUsers` to `convertUsers`

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
Please mention the issues here.

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
closes #1804 

### Other Information
Any other information that is important to this PR.
