### PR TITLE
fix: system panic when http response code is 503

### DIFF
--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -16,7 +16,7 @@ import (
 
 type ApiAsyncCallback func(*http.Response, error) error
 
-var HttpMinStatusRetryCode = 400
+var HttpMinStatusRetryCode = http.StatusBadRequest
 
 // ApiAsyncClient is built on top of ApiClient, to provide a asynchronous semantic
 // You may submit multiple requests at once by calling `GetAsync`, and those requests

--- a/plugins/helper/api_async_client.go
+++ b/plugins/helper/api_async_client.go
@@ -16,6 +16,8 @@ import (
 
 type ApiAsyncCallback func(*http.Response, error) error
 
+var HttpMinStatusRetryCode = 400
+
 // ApiAsyncClient is built on top of ApiClient, to provide a asynchronous semantic
 // You may submit multiple requests at once by calling `GetAsync`, and those requests
 // will be performed in parallel with rate-limit support
@@ -121,15 +123,24 @@ func (apiClient *ApiAsyncClient) DoAsync(
 			}
 		}
 
-		// it make sense to retry on request failure, but not error from handler and canceled error
+		// check
+		needRetry := false
 		if err != nil {
+			needRetry = true
+		} else if res.StatusCode >= HttpMinStatusRetryCode {
+			needRetry = true
+			err = fmt.Errorf("http code error[%d]:[%s]", res.StatusCode, body)
+		}
+
+		//  if it need retry, check and try to retry
+		if needRetry {
+			// check weather we still have retry times and not error from handler and canceled error
 			if retry < apiClient.maxRetry && err != context.Canceled {
 				apiClient.logError("retry #%d for %s", retry, err.Error())
 				retry++
 				return apiClient.scheduler.Submit(subFunc, apiClient.scheduler.subPool)
 			}
-		} else if res.StatusCode >= 400 {
-			err = fmt.Errorf("http code error[%d]:[%s]", res.StatusCode, body)
+			return err
 		}
 
 		// it is important to let handler have a chance to handle error, or it can hang indefinitely

--- a/plugins/helper/api_async_client_test.go
+++ b/plugins/helper/api_async_client_test.go
@@ -140,7 +140,7 @@ func TestWaitAsync_WithWork(t *testing.T) {
 	) (*http.Response, error) {
 		return &http.Response{
 			Body:       &TestReader{Err: io.EOF},
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 		}, nil
 	})
 	defer gm_do.Reset()
@@ -181,7 +181,7 @@ func TestWaitAsync_MutiWork(t *testing.T) {
 	) (*http.Response, error) {
 		return &http.Response{
 			Body:       &TestReader{Err: io.EOF},
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 		}, nil
 	})
 	defer gm_do.Reset()
@@ -225,7 +225,7 @@ func TestDoAsync_OnceSuceess(t *testing.T) {
 	) (*http.Response, error) {
 		return &http.Response{
 			Body:       &TestReader{Err: io.EOF},
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 		}, nil
 	})
 	defer gm_do.Reset()
@@ -255,7 +255,7 @@ func TestDoAsync_TryAndFail(t *testing.T) {
 	) (*http.Response, error) {
 		return &http.Response{
 			Body:       &TestReader{Err: ErrUnitTest},
-			StatusCode: 500,
+			StatusCode: http.StatusInternalServerError,
 		}, nil
 	})
 	defer gm_do.Reset()
@@ -293,33 +293,33 @@ func TestDoAsync_TryAndSuceess(t *testing.T) {
 		case 1:
 			return &http.Response{
 				Body:       &TestReader{Err: ErrUnitTest},
-				StatusCode: 500,
+				StatusCode: http.StatusInternalServerError,
 			}, nil
 		case 2:
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
-				StatusCode: 500,
+				StatusCode: http.StatusInternalServerError,
 			}, nil
 		case 3:
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
-				StatusCode: 400,
+				StatusCode: http.StatusBadRequest,
 			}, nil
 		case 4:
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
-				StatusCode: 300,
+				StatusCode: http.StatusMultipleChoices,
 			}, nil
 		case 5:
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
-				StatusCode: 200,
+				StatusCode: http.StatusOK,
 			}, nil
 		default:
 			assert.Empty(t, TestNoRunHere)
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
-				StatusCode: 200,
+				StatusCode: http.StatusOK,
 			}, TestError
 		}
 	})

--- a/plugins/helper/api_async_client_test.go
+++ b/plugins/helper/api_async_client_test.go
@@ -289,16 +289,38 @@ func TestDoAsync_TryAndSuceess(t *testing.T) {
 		headers http.Header,
 	) (*http.Response, error) {
 		times++
-		if times <= 3 {
+		switch times {
+		case 1:
 			return &http.Response{
 				Body:       &TestReader{Err: ErrUnitTest},
-				StatusCode: 301,
+				StatusCode: 500,
 			}, nil
-		} else {
+		case 2:
+			return &http.Response{
+				Body:       &TestReader{Err: io.EOF},
+				StatusCode: 500,
+			}, nil
+		case 3:
+			return &http.Response{
+				Body:       &TestReader{Err: io.EOF},
+				StatusCode: 400,
+			}, nil
+		case 4:
+			return &http.Response{
+				Body:       &TestReader{Err: io.EOF},
+				StatusCode: 300,
+			}, nil
+		case 5:
 			return &http.Response{
 				Body:       &TestReader{Err: io.EOF},
 				StatusCode: 200,
 			}, nil
+		default:
+			assert.Empty(t, TestNoRunHere)
+			return &http.Response{
+				Body:       &TestReader{Err: io.EOF},
+				StatusCode: 200,
+			}, TestError
 		}
 	})
 	defer gm_do.Reset()
@@ -310,4 +332,5 @@ func TestDoAsync_TryAndSuceess(t *testing.T) {
 
 	err = asyncApiClient.WaitAsync()
 	assert.Equal(t, err, nil)
+	assert.Equal(t, times, 4)
 }

--- a/plugins/helper/api_collector_test.go
+++ b/plugins/helper/api_collector_test.go
@@ -69,7 +69,7 @@ var TestSize int = 116102
 
 var TestHttpResponse_Suc http.Response = http.Response{
 	Status:     "200 OK",
-	StatusCode: 200,
+	StatusCode: http.StatusOK,
 	Proto:      "HTTP/1.0",
 	ProtoMajor: 1,
 	ProtoMinor: 0,
@@ -77,7 +77,7 @@ var TestHttpResponse_Suc http.Response = http.Response{
 
 var TestHttpResponse_404 http.Response = http.Response{
 	Status:     "404 Not Found",
-	StatusCode: 404,
+	StatusCode: http.StatusNotFound,
 	Proto:      "HTTP/1.0",
 	ProtoMajor: 1,
 	ProtoMinor: 0,


### PR DESCRIPTION
# Summary
Add retry when got the http status code more than 400 even without any error.
also modified corresponding unit test

### Description
In issue #1833 , it failed because it didn't retry when http status code is 503. 
The http request retry only when it has error, to fix, we make sure the http request will retry when the status code  is equal or larger than http.StatusBadRequest(400)

### Does this close any open issues?
closes #1833


