### PR TITLE
fix(config-ui): change Username/Password to camelCase

### DIFF
--- a/config-ui/src/hooks/useConnectionManager.jsx
+++ b/config-ui/src/hooks/useConnectionManager.jsx
@@ -310,8 +310,8 @@ function useConnectionManager ({
       const notify = false
       const payload = {
         endpoint: c.Endpoint || c.endpoint,
-        username: c.Username,
-        password: c.Password,
+        username: c.username,
+        password: c.password,
         auth: c.basicAuthEncoded || c.auth,
         proxy: c.Proxy || c.Proxy
       }


### PR DESCRIPTION
# Summary
jenkins got `Disconnected` because it tried to fetch Username/Password,
Right now, we changed all fields to camelCase, so we need to assign `c.username/password`

### Does this close any open issues?
closes #1847

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
![image](https://user-images.githubusercontent.com/39366025/167974434-4d601bd8-2f3e-429c-a3e8-492a416cc930.png)

