### PR TITLE
Fix pipelines - cancel running pipeline not successful

### DIFF
--- a/plugins/core/plugin_utils.go
+++ b/plugins/core/plugin_utils.go
@@ -70,6 +70,9 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 // PKCS7 unPadding
 func PKCS7UnPadding(origData []byte) []byte {
 	length := len(origData)
+	if length == 0 {
+		return nil
+	}
 	unpadding := int(origData[length-1])
 	if unpadding >= length {
 		return nil

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -272,13 +272,22 @@ func (collector *ApiCollector) generateUrl(pager *Pager, input interface{}) (str
 func (collector *ApiCollector) stepFetch(ctx context.Context, cancel func(), reqData RequestData) error {
 	// channel `c` is used to make sure fetchAsync is called serially
 	c := make(chan struct{})
+	var err1 error
 	handler := func(res *http.Response, err error) error {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		default:
+
+		}
 		if err != nil {
+			err1 = err
 			close(c)
 			return err
 		}
 		count, err := collector.saveRawData(res, reqData.Input)
 		if err != nil {
+			err1 = err
 			close(c)
 			cancel()
 			return err
@@ -294,15 +303,24 @@ func (collector *ApiCollector) stepFetch(ctx context.Context, cancel func(), req
 	}
 	// kick off
 	go func() { c <- struct{}{} }()
-	for range c {
-		err := collector.fetchAsync(&reqData, handler)
-		if err != nil {
-			close(c)
-			cancel()
-			return err
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case _, ok := <-c:
+			if !ok || err1 != nil {
+				return err1
+			} else {
+				err := collector.fetchAsync(&reqData, handler)
+				if err != nil {
+					close(c)
+					cancel()
+					return err
+				}
+			}
 		}
 	}
-	return nil
+	return err1
 }
 
 func (collector *ApiCollector) fetchAsync(reqData *RequestData, handler ApiAsyncCallback) error {
@@ -312,6 +330,13 @@ func (collector *ApiCollector) fetchAsync(reqData *RequestData, handler ApiAsync
 			Size: 100,
 			Skip: 0,
 		}
+	}
+	ctx := collector.args.Ctx.GetContext()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+
 	}
 	apiUrl, err := collector.generateUrl(reqData.Pager, reqData.Input)
 	if err != nil {

--- a/plugins/jira/jira.go
+++ b/plugins/jira/jira.go
@@ -87,7 +87,7 @@ func (plugin Jira) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		return nil, fmt.Errorf("connectionId is invalid")
 	}
 	connection := &models.JiraConnection{}
-	err = db.Find(connection, op.ConnectionId).Error
+	err = db.First(connection, op.ConnectionId).Error
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/tapd/tapd.go
+++ b/plugins/tapd/tapd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/merico-dev/lake/migration"
 	"github.com/merico-dev/lake/models/domainlayer/didgen"
 	"github.com/merico-dev/lake/plugins/core"
@@ -14,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
-	"time"
 )
 
 var _ core.PluginMeta = (*Tapd)(nil)
@@ -94,7 +95,7 @@ func (plugin Tapd) PrepareTaskData(taskCtx core.TaskContext, options map[string]
 		return nil, fmt.Errorf("ConnectionId is required for Tapd execution")
 	}
 	connection := &models.TapdConnection{}
-	err = db.Find(connection, op.ConnectionId).Error
+	err = db.First(connection, op.ConnectionId).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

# Summary

fix 

#1844 config-ui: pipelines - cancel running pipeline not successful
#1866 PKCS7UnPadding panic with empty origData
#1867 tapd not sent out error when find connection empty
#1868 jira use empty connection data without any error

### Key Points

- [ ] This is a breaking change
- [ ] New or existing documentation is updated

### Description
Describe what this PR does, and aims to solve in a few sentences.

### Does this close any open issues?
close #1844
close #1866
close #1867
close #1868


### Screenshots
![image](https://user-images.githubusercontent.com/8455907/168534842-29808c32-b71a-4d84-b8d4-8f1f6613c8e0.png)


### Other Information
Any other information that is important to this PR.
