### PR TITLE
fix(github): fix unicode for pg

### DIFF
--- a/models/domainlayer/code/refs_pr_cherry_pick.go
+++ b/models/domainlayer/code/refs_pr_cherry_pick.go
@@ -2,6 +2,7 @@ package code
 
 import "github.com/merico-dev/lake/models/common"
 
+// multi pk
 type RefsPrCherrypick struct {
 	RepoName               string `gorm:"type:varchar(255)"`
 	ParentPrKey            int

--- a/plugins/helper/api_client.go
+++ b/plugins/helper/api_client.go
@@ -196,7 +196,7 @@ func (apiClient *ApiClient) Do(
 	apiClient.logDebug("[api-client] %v %v", method, *uri)
 	res, err = apiClient.client.Do(req)
 	if err != nil {
-		apiClient.logError("[api-client] failed to request %s with error:\n%w", req.URL.String(), err)
+		apiClient.logError("[api-client] failed to request %s with error:\n%s", req.URL.String(), err.Error())
 		return nil, err
 	}
 
@@ -261,6 +261,7 @@ func GetURIStringPointer(baseUrl string, relativePath string, query url.Values) 
 		for key, value := range query {
 			queryString.Set(key, strings.Join(value, ""))
 		}
+
 		u.RawQuery = queryString.Encode()
 	}
 	uri := base.ResolveReference(u).String()

--- a/plugins/helper/api_collector.go
+++ b/plugins/helper/api_collector.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 
 	"github.com/merico-dev/lake/plugins/core"
-	"gorm.io/datatypes"
 )
 
 type Pager struct {
@@ -409,7 +408,7 @@ func (collector *ApiCollector) saveRawData(res *http.Response, input interface{}
 	for i, msg := range items {
 		dd[i] = &RawData{
 			Params: collector.params,
-			Data:   datatypes.JSON(msg),
+			Data:   msg,
 			Url:    u,
 			Input:  inputJson,
 		}

--- a/plugins/helper/api_collector_test.go
+++ b/plugins/helper/api_collector_test.go
@@ -255,7 +255,7 @@ func TestSaveRawData(t *testing.T) {
 		for _, v := range rd {
 			// check data and url
 			assert.Equal(t, v.Params, string(params))
-			assert.Equal(t, v.Data.String(), TestRawMessage)
+			assert.Equal(t, string(v.Data), TestRawMessage)
 			assert.Equal(t, v.Url, TestUrl)
 			assert.Equal(t, v.Input.String(), string(input))
 		}

--- a/plugins/helper/api_rawdata.go
+++ b/plugins/helper/api_rawdata.go
@@ -13,7 +13,7 @@ import (
 type RawData struct {
 	ID        uint64 `gorm:"primaryKey"`
 	Params    string `gorm:"type:varchar(255);index"`
-	Data      datatypes.JSON
+	Data      []byte
 	Url       string
 	Input     datatypes.JSON
 	CreatedAt time.Time


### PR DESCRIPTION
# Summary

As of #1870, pg cannot support unicode \u0000, we have to drop json as field type in the table. We use text to store json data

In addition, this pr modified an error log as it print the location of err not msg

### Does this close any open issues?
close #1870

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
