### PR TITLE
fix(github): github connection properties are saved with error

### DIFF
--- a/config-ui/src/hooks/useSettingsManager.jsx
+++ b/config-ui/src/hooks/useSettingsManager.jsx
@@ -26,36 +26,36 @@ function useSettingsManager ({
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          Endpoint: connection.endpoint,
-          BasicAuthEncoded: connection.basicAuthEncoded,
-          Proxy: connection.proxy || connection.Proxy
+          endPoing: connection.endpoint,
+          basicAuthEncoded: connection.basicAuthEncoded,
+          proxy: connection.proxy || connection.Proxy
         }
         break
       case Providers.GITHUB:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          GITHUB_ENDPOINT: connection.endpoint,
-          GITHUB_AUTH: connection.auth,
-          GITHUB_PROXY: connection.proxy || connection.Proxy
+          endpoint: connection.endpoint,
+          auth: connection.auth,
+          proxy: connection.proxy || connection.Proxy
         }
         break
       case Providers.JENKINS:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          JENKINS_ENDPOINT: connection.endpoint,
-          JENKINS_USERNAME: connection.username,
-          JENKINS_PASSWORD: connection.password
+          endpoint: connection.endpoint,
+          username: connection.username,
+          password: connection.password
         }
         break
       case Providers.GITLAB:
         connectionPayload = {
           ...connectionPayload,
           name: connection.name,
-          GITLAB_ENDPOINT: connection.endpoint,
-          GITLAB_AUTH: connection.auth,
-          GITLAB_PROXY: connection.proxy || connection.Proxy
+          endpoint: connection.endpoint,
+          auth: connection.auth,
+          proxy: connection.proxy || connection.Proxy
         }
         break
     }

--- a/plugins/github/models/connection.go
+++ b/plugins/github/models/connection.go
@@ -5,18 +5,18 @@ type GithubConnection struct {
 	Auth     string `mapstructure:"auth" validate:"required" env:"GITHUB_AUTH" json:"auth"`
 	Proxy    string `mapstructure:"proxy" env:"GITHUB_PROXY" json:"proxy"`
 
-	Config
+	Config `mapstructure:",squash"`
 }
 
 type Config struct {
-	PrType               string `mapstructure:"prType,squash" env:"GITHUB_PR_TYPE" json:"prType"`
-	PrComponent          string `mapstructure:"prComponent,squash" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
-	IssueSeverity        string `mapstructure:"issueSeverity,squash" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
-	IssuePriority        string `mapstructure:"issuePriority,squash" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
-	IssueComponent       string `mapstructure:"issueComponent,squash" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug,squash" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
-	IssueTypeIncident    string `mapstructure:"typeIncident,squash" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"typeIncident"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement,squash" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
+	PrType               string `mapstructure:"prType" env:"GITHUB_PR_TYPE" json:"prType"`
+	PrComponent          string `mapstructure:"prComponent" env:"GITHUB_PR_COMPONENT" json:"prComponent"`
+	IssueSeverity        string `mapstructure:"issueSeverity" env:"GITHUB_ISSUE_SEVERITY" json:"issueSeverity"`
+	IssuePriority        string `mapstructure:"issuePriority" env:"GITHUB_ISSUE_PRIORITY" json:"issuePriority"`
+	IssueComponent       string `mapstructure:"issueComponent" env:"GITHUB_ISSUE_COMPONENT" json:"issueComponent"`
+	IssueTypeBug         string `mapstructure:"issueTypeBug" env:"GITHUB_ISSUE_TYPE_BUG" json:"issueTypeBug"`
+	IssueTypeIncident    string `mapstructure:"typeIncident" env:"GITHUB_ISSUE_TYPE_INCIDENT" json:"typeIncident"`
+	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" env:"GITHUB_ISSUE_TYPE_REQUIREMENT" json:"issueTypeRequirement"`
 }
 
 // This object conforms to what the frontend currently expects.


### PR DESCRIPTION
# Summary

the way we used mapstructure has some problems. In this pr, we moved `mapstructure:",squash"`to under `Config` in GithubConnection


### Does this close any open issues?
closes #1888 

### Current Behavior
Describe the current behaviour of this issue, if relevant.

### New Behavior
Describe the new behaviour updated in this issue, if relevant.

### Screenshots
modified successfully 
<img width="344" alt="image" src="https://user-images.githubusercontent.com/39366025/168737676-f9eec856-e40d-4647-9984-a85e1a15eeb3.png">


### Other Information
Any other information that is important to this PR.
